### PR TITLE
feat(taosBenchmark): remove retry function for stmt writing as engine…

### DIFF
--- a/tools/taos-tools/src/benchInsert.c
+++ b/tools/taos-tools/src/benchInsert.c
@@ -1733,7 +1733,7 @@ int32_t submitStmt2Impl(threadInfo * pThreadInfo, TAOS_STMT2_BINDV *bindv, int64
 
 // no retry function submitStmt2
 int32_t submitStmt2(threadInfo * pThreadInfo, TAOS_STMT2_BINDV *bindv, int64_t *delay1, int64_t *delay3,
-                    int64_t* startTs, int64_t* endTs, uint32_t* generated, int32_t /*w*/) {
+                    int64_t* startTs, int64_t* endTs, uint32_t* generated, int32_t) {
     return submitStmt2Impl(pThreadInfo, bindv, delay1, delay3, startTs, endTs, generated);
 }
 

--- a/tools/taos-tools/src/benchInsert.c
+++ b/tools/taos-tools/src/benchInsert.c
@@ -1635,6 +1635,7 @@ void loadChildTableInfo(threadInfo* pThreadInfo) {
     tmfree(buf);
 }
 
+/*
 // create conn again
 int32_t reCreateConn(threadInfo * pThreadInfo) {
     // single
@@ -1709,6 +1710,7 @@ int32_t reConnectStmt2(threadInfo * pThreadInfo, int32_t w) {
 
     return code;
 }
+*/
 
 int32_t submitStmt2Impl(threadInfo * pThreadInfo, TAOS_STMT2_BINDV *bindv, int64_t *delay1, int64_t *delay3,
                     int64_t* startTs, int64_t* endTs, uint32_t* generated) {
@@ -1729,6 +1731,13 @@ int32_t submitStmt2Impl(threadInfo * pThreadInfo, TAOS_STMT2_BINDV *bindv, int64
     return code;
 }
 
+// no retry function submitStmt2
+int32_t submitStmt2(threadInfo * pThreadInfo, TAOS_STMT2_BINDV *bindv, int64_t *delay1, int64_t *delay3,
+                    int64_t* startTs, int64_t* endTs, uint32_t* generated, int32_t w) {
+    return submitStmt2Impl(pThreadInfo, bindv, delay1, delay3, startTs, endTs, generated);
+}
+
+/*
 int32_t submitStmt2(threadInfo * pThreadInfo, TAOS_STMT2_BINDV *bindv, int64_t *delay1, int64_t *delay3,
                     int64_t* startTs, int64_t* endTs, uint32_t* generated, int32_t w) {
     // calc loop
@@ -1787,6 +1796,7 @@ int32_t submitStmt2(threadInfo * pThreadInfo, TAOS_STMT2_BINDV *bindv, int64_t *
     // success
     return 0;
 }
+*/
 
 static void *syncWriteInterlace(void *sarg) {
     threadInfo * pThreadInfo = (threadInfo *)sarg;

--- a/tools/taos-tools/src/benchInsert.c
+++ b/tools/taos-tools/src/benchInsert.c
@@ -1733,7 +1733,7 @@ int32_t submitStmt2Impl(threadInfo * pThreadInfo, TAOS_STMT2_BINDV *bindv, int64
 
 // no retry function submitStmt2
 int32_t submitStmt2(threadInfo * pThreadInfo, TAOS_STMT2_BINDV *bindv, int64_t *delay1, int64_t *delay3,
-                    int64_t* startTs, int64_t* endTs, uint32_t* generated, int32_t) {
+                    int64_t* startTs, int64_t* endTs, uint32_t* generated, int32_t w) {
     return submitStmt2Impl(pThreadInfo, bindv, delay1, delay3, startTs, endTs, generated);
 }
 

--- a/tools/taos-tools/src/benchInsert.c
+++ b/tools/taos-tools/src/benchInsert.c
@@ -1733,7 +1733,7 @@ int32_t submitStmt2Impl(threadInfo * pThreadInfo, TAOS_STMT2_BINDV *bindv, int64
 
 // no retry function submitStmt2
 int32_t submitStmt2(threadInfo * pThreadInfo, TAOS_STMT2_BINDV *bindv, int64_t *delay1, int64_t *delay3,
-                    int64_t* startTs, int64_t* endTs, uint32_t* generated, int32_t w) {
+                    int64_t* startTs, int64_t* endTs, uint32_t* generated, int32_t /*w*/) {
     return submitStmt2Impl(pThreadInfo, bindv, delay1, delay3, startTs, endTs, generated);
 }
 


### PR DESCRIPTION
# Description

Remove retry function for stmt writing of taosBenchmark, as engine will handle

Jira: https://jira.taosdata.com:18080/browse/TD-33432

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
