### PR TITLE
fix(func/smaple): use int64_t instead of int32_t to fix overflow

### DIFF
--- a/source/libs/function/inc/functionResInfoInt.h
+++ b/source/libs/function/inc/functionResInfoInt.h
@@ -430,7 +430,7 @@ typedef struct SMavgInfo {
 
 typedef struct SSampleInfo {
   int32_t  samples;
-  int32_t  totalPoints;
+  int64_t  totalPoints;
   int32_t  numSampled;
   uint8_t  colType;
   uint16_t colBytes;

--- a/source/libs/function/src/builtinsimpl.c
+++ b/source/libs/function/src/builtinsimpl.c
@@ -6036,7 +6036,7 @@ static int32_t doReservoirSample(SqlFunctionCtx* pCtx, SSampleInfo* pInfo, char*
     }
     pInfo->numSampled++;
   } else {
-    int32_t j = taosRand() % (pInfo->totalPoints);
+    int32_t j = (int32_t)(taosRand() % (uint64_t)pInfo->totalPoints);
     if (j < pInfo->samples) {
       sampleAssignResult(pInfo, data, j);
       if (pCtx->subsidiaries.num > 0) {


### PR DESCRIPTION
# Description

<!-- Please briefly describe the code changes in this pull request. -->

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link
https://project.feishu.cn/taosdata_td/defect/detail/6803294489
# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
