### PR TITLE
fix(tmq): reset hb/poll counters on resubscribe and drain phantom consumer removals

### DIFF
--- a/source/dnode/mnode/impl/src/mndConsumer.c
+++ b/source/dnode/mnode/impl/src/mndConsumer.c
@@ -902,7 +902,9 @@ static int32_t mndConsumerActionUpdate(SSdb *pSdb, SMqConsumerObj *pOldConsumer,
 
     pOldConsumer->subscribeTime = taosGetTimestampMs();
     pOldConsumer->status = MQ_CONSUMER_STATUS_REBALANCE;
-    mInfo("consumer:0x%" PRIx64 " subscribe update, modify existed consumer", pOldConsumer->consumerId);
+    atomic_store_32(&pOldConsumer->hbStatus, 0);
+    atomic_store_32(&pOldConsumer->pollStatus, 0);
+    mInfo("consumer:0x%" PRIx64 " subscribe update, modify existed consumer, reset hb/poll status", pOldConsumer->consumerId);
   } else if (pNewConsumer->updateType == CONSUMER_UPDATE_REB) {
     (void)atomic_add_fetch_32(&pOldConsumer->epoch, 1);
     pOldConsumer->status = MQ_CONSUMER_STATUS_READY;

--- a/source/dnode/mnode/impl/src/mndSubscribe.c
+++ b/source/dnode/mnode/impl/src/mndSubscribe.c
@@ -338,6 +338,10 @@ static int32_t processRemovedConsumers(SMqRebOutputObj *pOutput, SHashObj *pHash
     MND_TMQ_NULL_CHECK(consumerId);
     SMqConsumerEp *pConsumerEp = taosHashGet(pOutput->pSub->consumerHash, consumerId, sizeof(int64_t));
     if (pConsumerEp == NULL) {
+      mInfo("tmq rebalance sub:%s consumer:0x%" PRIx64 " not found in consumerHash, cleanup only",
+            pOutput->pSub->key, *consumerId);
+      MND_TMQ_NULL_CHECK(taosArrayPush(pOutput->removedConsumers, consumerId));
+      actualRemoved++;
       continue;
     }
 


### PR DESCRIPTION
Two related TMQ fixes for a consumer lifecycle bug during subscribe/rebalance.

### What happens

When an existing consumer calls subscribe() to change topics, mndConsumerActionUpdate sets status to MQ_CONSUMER_STATUS_REBALANCE but does not reset hbStatus or pollStatus. The rebalance timer can then observe REBALANCE + counters carried over from the previous subscription cycle, classify the consumer as offline, and send TDMT_MND_TMQ_LOST_CONSUMER_CLEAR, dropping it from SDB. After that, heartbeats and polls fail with Consumer not exist.

Over repeated restart/reconnect cycles, a second issue appears: consumer clear removes the consumer from SDB but does not remove it from a subscription's consumerHash. On a later rebalance, processRemovedConsumers may not find that consumer in consumerHash, skip it, and never add it to pOutput->removedConsumers. That prevents CONSUMER_REMOVE_REB from being committed, so rebRemovedTopics is never drained and the same phantom removal is retried every tick. This also distorts calcVgroupsCnt because it uses input removedConsumers count, not actual removals.

### Fixes

1. **mndConsumer.c** — In CONSUMER_UPDATE_SUB, reset hbStatus and pollStatus to 0. A subscribe RPC is an active liveness signal, and heartbeat handling already resets these counters. Both fields are in-memory only (not serialized), and reset is performed under the existing write lock.

2. **mndSubscribe.c** — In processRemovedConsumers, if a consumer is not found in consumerHash, still push it to pOutput->removedConsumers and count it. This allows the normal CONSUMER_REMOVE_REB commit path to drain rebRemovedTopics and break the phantom-removal loop. In the rebalance path, these IDs come from checkOneConsumer/buildRebInfo over sdbFetch (SDB_STATUS_READY), so updates are expected to apply in place. removeFromTopicList in REMOVE_REB is safe when the topic is already absent.

### Testing

Built patched taosd and ran TMQ subscribe/poll reconnect cycles across multiple topics.

- Before patch: frequent Consumer not exist failure loops and sustained removedNum not matched log spam.
- After patch: no false consumer clears, no phantom-removal retry loops, stable poll delivery.