### PR TITLE
fix(test/com_config): skip mempool case for windows

### DIFF
--- a/test/cases/80-Components/01-Taosd/test_com_config.py
+++ b/test/cases/80-Components/01-Taosd/test_com_config.py
@@ -226,7 +226,8 @@ class TestAlterConfig:
         self.alter_dnode_1_case()
 
         #TS-6363
-        self.alter_memPoolReservedSizeMB_case()
+        if platform.system().lower() != 'windows':
+            self.alter_memPoolReservedSizeMB_case()
 
         self.alter_timezone_case()
 


### PR DESCRIPTION
# Description

<!-- Please briefly describe the code changes in this pull request. -->

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link
https://project.feishu.cn/taosdata_td/defect/detail/6880146173
# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
