### PR TITLE
fix(taosd): follow-up guards for tag pseudo-column crash path

### DIFF
--- a/source/common/src/tdatablock.c
+++ b/source/common/src/tdatablock.c
@@ -274,6 +274,10 @@ static int32_t colDataReserve(SColumnInfoData* pColumnInfoData, size_t newSize) 
 
 int32_t doCopyNItems(struct SColumnInfoData* pColumnInfoData, int32_t currentRow, const char* pData,
                             int32_t itemLen, int32_t numOfRows, bool trimValue) {
+  if (numOfRows <= 0) {
+    return TSDB_CODE_SUCCESS;
+  }
+
   if (pColumnInfoData->info.bytes < itemLen) {
     uWarn("column/tag actual data len %d is bigger than schema len %d, trim it:%d", itemLen,
           pColumnInfoData->info.bytes, trimValue);

--- a/source/libs/executor/src/scanoperator.c
+++ b/source/libs/executor/src/scanoperator.c
@@ -557,9 +557,11 @@ static int32_t createTableCacheVal(const SMetaReader* pMetaReader, STableCachedV
   // only child table has tag value
   if (pMetaReader->me.type == TSDB_CHILD_TABLE || pMetaReader->me.type == TSDB_VIRTUAL_CHILD_TABLE) {
     STag* pTag = (STag*)pMetaReader->me.ctbEntry.pTags;
-    pVal->pTags = taosMemoryMalloc(pTag->len);
-    QUERY_CHECK_NULL(pVal->pTags, code, lino, _end, terrno);
-    memcpy(pVal->pTags, pTag, pTag->len);
+    if (pTag != NULL) {
+      pVal->pTags = taosMemoryMalloc(pTag->len);
+      QUERY_CHECK_NULL(pVal->pTags, code, lino, _end, terrno);
+      memcpy(pVal->pTags, pTag, pTag->len);
+    }
   }
 
   (*ppResVal) = pVal;
@@ -701,7 +703,10 @@ int32_t addTagPseudoColumnData(SReadHandle* pHandle, const SExprInfo* pExpr, int
     } else {  // these are tags
       STagVal tagVal = {0};
       tagVal.cid = pExpr1->base.pParam[0].pCol->colId;
-      const char* p = pHandle->api.metaFn.extractTagVal(val.pTags, pColInfoData->info.type, &tagVal);
+      const char* p = NULL;
+      if (val.pTags != NULL) {
+        p = pHandle->api.metaFn.extractTagVal(val.pTags, pColInfoData->info.type, &tagVal);
+      }
 
       char* data = NULL;
       if (pColInfoData->info.type != TSDB_DATA_TYPE_JSON && p != NULL) {


### PR DESCRIPTION
Follow-up hardening for issue #34544: https://github.com/taosdata/TDengine/issues/34544

After testing commit 6db0339 on macOS arm64 under TMQ + streams pressure, we still observed a crash in the same path:
addTagPseudoColumnData -> colDataSetNItems -> doCopyNItems -> memmove

What this PR changes (surgical):
1) source/common/src/tdatablock.c
- doCopyNItems(...): early return when numOfRows <= 0

2) source/libs/executor/src/scanoperator.c
- createTableCacheVal(...): null-check pMetaReader->me.ctbEntry.pTags before dereference/copy
- addTagPseudoColumnData(...): only call extractTagVal(...) when val.pTags != NULL

Why:
- Prevents zero-row copy crash mode
- Prevents null tag-buffer dereference in child-table metadata edge cases
- Keeps normal behavior unchanged

Scope:
- Minimal defensive guards only
- No architectural changes

Related to #34544