### PR TITLE
docs: fix link on udf page

### DIFF
--- a/docs/en/07-develop/09-udf.md
+++ b/docs/en/07-develop/09-udf.md
@@ -887,4 +887,4 @@ The `pycumsum` function finds the cumulative sum for all data in the input colum
 
 </details>
 ## Manage and Use UDF
-You need to add UDF to TDengine before using it in SQL queries. For more information about how to manage UDF and how to invoke UDF, please see [Manage and Use UDF](../taos-sql/udf/).
+You need to add UDF to TDengine before using it in SQL queries. For more information about how to manage UDF and how to invoke UDF, please see [Manage and Use UDF](../../taos-sql/udf/).


### PR DESCRIPTION
fixes the link to "manage and use UDF" which is currently broken