### PR TITLE
fix(taos-tools): remove custom duplicate macros and uniformly use the macro definitions under the project's include directory

### DIFF
--- a/tools/taos-tools/inc/bench.h
+++ b/tools/taos-tools/inc/bench.h
@@ -140,8 +140,8 @@ typedef unsigned __int32 uint32_t;
 // 16*MAX_COLUMNS + (192+32)*2 + insert into
 #define HEAD_BUFF_LEN         (TSDB_MAX_COLUMNS * 24)
 
-#define FETCH_BUFFER_SIZE     (100 * TSDB_MAX_ALLOWED_SQL_LEN)
-#define COND_BUF_LEN          (TSDB_MAX_ALLOWED_SQL_LEN - 30)
+#define FETCH_BUFFER_SIZE     (100 * TOOLS_MAX_ALLOWED_SQL_LEN)
+#define COND_BUF_LEN          (TOOLS_MAX_ALLOWED_SQL_LEN - 30)
 
 #define OPT_ABORT                 1    /* –abort */
 #define MAX_RECORDS_PER_REQ       65536
@@ -293,7 +293,7 @@ enum enum_TAOS_INTERFACE {
     STMT_IFACE,
     STMT2_IFACE,
     SML_IFACE,
-    SML_REST_IFACE,    
+    SML_REST_IFACE,
     INTERFACE_BUT
 };
 
@@ -702,7 +702,7 @@ typedef struct SuperQueryInfo_S {
     int       subscribeKeepProgress;
     int64_t   childTblCount;
     int       sqlCount;
-    char      sql[MAX_QUERY_SQL_COUNT][TSDB_MAX_ALLOWED_SQL_LEN + 1];
+    char      sql[MAX_QUERY_SQL_COUNT][TOOLS_MAX_ALLOWED_SQL_LEN + 1];
     char      result[MAX_QUERY_SQL_COUNT][MAX_FILE_NAME_LEN];
     int       resubAfterConsume;
     int       endAfterConsume;
@@ -795,7 +795,7 @@ typedef struct SArguments_S {
 #endif
     bool                terminate;
     bool                in_prompt;
-    
+
     // websocket
     char*               dsn;
 

--- a/tools/taos-tools/inc/dumpUtil.h
+++ b/tools/taos-tools/inc/dumpUtil.h
@@ -4,6 +4,7 @@
 #include <taos.h>
 #include <taoserror.h>
 #include <toolsdef.h>
+#include "tdef.h"
 #include "dump.h"
 
 //
@@ -31,9 +32,6 @@
 #define RETRY_TYPE_CONNECT 0
 #define RETRY_TYPE_QUERY   1
 #define RETRY_TYPE_FETCH   2
-
-//come from TDengine util/tdef.h
-#define TSDB_TABLE_NAME_LEN           193                                // it is a null-terminated string
 
 //
 // ------------- struct define ----------

--- a/tools/taos-tools/inc/toolsdef.h
+++ b/tools/taos-tools/inc/toolsdef.h
@@ -25,6 +25,9 @@ extern "C" {
 
 #define ALLOW_FORBID_FUNC
 #include "os.h"
+#include "types.h"
+#include "taoserror.h"
+#include "taosdef.h"
 
 #define TINY_BUFF_LEN                   8
 #define SMALL_BUFF_LEN                  20
@@ -40,191 +43,9 @@ extern "C" {
 // max hostname length on Linux is 253
 #define MAX_HOSTNAME_LEN                254
 
-#define TSDB_CODE_SUCCESS               0
-#define TSDB_CODE_FAILED                -1   // unknown or needn't tell detail error
-
-// NULL definition
-#ifndef TSDB_DATA_BOOL_NULL
-#define TSDB_DATA_BOOL_NULL             0x02
-#endif
-
-#ifndef TSDB_DATA_TINYINT_NULL
-#define TSDB_DATA_TINYINT_NULL          0x80
-#endif
-
-#ifndef TSDB_DATA_SMALLINT_NULL
-#define TSDB_DATA_SMALLINT_NULL         0x8000
-#endif
-
-#ifndef TSDB_DATA_INT_NULL
-#define TSDB_DATA_INT_NULL              0x80000000L
-#endif
-
-#ifndef TSDB_DATA_BIGINT_NULL
-#define TSDB_DATA_BIGINT_NULL           0x8000000000000000L
-#endif
-
-#ifndef TSDB_DATA_TIMESTAMP_NULL
-#define TSDB_DATA_TIMESTAMP_NULL        TSDB_DATA_BIGINT_NULL
-#endif
-
-#ifndef TSDB_DATA_FLOAT_NULL
-#define TSDB_DATA_FLOAT_NULL            0x7FF00000              /* it is an NAN */
-#endif
-
-#ifndef TSDB_DATA_DOUBLE_NULL
-#define TSDB_DATA_DOUBLE_NULL           0x7FFFFF0000000000L    /* an NAN */
-#endif
-
-#ifndef TSDB_DATA_NCHAR_NULL
-#define TSDB_DATA_NCHAR_NULL            0xFFFFFFFF
-#endif
-
-#ifndef TSDB_DATA_BINARY_NULL
-#define TSDB_DATA_BINARY_NULL           0xFF
-#endif
-
-#ifndef TSDB_DATA_JSON_PLACEHOLDER
-#define TSDB_DATA_JSON_PLACEHOLDER      0x7F
-#endif
-
-#ifndef TSDB_DATA_JSON_NULL
-#define TSDB_DATA_JSON_NULL             0xFFFFFFFF
-#endif
-
-#ifndef TSDB_DATA_JSON_null
-#define TSDB_DATA_JSON_null             0xFFFFFFFE
-#endif
-
-#ifndef TSDB_DATA_JSON_NOT_NULL
-#define TSDB_DATA_JSON_NOT_NULL         0x01
-#endif
-
-#ifndef TSDB_DATA_JSON_CAN_NOT_COMPARE
-#define TSDB_DATA_JSON_CAN_NOT_COMPARE  0x7FFFFFFF
-#endif
-
-#ifndef TSDB_DATA_UTINYINT_NULL
-#define TSDB_DATA_UTINYINT_NULL         0xFF
-#endif
-
-#ifndef TSDB_DATA_USMALLINT_NULL
-#define TSDB_DATA_USMALLINT_NULL        0xFFFF
-#endif
-
-#ifndef TSDB_DATA_UINT_NULL
-#define TSDB_DATA_UINT_NULL             0xFFFFFFFF
-#endif
-
-#ifndef TSDB_DATA_UBIGINT_NULL
-#define TSDB_DATA_UBIGINT_NULL          0xFFFFFFFFFFFFFFFFL
-#endif
-
-
-#ifndef GET_INT8_VAL
-#define GET_INT8_VAL(x)    (*(int8_t *)(x))
-#endif
-
-#ifndef GET_INT16_VAL
-#define GET_INT16_VAL(x)   (*(int16_t *)(x))
-#endif
-
-#ifndef GET_INT32_VAL
-#define GET_INT32_VAL(x)   (*(int32_t *)(x))
-#endif
-
-#ifndef GET_INT64_VAL
-#define GET_INT64_VAL(x)   (*(int64_t *)(x))
-#endif
-
-#ifndef GET_UINT8_VAL
-#define GET_UINT8_VAL(x)   (*(uint8_t*)(x))
-#endif
-
-#ifndef GET_UINT16_VAL
-#define GET_UINT16_VAL(x)  (*(uint16_t *)(x))
-#endif
-
-#ifndef GET_UINT32_VAL
-#define GET_UINT32_VAL(x)  (*(uint32_t *)(x))
-#endif
-
-#ifndef GET_UINT64_VAL
-#define GET_UINT64_VAL(x)  (*(uint64_t *)(x))
-#endif
-
-#ifndef TSDB_DEFAULT_USER
-#define TSDB_DEFAULT_USER               "root"
-#endif
-#ifndef TSDB_DEFAULT_PASS
-#define TSDB_DEFAULT_PASS               "taosdata"
-#endif
-
-#define TSDB_TIME_PRECISION_MILLI       0
-#define TSDB_TIME_PRECISION_MICRO       1
-#define TSDB_TIME_PRECISION_NANO        2
-
-#ifndef TSDB_MAX_COLUMNS
-#define TSDB_MAX_COLUMNS                32767
-#endif
-
-#ifndef TSDB_MIN_COLUMNS
-#define TSDB_MIN_COLUMNS                2       //PRIMARY COLUMN(timestamp) + other columns
-#endif
-
-#ifndef TSDB_TABLE_NAME_LEN
-#define TSDB_TABLE_NAME_LEN             193     // it is a null-terminated string
-#endif
-
-#ifndef TSDB_DB_NAME_LEN
-#define TSDB_DB_NAME_LEN                65
-#endif
-
-#ifndef TSDB_COL_NAME_LEN
-#define TSDB_COL_NAME_LEN               65
-#endif
-
-// come from tdef.h 
-#ifndef TSDB_MAX_ALLOWED_SQL_LEN
-#define TSDB_MAX_ALLOWED_SQL_LEN        (4*1024*1024u) /* sql max length */
-#endif
-
-#ifndef TSDB_MAX_BYTES_PER_ROW
-#define TSDB_MAX_BYTES_PER_ROW          65531
-#endif
-
-#ifndef TSDB_MAX_TAGS
-#define TSDB_MAX_TAGS                   128
-#endif
-
-#ifndef TSDB_DEFAULT_PKT_SIZE
-#define TSDB_DEFAULT_PKT_SIZE           65480  //same as RPC_MAX_UDP_SIZE
-#endif
-
-#ifdef TSKEY32
-#define TSKEY int32_t;
-#else
-#define TSKEY int64_t
-#endif
-
-#ifndef TSDB_KEYSIZE
-#define TSDB_KEYSIZE                    sizeof(TSKEY)
-#endif
-
-#ifndef TSDB_MAX_FIELD_LEN
-#define TSDB_MAX_FIELD_LEN              65519
-#endif
-
-#ifndef TSDB_MAX_BINARY_LEN
-#define TSDB_MAX_BINARY_LEN             TSDB_MAX_FIELD_LEN
-#endif
-
-#ifndef TSDB_FILENAME_LEN
-#define TSDB_FILENAME_LEN               128
-#endif
-
-#ifndef TSDB_PORT_HTTP
-#define TSDB_PORT_HTTP                  11
+// come from tdef.h
+#ifndef TOOLS_MAX_ALLOWED_SQL_LEN
+#define TOOLS_MAX_ALLOWED_SQL_LEN        (4*1024*1024u) /* sql max length */
 #endif
 
 #if _MSC_VER <= 1900
@@ -235,27 +56,6 @@ extern "C" {
     #define FORCE_INLINE inline __attribute__((always_inline))
 #else
     #define FORCE_INLINE
-#endif
-
-#ifdef _TD_ARM_32
-    float  taos_align_get_float(const char* pBuf);
-    double taos_align_get_double(const char* pBuf);
-
-    #define GET_FLOAT_VAL(x)        taos_align_get_float(x)
-    #define GET_DOUBLE_VAL(x)       taos_align_get_double(x)
-    #define SET_FLOAT_VAL(x, y)     { float z = (float)(y);   (*(int32_t*) x = *(int32_t*)(&z)); }
-    #define SET_DOUBLE_VAL(x, y)    { double z = (double)(y); (*(int64_t*) x = *(int64_t*)(&z)); }
-    #define SET_TIMESTAMP_VAL(x, y) { int64_t z = (int64_t)(y); (*(int64_t*) x = *(int64_t*)(&z)); }
-    #define SET_FLOAT_PTR(x, y)     { (*(int32_t*) x = *(int32_t*)y); }
-    #define SET_DOUBLE_PTR(x, y)    { (*(int64_t*) x = *(int64_t*)y); }
-#else
-    #define GET_FLOAT_VAL(x)        (*(float *)(x))
-    #define GET_DOUBLE_VAL(x)       (*(double *)(x))
-    #define SET_FLOAT_VAL(x, y)     { (*(float *)(x))  = (float)(y);       }
-    #define SET_DOUBLE_VAL(x, y)    { (*(double *)(x)) = (double)(y);      }
-    #define SET_TIMESTAMP_VAL(x, y) { (*(int64_t *)(x)) = (int64_t)(y);    }
-    #define SET_FLOAT_PTR(x, y)     { (*(float *)(x))  = (*(float *)(y));  }
-    #define SET_DOUBLE_PTR(x, y)    { (*(double *)(x)) = (*(double *)(y)); }
 #endif
 
 #ifdef WINDOWS

--- a/tools/taos-tools/inc/toolsdef.h
+++ b/tools/taos-tools/inc/toolsdef.h
@@ -43,7 +43,7 @@ extern "C" {
 // max hostname length on Linux is 253
 #define MAX_HOSTNAME_LEN                254
 
-// come from tdef.h
+// Maximum SQL length allowed by tools
 #ifndef TOOLS_MAX_ALLOWED_SQL_LEN
 #define TOOLS_MAX_ALLOWED_SQL_LEN        (4*1024*1024u) /* sql max length */
 #endif

--- a/tools/taos-tools/src/CMakeLists.txt
+++ b/tools/taos-tools/src/CMakeLists.txt
@@ -43,7 +43,7 @@ MESSAGE("collect --version show info:")
 IF (DEFINED TD_VER_NUMBER)
     ADD_DEFINITIONS(-DTD_VER_NUMBER="${TD_VER_NUMBER}")
     MESSAGE(STATUS "version:${TD_VER_NUMBER}")
-ELSE ()    
+ELSE ()
     # abort build
     MESSAGE(FATAL_ERROR "build taos-tools not found TD_VER_NUMBER define.")
 ENDIF ()
@@ -56,7 +56,7 @@ IF(GIT_FOUND)
         COMMAND git log -1 --format=%H
         WORKING_DIRECTORY ${TD_COMMUNITY_DIR}
         OUTPUT_VARIABLE GIT_COMMIT_ID
-        )    
+        )
 
     STRING(SUBSTRING "${GIT_COMMIT_ID}" 0 40 TAOSBENCHMARK_COMMIT_ID)
     SET(TAOSDUMP_COMMIT_ID "${TAOSBENCHMARK_COMMIT_ID}")
@@ -66,7 +66,7 @@ IF(GIT_FOUND)
     MESSAGE(STATUS "taosBenchmark commit id: ${TAOSBENCHMARK_COMMIT_ID}")
     # define
     ADD_DEFINITIONS(-DTAOSDUMP_COMMIT_ID="${TAOSDUMP_COMMIT_ID}")
-    ADD_DEFINITIONS(-DTAOSBENCHMARK_COMMIT_ID="${TAOSBENCHMARK_COMMIT_ID}")        
+    ADD_DEFINITIONS(-DTAOSBENCHMARK_COMMIT_ID="${TAOSBENCHMARK_COMMIT_ID}")
 ELSE()
     MESSAGE(FATAL_ERROR "build taos-tools FIND_PACKAGE(Git) failed.")
 ENDIF (GIT_FOUND)
@@ -120,8 +120,8 @@ ENDIF ()
 target_link_libraries(taosdump PRIVATE toolscJson)
 TARGET_LINK_LIBRARIES(taosBenchmark PRIVATE toolscJson)
 
-TARGET_LINK_LIBRARIES(taosdump PRIVATE taos)
-TARGET_LINK_LIBRARIES(taosBenchmark PRIVATE taos)
+TARGET_LINK_LIBRARIES(taosdump PUBLIC taos)
+TARGET_LINK_LIBRARIES(taosBenchmark PUBLIC taos)
 
 if(NOT WIN32)
   target_link_libraries(taosdump PRIVATE stdc++)

--- a/tools/taos-tools/src/benchCommandOpt.c
+++ b/tools/taos-tools/src/benchCommandOpt.c
@@ -160,7 +160,7 @@ static void initStable() {
     stbInfo->stbName = "meters";
     stbInfo->childTblPrefix = DEFAULT_TB_PREFIX;
     stbInfo->use_metric = 1;
-    stbInfo->max_sql_len = TSDB_MAX_ALLOWED_SQL_LEN;
+    stbInfo->max_sql_len = TOOLS_MAX_ALLOWED_SQL_LEN;
     stbInfo->cols = benchArrayInit(3, sizeof(Field));
     for (int i = 0; i < 3; ++i) {
         Field *col = benchCalloc(1, sizeof(Field), true);
@@ -375,7 +375,7 @@ static void *queryStableAggrFunc(void *sarg) {
 #ifdef LINUX
     prctl(PR_SET_NAME, "queryStableAggrFunc");
 #endif
-    char *command = benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, false);
+    char *command = benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, false);
     FILE *  fp = g_arguments->fpOfInsertResult;
     SDataBase * database = benchArrayGet(g_arguments->databases, 0);
     SSuperTable * stbInfo = benchArrayGet(database->superTbls, 0);
@@ -418,7 +418,7 @@ static void *queryStableAggrFunc(void *sarg) {
                 }
             }
             strncat(condition, tempS, COND_BUF_LEN - 1);
-            (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+            (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
                      "SELECT %s FROM %s.meters WHERE %s",
                     aggreFunc[j], database->dbName,
                     condition);
@@ -469,7 +469,7 @@ static void *queryNtableAggrFunc(void *sarg) {
 #ifdef LINUX
     prctl(PR_SET_NAME, "queryNtableAggrFunc");
 #endif
-    char *  command = benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, false);
+    char *  command = benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, false);
     FILE *  fp = g_arguments->fpOfInsertResult;
     SDataBase * database = benchArrayGet(g_arguments->databases, 0);
     SSuperTable * stbInfo = benchArrayGet(database->superTbls, 0);
@@ -497,7 +497,7 @@ static void *queryNtableAggrFunc(void *sarg) {
         uint64_t count = 0;
         for (int64_t i = 0; i < stbInfo->childTblCount; i++) {
             (void)snprintf(command,
-                    TSDB_MAX_ALLOWED_SQL_LEN,
+                    TOOLS_MAX_ALLOWED_SQL_LEN,
                     g_arguments->escape_character
                     ? "SELECT %s FROM `%s`.`%s%" PRId64 "` WHERE ts>= %" PRIu64
                     : "SELECT %s FROM %s.%s%" PRId64 " WHERE ts>= %" PRIu64 ,

--- a/tools/taos-tools/src/benchData.c
+++ b/tools/taos-tools/src/benchData.c
@@ -246,7 +246,7 @@ void rand_string(char *str, int size, bool chinese) {
 // generate prepare sql
 char* genPrepareSql(SSuperTable *stbInfo, char* tagData, uint64_t tableSeq, char *db) {
     int   len = 0;
-    char *prepare = benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, true);
+    char *prepare = benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, true);
     int n;
     char *tagQ = NULL;
     char *colQ = genQMark(stbInfo->cols->size);
@@ -267,19 +267,19 @@ char* genPrepareSql(SSuperTable *stbInfo, char* tagData, uint64_t tableSeq, char
             (void)snprintf(ttl, SMALL_BUFF_LEN, "TTL %d", stbInfo->ttl);
         }
         n = snprintf(prepare + len,
-                       TSDB_MAX_ALLOWED_SQL_LEN - len,
+                       TOOLS_MAX_ALLOWED_SQL_LEN - len,
                        "INSERT INTO ? USING `%s`.`%s` TAGS (%s) %s VALUES(?,%s)",
                        db, stbInfo->stbName, tagQ, ttl, colQ);
     } else {
         if (workingMode(g_arguments->connMode, g_arguments->dsn) == CONN_MODE_NATIVE) {
             // native
-            n = snprintf(prepare + len, TSDB_MAX_ALLOWED_SQL_LEN - len,
+            n = snprintf(prepare + len, TOOLS_MAX_ALLOWED_SQL_LEN - len,
                 "INSERT INTO ? VALUES(?,%s)", colQ);
         } else {
             // websocket
             bool ntb = stbInfo->tags == NULL || stbInfo->tags->size == 0; // normal table
             colNames = genColNames(stbInfo->cols, !ntb, stbInfo->primaryKeyName);
-            n = snprintf(prepare + len, TSDB_MAX_ALLOWED_SQL_LEN - len,
+            n = snprintf(prepare + len, TOOLS_MAX_ALLOWED_SQL_LEN - len,
                 "INSERT INTO `%s`.`%s`(%s) VALUES(%s,%s)", db, stbInfo->stbName, colNames,
                 ntb ? "?" : "?,?", colQ);
         }
@@ -430,14 +430,14 @@ static int getAndSetRowsFromCsvFile(char *sampleFile, uint64_t *insertRows) {
     int     line_count = 0;
     char *  buf = NULL;
 
-    buf = benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, false);
+    buf = benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, false);
     if (NULL == buf) {
         errorPrint("%s() failed to allocate memory!\n", __func__);
         fclose(fp);
         return -1;
     }
 
-    while (fgets(buf, TSDB_MAX_ALLOWED_SQL_LEN, fp)) {
+    while (fgets(buf, TOOLS_MAX_ALLOWED_SQL_LEN, fp)) {
         line_count++;
     }
     *insertRows = line_count;
@@ -2087,13 +2087,13 @@ int prepareSampleData(SDataBase* database, SSuperTable* stbInfo) {
 
         if(stbInfo->partialColNum < stbInfo->cols->size) {
             stbInfo->partialColNameBuf =
-                    benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, true);
+                    benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, true);
             int pos = 0;
             int n;
             n = snprintf(stbInfo->partialColNameBuf + pos,
-                            TSDB_MAX_ALLOWED_SQL_LEN - pos, "%s",
+                            TOOLS_MAX_ALLOWED_SQL_LEN - pos, "%s",
                             stbInfo->primaryKeyName);
-            if (n < 0 || n > TSDB_MAX_ALLOWED_SQL_LEN - pos) {
+            if (n < 0 || n > TOOLS_MAX_ALLOWED_SQL_LEN - pos) {
                 errorPrint("%s() LN%d snprintf overflow\n",
                            __func__, __LINE__);
             } else {
@@ -2102,9 +2102,9 @@ int prepareSampleData(SDataBase* database, SSuperTable* stbInfo) {
             for (int i = stbInfo->partialColFrom; i < stbInfo->partialColFrom + stbInfo->partialColNum; ++i) {
                 Field * col = benchArrayGet(stbInfo->cols, i);
                 n = snprintf(stbInfo->partialColNameBuf+pos,
-                                TSDB_MAX_ALLOWED_SQL_LEN - pos,
+                                TOOLS_MAX_ALLOWED_SQL_LEN - pos,
                                ",%s", col->name);
-                if (n < 0 || n > TSDB_MAX_ALLOWED_SQL_LEN - pos) {
+                if (n < 0 || n > TOOLS_MAX_ALLOWED_SQL_LEN - pos) {
                     errorPrint("%s() LN%d snprintf overflow at %d\n",
                                __func__, __LINE__, i);
                 } else {

--- a/tools/taos-tools/src/benchInsert.c
+++ b/tools/taos-tools/src/benchInsert.c
@@ -257,7 +257,7 @@ static int createSuperTable(SDataBase* database, SSuperTable* stbInfo) {
 
     uint32_t col_buffer_len = (TSDB_COL_NAME_LEN + 15 + COMP_NAME_LEN*3) * stbInfo->cols->size;
     char         *colsBuf = benchCalloc(1, col_buffer_len, false);
-    char*         command = benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, false);
+    char*         command = benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, false);
     int          len = 0;
 
     for (int colIndex = 0; colIndex < stbInfo->cols->size; colIndex++) {
@@ -389,7 +389,7 @@ skip:
     (void)snprintf(tagsBuf + len, tag_buffer_len - len, ")");
 
     int length = snprintf(
-        command, TSDB_MAX_ALLOWED_SQL_LEN,
+        command, TOOLS_MAX_ALLOWED_SQL_LEN,
         g_arguments->escape_character
             ? "CREATE TABLE IF NOT EXISTS `%s`.`%s` (%s TIMESTAMP%s) TAGS %s"
             : "CREATE TABLE IF NOT EXISTS %s.%s (%s TIMESTAMP%s) TAGS %s",
@@ -397,35 +397,35 @@ skip:
     tmfree(colsBuf);
     tmfree(tagsBuf);
     if (stbInfo->comment != NULL) {
-        length += snprintf(command + length, TSDB_MAX_ALLOWED_SQL_LEN - length,
+        length += snprintf(command + length, TOOLS_MAX_ALLOWED_SQL_LEN - length,
                            " COMMENT '%s'", stbInfo->comment);
     }
     if (stbInfo->delay >= 0) {
         length += snprintf(command + length,
-                           TSDB_MAX_ALLOWED_SQL_LEN - length, " DELAY %d",
+                           TOOLS_MAX_ALLOWED_SQL_LEN - length, " DELAY %d",
                            stbInfo->delay);
     }
     if (stbInfo->file_factor >= 0) {
         length +=
             snprintf(command + length,
-                     TSDB_MAX_ALLOWED_SQL_LEN - length, " FILE_FACTOR %f",
+                     TOOLS_MAX_ALLOWED_SQL_LEN - length, " FILE_FACTOR %f",
                      (float)stbInfo->file_factor / 100);
     }
     if (stbInfo->rollup != NULL) {
         length += snprintf(command + length,
-                           TSDB_MAX_ALLOWED_SQL_LEN - length,
+                           TOOLS_MAX_ALLOWED_SQL_LEN - length,
                            " ROLLUP(%s)", stbInfo->rollup);
     }
 
     if (stbInfo->max_delay != NULL) {
         length += snprintf(command + length,
-                           TSDB_MAX_ALLOWED_SQL_LEN - length,
+                           TOOLS_MAX_ALLOWED_SQL_LEN - length,
                 " MAX_DELAY %s", stbInfo->max_delay);
     }
 
     if (stbInfo->watermark != NULL) {
         length += snprintf(command + length,
-                           TSDB_MAX_ALLOWED_SQL_LEN - length,
+                           TOOLS_MAX_ALLOWED_SQL_LEN - length,
                 " WATERMARK %s", stbInfo->watermark);
     }
 
@@ -433,7 +433,7 @@ skip:
     /*
     if (stbInfo->ttl != 0) {
         length += snprintf(command + length,
-                           TSDB_MAX_ALLOWED_SQL_LEN - length,
+                           TOOLS_MAX_ALLOWED_SQL_LEN - length,
                 " TTL %d", stbInfo->ttl);
     }
     */
@@ -443,13 +443,13 @@ skip:
         Field * col = benchArrayGet(stbInfo->cols, i);
         if (col->sma) {
             if (first_sma) {
-                n = snprintf(command + length, TSDB_MAX_ALLOWED_SQL_LEN - length, " SMA(%s", col->name);
+                n = snprintf(command + length, TOOLS_MAX_ALLOWED_SQL_LEN - length, " SMA(%s", col->name);
                 first_sma = false;
             } else {
-                n = snprintf(command + length, TSDB_MAX_ALLOWED_SQL_LEN - length, ",%s", col->name);
+                n = snprintf(command + length, TOOLS_MAX_ALLOWED_SQL_LEN - length, ",%s", col->name);
             }
 
-            if (n < 0 || n > TSDB_MAX_ALLOWED_SQL_LEN - length) {
+            if (n < 0 || n > TOOLS_MAX_ALLOWED_SQL_LEN - length) {
                 errorPrint("%s() LN%d snprintf overflow on %d iteral\n", __func__, __LINE__, i);
                 break;
             } else {
@@ -458,7 +458,7 @@ skip:
         }
     }
     if (!first_sma) {
-        (void)snprintf(command + length, TSDB_MAX_ALLOWED_SQL_LEN - length, ")");
+        (void)snprintf(command + length, TOOLS_MAX_ALLOWED_SQL_LEN - length, ")");
     }
     debugPrint("create stable: <%s>\n", command);
 
@@ -557,14 +557,14 @@ int geneDbCreateCmd(SDataBase *database, char *command, int remainVnodes) {
 
             if (cfg->valuestring) {
                 n = snprintf(command + dataLen,
-                                        TSDB_MAX_ALLOWED_SQL_LEN - dataLen,
+                                        TOOLS_MAX_ALLOWED_SQL_LEN - dataLen,
                             " %s %s", cfg->name, cfg->valuestring);
             } else {
                 n = snprintf(command + dataLen,
-                                        TSDB_MAX_ALLOWED_SQL_LEN - dataLen,
+                                        TOOLS_MAX_ALLOWED_SQL_LEN - dataLen,
                             " %s %d", cfg->name, cfg->valueint);
             }
-            if (n < 0 || n >= TSDB_MAX_ALLOWED_SQL_LEN - dataLen) {
+            if (n < 0 || n >= TOOLS_MAX_ALLOWED_SQL_LEN - dataLen) {
                 errorPrint("%s() LN%d snprintf overflow on %d\n",
                            __func__, __LINE__, i);
                 break;
@@ -576,20 +576,20 @@ int geneDbCreateCmd(SDataBase *database, char *command, int remainVnodes) {
 
     // not found vgroups
     if (vgroups > 0) {
-        dataLen += snprintf(command + dataLen, TSDB_MAX_ALLOWED_SQL_LEN - dataLen, " VGROUPS %d", vgroups);
+        dataLen += snprintf(command + dataLen, TOOLS_MAX_ALLOWED_SQL_LEN - dataLen, " VGROUPS %d", vgroups);
     }
 
     switch (database->precision) {
         case TSDB_TIME_PRECISION_MILLI:
-            (void)snprintf(command + dataLen, TSDB_MAX_ALLOWED_SQL_LEN - dataLen,
+            (void)snprintf(command + dataLen, TOOLS_MAX_ALLOWED_SQL_LEN - dataLen,
                                 " PRECISION \'ms\';");
             break;
         case TSDB_TIME_PRECISION_MICRO:
-            (void)snprintf(command + dataLen, TSDB_MAX_ALLOWED_SQL_LEN - dataLen,
+            (void)snprintf(command + dataLen, TOOLS_MAX_ALLOWED_SQL_LEN - dataLen,
                                 " PRECISION \'us\';");
             break;
         case TSDB_TIME_PRECISION_NANO:
-            (void)snprintf(command + dataLen, TSDB_MAX_ALLOWED_SQL_LEN - dataLen,
+            (void)snprintf(command + dataLen, TOOLS_MAX_ALLOWED_SQL_LEN - dataLen,
                                 " PRECISION \'ns\';");
             break;
     }
@@ -792,9 +792,9 @@ static int generateChildTblName(int len, char *buffer, SDataBase *database,
                                 SSuperTable *stbInfo, uint64_t tableSeq, char* tagData, int i,
                                 char *ttl, char *tableName) {
     if (0 == len) {
-        memset(buffer, 0, TSDB_MAX_ALLOWED_SQL_LEN);
+        memset(buffer, 0, TOOLS_MAX_ALLOWED_SQL_LEN);
         len += snprintf(buffer + len,
-                        TSDB_MAX_ALLOWED_SQL_LEN - len, "CREATE TABLE");
+                        TOOLS_MAX_ALLOWED_SQL_LEN - len, "CREATE TABLE");
     }
 
     const char *tagStart = tagData + i * stbInfo->lenOfTags;  // start position of current row's TAG
@@ -821,7 +821,7 @@ static int generateChildTblName(int len, char *buffer, SDataBase *database,
 
     }
 
-    len += snprintf(buffer + len, TSDB_MAX_ALLOWED_SQL_LEN - len, fmt,
+    len += snprintf(buffer + len, TOOLS_MAX_ALLOWED_SQL_LEN - len, fmt,
                     database->dbName, tableName,
                     database->dbName, stbInfo->stbName,
                     tagsForSQL, ttl);
@@ -877,7 +877,7 @@ static void *createTable(void *sarg) {
 #ifdef LINUX
     prctl(PR_SET_NAME, "createTable");
 #endif
-    pThreadInfo->buffer = benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, false);
+    pThreadInfo->buffer = benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, false);
     infoPrint(
               "thread[%d] start creating table from %" PRIu64 " to %" PRIu64
               "\n",
@@ -909,14 +909,14 @@ static void *createTable(void *sarg) {
         }
         if (!stbInfo->use_metric || stbInfo->tags->size == 0) {
             if (stbInfo->childTblCount == 1) {
-                (void)snprintf(pThreadInfo->buffer, TSDB_MAX_ALLOWED_SQL_LEN,
+                (void)snprintf(pThreadInfo->buffer, TOOLS_MAX_ALLOWED_SQL_LEN,
                          g_arguments->escape_character
                          ? "CREATE TABLE IF NOT EXISTS `%s`.`%s` %s;"
                          : "CREATE TABLE IF NOT EXISTS %s.%s %s;",
                          database->dbName, stbInfo->stbName,
                          stbInfo->colsOfCreateChildTable);
             } else {
-                (void)snprintf(pThreadInfo->buffer, TSDB_MAX_ALLOWED_SQL_LEN,
+                (void)snprintf(pThreadInfo->buffer, TOOLS_MAX_ALLOWED_SQL_LEN,
                          g_arguments->escape_character
                          ? "CREATE TABLE IF NOT EXISTS `%s`.`%s` %s;"
                          : "CREATE TABLE IF NOT EXISTS %s.%s %s;",
@@ -954,7 +954,7 @@ static void *createTable(void *sarg) {
             int smallBatch = getBatchOfTblCreating(pThreadInfo, stbInfo);
             if ((!smallBatch || (smallBatchCount == smallBatch))
                     && (batchNum < stbInfo->batchTblCreatingNum)
-                    && ((TSDB_MAX_ALLOWED_SQL_LEN - len) >=
+                    && ((TOOLS_MAX_ALLOWED_SQL_LEN - len) >=
                         (stbInfo->lenOfTags + EXTRA_SQL_LEN))) {
                 continue;
             } else {
@@ -1478,15 +1478,15 @@ int32_t execInsert(threadInfo *pThreadInfo, uint32_t k, int64_t *delay3) {
                         if (TSDB_SML_TELNET_PROTOCOL == protocol
                                 && stbInfo->tcpTransfer) {
                             n = snprintf(pThreadInfo->buffer + len,
-                                            TSDB_MAX_ALLOWED_SQL_LEN - len,
+                                            TOOLS_MAX_ALLOWED_SQL_LEN - len,
                                            "put %s\n", pThreadInfo->lines[i]);
                         } else {
                             n = snprintf(pThreadInfo->buffer + len,
-                                            TSDB_MAX_ALLOWED_SQL_LEN - len,
+                                            TOOLS_MAX_ALLOWED_SQL_LEN - len,
                                             "%s\n",
                                            pThreadInfo->lines[i]);
                         }
-                        if (n < 0 || n >= TSDB_MAX_ALLOWED_SQL_LEN - len) {
+                        if (n < 0 || n >= TOOLS_MAX_ALLOWED_SQL_LEN - len) {
                             errorPrint("%s() LN%d snprintf overflow on %d\n",
                                 __func__, __LINE__, i);
                             break;
@@ -1521,9 +1521,9 @@ static int smartContinueIfFail(threadInfo *pThreadInfo,
     SDataBase *  database = pThreadInfo->dbInfo;
     SSuperTable *stbInfo = pThreadInfo->stbInfo;
     char *buffer =
-        benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, false);
+        benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, false);
     (void)snprintf(
-            buffer, TSDB_MAX_ALLOWED_SQL_LEN,
+            buffer, TOOLS_MAX_ALLOWED_SQL_LEN,
             g_arguments->escape_character ?
                 "CREATE TABLE IF NOT EXISTS `%s`.`%s` USING `%s`.`%s` TAGS (%s) %s "
                 : "CREATE TABLE IF NOT EXISTS %s.%s USING %s.%s TAGS (%s) %s ",
@@ -2686,7 +2686,7 @@ static int32_t prepareProgressDataSql(
     if (stbInfo->partialColNum == stbInfo->cols->size) {
         if (stbInfo->autoTblCreating) {
             *len =
-                snprintf(pstr, TSDB_MAX_ALLOWED_SQL_LEN,
+                snprintf(pstr, TOOLS_MAX_ALLOWED_SQL_LEN,
                         g_arguments->escape_character
                         ? "%s `%s`.`%s` USING `%s`.`%s` TAGS (%s) %s VALUES "
                         : "%s %s.%s USING %s.%s TAGS (%s) %s VALUES ",
@@ -2696,7 +2696,7 @@ static int32_t prepareProgressDataSql(
                          tagData +
                          stbInfo->lenOfTags * tableSeq, ttl);
         } else {
-            *len = snprintf(pstr, TSDB_MAX_ALLOWED_SQL_LEN,
+            *len = snprintf(pstr, TOOLS_MAX_ALLOWED_SQL_LEN,
                     g_arguments->escape_character
                            ? "%s `%s`.`%s` VALUES "
                            : "%s %s.%s VALUES ",
@@ -2706,7 +2706,7 @@ static int32_t prepareProgressDataSql(
     } else {
         if (stbInfo->autoTblCreating) {
             *len = snprintf(
-                    pstr, TSDB_MAX_ALLOWED_SQL_LEN,
+                    pstr, TOOLS_MAX_ALLOWED_SQL_LEN,
                     g_arguments->escape_character
                     ? "%s `%s`.`%s` (%s) USING `%s`.`%s` TAGS (%s) %s VALUES "
                     : "%s %s.%s (%s) USING %s.%s TAGS (%s) %s VALUES ",
@@ -2717,7 +2717,7 @@ static int32_t prepareProgressDataSql(
                     tagData +
                     stbInfo->lenOfTags * tableSeq, ttl);
         } else {
-            *len = snprintf(pstr, TSDB_MAX_ALLOWED_SQL_LEN,
+            *len = snprintf(pstr, TOOLS_MAX_ALLOWED_SQL_LEN,
                     g_arguments->escape_character
                     ? "%s `%s`.`%s` (%s) VALUES "
                     : "%s %s.%s (%s) VALUES ",
@@ -2740,13 +2740,13 @@ static int32_t prepareProgressDataSql(
                 && (!stbInfo->random_data_source)) {
             *len +=
                 snprintf(pstr + *len,
-                         TSDB_MAX_ALLOWED_SQL_LEN - *len, "(%s)",
+                         TOOLS_MAX_ALLOWED_SQL_LEN - *len, "(%s)",
                          sampleDataBuf +
                          *pos * stbInfo->lenOfCols);
         } else {
             int64_t disorderTs = getDisorderTs(stbInfo, &disorderRange);
             *len += snprintf(pstr + *len,
-                            TSDB_MAX_ALLOWED_SQL_LEN - *len,
+                            TOOLS_MAX_ALLOWED_SQL_LEN - *len,
                             "(%" PRId64 ",%s)",
                             disorderTs?disorderTs:*timestamp,
                             ownSampleDataBuf +
@@ -2762,7 +2762,7 @@ static int32_t prepareProgressDataSql(
         }
 
         generated++;
-        if (*len > (TSDB_MAX_ALLOWED_SQL_LEN
+        if (*len > (TOOLS_MAX_ALLOWED_SQL_LEN
             - stbInfo->lenOfCols)) {
             break;
         }
@@ -3861,7 +3861,7 @@ void *genInsertTheadInfo(void* arg) {
             if (stbInfo->interlaceRows > 0) {
                 pThreadInfo->buffer = new_ds(0);
             } else {
-                pThreadInfo->buffer = benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, true);
+                pThreadInfo->buffer = benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, true);
             }
             int sockfd = createSockFd();
             if (sockfd < 0) {
@@ -4032,10 +4032,10 @@ void *genInsertTheadInfo(void* arg) {
             if (stbInfo->interlaceRows > 0) {
                 pThreadInfo->buffer = new_ds(0);
             } else {
-                pThreadInfo->buffer = benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, true);
+                pThreadInfo->buffer = benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, true);
                 if (g_arguments->check_sql) {
-                    pThreadInfo->csql = benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, true);
-                    memset(pThreadInfo->csql, 0, TSDB_MAX_ALLOWED_SQL_LEN);
+                    pThreadInfo->csql = benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, true);
+                    memset(pThreadInfo->csql, 0, TOOLS_MAX_ALLOWED_SQL_LEN);
                 }
             }
 

--- a/tools/taos-tools/src/benchInsertMix.c
+++ b/tools/taos-tools/src/benchInsertMix.c
@@ -594,7 +594,7 @@ uint32_t genBatchSql(threadInfo* info, SSuperTable* stb, SMixRatio* mix, int64_t
       ts += timestamp_step;
     }
 
-    // check over TSDB_MAX_ALLOWED_SQL_LENGTH
+    // check over TOOLS_MAX_ALLOWED_SQL_LEN
     if (len > (TOOLS_MAX_ALLOWED_SQL_LEN - stb->lenOfCols - 320)) {
       break;
     }

--- a/tools/taos-tools/src/benchInsertMix.c
+++ b/tools/taos-tools/src/benchInsertMix.c
@@ -190,32 +190,32 @@ uint32_t genInsertPreSql(threadInfo* info, SDataBase* db, SSuperTable* stb, char
 
     if (stb->partialColNum == stb->cols->size) {
       if (stb->autoTblCreating) {
-        len = snprintf(pstr, TSDB_MAX_ALLOWED_SQL_LEN, "%s %s.%s USING %s.%s TAGS (%s) %s VALUES ", STR_INSERT_INTO, db->dbName,
+        len = snprintf(pstr, TOOLS_MAX_ALLOWED_SQL_LEN, "%s %s.%s USING %s.%s TAGS (%s) %s VALUES ", STR_INSERT_INTO, db->dbName,
                        tableName, db->dbName, stb->stbName, tagData + stb->lenOfTags * tableSeq, ttl);
       } else {
-        len = snprintf(pstr, TSDB_MAX_ALLOWED_SQL_LEN, "%s %s.%s VALUES ", STR_INSERT_INTO, db->dbName, tableName);
+        len = snprintf(pstr, TOOLS_MAX_ALLOWED_SQL_LEN, "%s %s.%s VALUES ", STR_INSERT_INTO, db->dbName, tableName);
       }
     } else {
       if (stb->autoTblCreating) {
-        len = snprintf(pstr, TSDB_MAX_ALLOWED_SQL_LEN, "%s %s.%s (%s) USING %s.%s TAGS (%s) %s VALUES ", STR_INSERT_INTO, db->dbName,
+        len = snprintf(pstr, TOOLS_MAX_ALLOWED_SQL_LEN, "%s %s.%s (%s) USING %s.%s TAGS (%s) %s VALUES ", STR_INSERT_INTO, db->dbName,
                        tableName, stb->partialColNameBuf, db->dbName, stb->stbName,
                        tagData + stb->lenOfTags * tableSeq, ttl);
       } else {
-        len = snprintf(pstr, TSDB_MAX_ALLOWED_SQL_LEN, "%s %s.%s (%s) VALUES ", STR_INSERT_INTO, db->dbName, tableName,
+        len = snprintf(pstr, TOOLS_MAX_ALLOWED_SQL_LEN, "%s %s.%s (%s) VALUES ", STR_INSERT_INTO, db->dbName, tableName,
                        stb->partialColNameBuf);
       }
     }
 
     // generate check sql
     if(info->csql) {
-      info->clen = snprintf(info->csql, TSDB_MAX_ALLOWED_SQL_LEN, "select count(*) from %s.%s where ts in(", db->dbName, tableName);
+      info->clen = snprintf(info->csql, TOOLS_MAX_ALLOWED_SQL_LEN, "select count(*) from %s.%s where ts in(", db->dbName, tableName);
     }
     return len;
   }
 
   // generate check sql
   if (info->csql) {
-    info->clen = snprintf(info->csql, TSDB_MAX_ALLOWED_SQL_LEN, "select count(*) from %s.%s where ts in(", db->dbName, tableName);
+    info->clen = snprintf(info->csql, TOOLS_MAX_ALLOWED_SQL_LEN, "select count(*) from %s.%s where ts in(", db->dbName, tableName);
   }
 
   // new mix rule
@@ -234,7 +234,7 @@ uint32_t genInsertPreSql(threadInfo* info, SDataBase* db, SSuperTable* stb, char
   }
 
   char * colNames = genBatColsNames(info, stb);
-  len = snprintf(pstr, TSDB_MAX_ALLOWED_SQL_LEN, "%s %s.%s (%s) VALUES ", STR_INSERT_INTO, db->dbName, tableName, colNames);
+  len = snprintf(pstr, TOOLS_MAX_ALLOWED_SQL_LEN, "%s %s.%s (%s) VALUES ", STR_INSERT_INTO, db->dbName, tableName, colNames);
   free(colNames);
 
   return len;
@@ -246,7 +246,7 @@ uint32_t genInsertPreSql(threadInfo* info, SDataBase* db, SSuperTable* stb, char
 uint32_t genDelPreSql(SDataBase* db, SSuperTable* stb, char* tableName, char* pstr) {
   uint32_t len = 0;
   // super table name or child table name random select
-  len = snprintf(pstr, TSDB_MAX_ALLOWED_SQL_LEN, "delete from %s.%s where ", db->dbName, tableName);
+  len = snprintf(pstr, TOOLS_MAX_ALLOWED_SQL_LEN, "delete from %s.%s where ", db->dbName, tableName);
 
   return len;
 }
@@ -260,7 +260,7 @@ uint32_t appendRowRuleOld(SSuperTable* stb, char* pstr, uint32_t len, int64_t ti
   int      disorderRange = stb->disorderRange;
 
   if (stb->useSampleTs && !stb->random_data_source) {
-    size = snprintf(pstr + len, TSDB_MAX_ALLOWED_SQL_LEN - len, "(%s)", stb->sampleDataBuf + pos * stb->lenOfCols);
+    size = snprintf(pstr + len, TOOLS_MAX_ALLOWED_SQL_LEN - len, "(%s)", stb->sampleDataBuf + pos * stb->lenOfCols);
   } else {
     int64_t disorderTs = 0;
     if (stb->disorderRatio > 0) {
@@ -278,7 +278,7 @@ uint32_t appendRowRuleOld(SSuperTable* stb, char* pstr, uint32_t len, int64_t ti
       }
     }
     // generate
-    size = snprintf(pstr + len, TSDB_MAX_ALLOWED_SQL_LEN - len, "(%" PRId64 ",%s)", disorderTs ? disorderTs : timestamp,
+    size = snprintf(pstr + len, TOOLS_MAX_ALLOWED_SQL_LEN - len, "(%" PRId64 ",%s)", disorderTs ? disorderTs : timestamp,
                     stb->sampleDataBuf + pos * stb->lenOfCols);
   }
 
@@ -299,9 +299,9 @@ uint32_t genRowMixAll(threadInfo* info, SSuperTable* stb, char* pstr, uint32_t l
       (void)sprintf(now, "now+%dm", min);
     }
 
-    size = snprintf(pstr + len, TSDB_MAX_ALLOWED_SQL_LEN - len, "(%s", now);
+    size = snprintf(pstr + len, TOOLS_MAX_ALLOWED_SQL_LEN - len, "(%s", now);
   } else {
-    size = snprintf(pstr + len, TSDB_MAX_ALLOWED_SQL_LEN - len, "(%" PRId64, ts);
+    size = snprintf(pstr + len, TOOLS_MAX_ALLOWED_SQL_LEN - len, "(%" PRId64, ts);
   }
 
   // other cols data
@@ -322,7 +322,7 @@ uint32_t genRowMixAll(threadInfo* info, SSuperTable* stb, char* pstr, uint32_t l
   }
 
   // end
-  size += snprintf(pstr + len + size, TSDB_MAX_ALLOWED_SQL_LEN - len - size, "%s", ")");
+  size += snprintf(pstr + len + size, TOOLS_MAX_ALLOWED_SQL_LEN - len - size, "%s", ")");
 
   return size;
 }
@@ -330,7 +330,7 @@ uint32_t genRowMixAll(threadInfo* info, SSuperTable* stb, char* pstr, uint32_t l
 uint32_t genRowTsCalc(threadInfo* info, SSuperTable* stb, char* pstr, uint32_t len, int64_t ts) {
   uint32_t size = 0;
   // first col is ts
-  size = snprintf(pstr +len, TSDB_MAX_ALLOWED_SQL_LEN - len, "(%" PRId64, ts);
+  size = snprintf(pstr +len, TOOLS_MAX_ALLOWED_SQL_LEN - len, "(%" PRId64, ts);
 
   // other cols data
   for(uint16_t i = 0; i< info->nBatCols; i++) {
@@ -339,7 +339,7 @@ uint32_t genRowTsCalc(threadInfo* info, SSuperTable* stb, char* pstr, uint32_t l
   }
 
   // end
-  size += snprintf(pstr + len + size, TSDB_MAX_ALLOWED_SQL_LEN - len - size, "%s", ")");
+  size += snprintf(pstr + len + size, TOOLS_MAX_ALLOWED_SQL_LEN - len - size, "%s", ")");
 
   return size;
 }
@@ -356,12 +356,12 @@ uint32_t createColsData(threadInfo* info, SSuperTable* stb, char* pstr, uint32_t
     size = genRowTsCalc(info, stb, pstr, len, ts);
   } else {  // random
     int32_t pos = RD(g_arguments->prepared_rand);
-    size = snprintf(pstr + len, TSDB_MAX_ALLOWED_SQL_LEN - len, "(%" PRId64 ",%s)", ts, stb->sampleDataBuf + pos * stb->lenOfCols);
+    size = snprintf(pstr + len, TOOLS_MAX_ALLOWED_SQL_LEN - len, "(%" PRId64 ",%s)", ts, stb->sampleDataBuf + pos * stb->lenOfCols);
   }
 
   // check sql
   if(info->csql) {
-    info->clen += snprintf(info->csql + info->clen, TSDB_MAX_ALLOWED_SQL_LEN - info->clen, "%" PRId64 ",", ts);
+    info->clen += snprintf(info->csql + info->clen, TOOLS_MAX_ALLOWED_SQL_LEN - info->clen, "%" PRId64 ",", ts);
   }
 
   return size;
@@ -595,7 +595,7 @@ uint32_t genBatchSql(threadInfo* info, SSuperTable* stb, SMixRatio* mix, int64_t
     }
 
     // check over TSDB_MAX_ALLOWED_SQL_LENGTH
-    if (len > (TSDB_MAX_ALLOWED_SQL_LEN - stb->lenOfCols - 320)) {
+    if (len > (TOOLS_MAX_ALLOWED_SQL_LEN - stb->lenOfCols - 320)) {
       break;
     }
 
@@ -650,7 +650,7 @@ uint32_t genBatchDelSql(SSuperTable* stb, SMixRatio* mix, int64_t batStartTime, 
   if(count64 == 0) return 0;
   count = count64;
 
-  (void)snprintf(pstr + slen, TSDB_MAX_ALLOWED_SQL_LEN - slen, "%s", where);
+  (void)snprintf(pstr + slen, TOOLS_MAX_ALLOWED_SQL_LEN - slen, "%s", where);
   //infoPrint("  batch delete cnt=%d range=%s \n", count, where);
 
   return count;

--- a/tools/taos-tools/src/benchJsonOpt.c
+++ b/tools/taos-tools/src/benchJsonOpt.c
@@ -1062,7 +1062,7 @@ static int getStableInfo(tools_cJSON *dbinfos, int index) {
         superTable->disorderRatio = 0;
         superTable->disorderRange = DEFAULT_DISORDER_RANGE;
         superTable->insert_interval = g_arguments->insert_interval;
-        superTable->max_sql_len = TSDB_MAX_ALLOWED_SQL_LEN;
+        superTable->max_sql_len = TOOLS_MAX_ALLOWED_SQL_LEN;
         superTable->partialColNum = 0;
         superTable->partialColFrom = 0;
         superTable->comment = NULL;
@@ -2056,8 +2056,8 @@ int32_t readSpecQueryJson(tools_cJSON * specifiedQuery) {
                            sqlFileObj->valuestring);
                 return -1;
             }
-            char *buf = benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, true);
-            while (fgets(buf, TSDB_MAX_ALLOWED_SQL_LEN, fp)) {
+            char *buf = benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, true);
+            while (fgets(buf, TOOLS_MAX_ALLOWED_SQL_LEN, fp)) {
                 SSQL * sql = benchCalloc(1, sizeof(SSQL), true);
                 (void)benchArrayPush(g_queryInfo.specifiedQueryInfo.sqls, sql);
                 sql = benchArrayGet(g_queryInfo.specifiedQueryInfo.sqls,
@@ -2070,7 +2070,7 @@ int32_t readSpecQueryJson(tools_cJSON * specifiedQuery) {
                         sizeof(int64_t), true);
                 TOOLS_STRNCPY(sql->command, buf, bufLen - 1);
                 debugPrint("read file buffer: %s\n", sql->command);
-                memset(buf, 0, TSDB_MAX_ALLOWED_SQL_LEN);
+                memset(buf, 0, TOOLS_MAX_ALLOWED_SQL_LEN);
             }
             free(buf);
             fclose(fp);
@@ -2258,7 +2258,7 @@ int32_t readSuperQueryJson(tools_cJSON * superQuery) {
                 tools_cJSON *sqlStr = tools_cJSON_GetObjectItem(sql, "sql");
                 if (sqlStr && sqlStr->type == tools_cJSON_String) {
                     TOOLS_STRNCPY(g_queryInfo.superQueryInfo.sql[j],
-                             sqlStr->valuestring, TSDB_MAX_ALLOWED_SQL_LEN);
+                             sqlStr->valuestring, TOOLS_MAX_ALLOWED_SQL_LEN);
                 }
 
                 tools_cJSON *result = tools_cJSON_GetObjectItem(sql, "result");

--- a/tools/taos-tools/src/benchQuery.c
+++ b/tools/taos-tools/src/benchQuery.c
@@ -290,7 +290,7 @@ static void *specQueryThread(void *sarg) {
 
 // super table query thread
 static void *stbQueryThread(void *sarg) {
-    char *sqlstr = benchCalloc(1, TSDB_MAX_ALLOWED_SQL_LEN, false);
+    char *sqlstr = benchCalloc(1, TOOLS_MAX_ALLOWED_SQL_LEN, false);
     qThreadInfo *pThreadInfo = (qThreadInfo *)sarg;
 #ifdef LINUX
     prctl(PR_SET_NAME, "stbQueryThread");
@@ -332,7 +332,7 @@ static void *stbQueryThread(void *sarg) {
 
             // for each sql
             for (int j = 0; j < g_queryInfo.superQueryInfo.sqlCount; j++) {
-                memset(sqlstr, 0, TSDB_MAX_ALLOWED_SQL_LEN);
+                memset(sqlstr, 0, TOOLS_MAX_ALLOWED_SQL_LEN);
                 // use cancel
                 if(g_arguments->terminate) {
                     infoPrint("%s\n", "user cancel , so exit testing.");

--- a/tools/taos-tools/src/benchUtil.c
+++ b/tools/taos-tools/src/benchUtil.c
@@ -256,8 +256,13 @@ int32_t replaceChildTblName(char *inSql, char *outSql, int tblIndex) {
             "`%s`.%s", g_queryInfo.dbName,
             g_queryInfo.superQueryInfo.childTblName[tblIndex]);
 
-    TOOLS_STRNCPY(outSql, inSql, pos - inSql + 1);
-    (void)snprintf(outSql + (pos - inSql), TOOLS_MAX_ALLOWED_SQL_LEN - 1,
+    size_t offset = (size_t)(pos - inSql);
+    if (offset >= TOOLS_MAX_ALLOWED_SQL_LEN) {
+        errorPrint("sql too long, offset (%zu) exceeds TOOLS_MAX_ALLOWED_SQL_LEN", offset);
+        return -1;
+    }
+    TOOLS_STRNCPY(outSql, inSql, offset + 1);
+    (void)snprintf(outSql + offset, TOOLS_MAX_ALLOWED_SQL_LEN - offset,
              "%s%s", subTblName, pos + strlen(mark));
     return 0;
 }

--- a/tools/taos-tools/src/benchUtil.c
+++ b/tools/taos-tools/src/benchUtil.c
@@ -257,7 +257,7 @@ int32_t replaceChildTblName(char *inSql, char *outSql, int tblIndex) {
             g_queryInfo.superQueryInfo.childTblName[tblIndex]);
 
     TOOLS_STRNCPY(outSql, inSql, pos - inSql + 1);
-    (void)snprintf(outSql + (pos - inSql), TSDB_MAX_ALLOWED_SQL_LEN - 1,
+    (void)snprintf(outSql + (pos - inSql), TOOLS_MAX_ALLOWED_SQL_LEN - 1,
              "%s%s", subTblName, pos + strlen(mark));
     return 0;
 }

--- a/tools/taos-tools/src/taosdump.c
+++ b/tools/taos-tools/src/taosdump.c
@@ -1119,14 +1119,14 @@ static int getTableRecordInfoImplNative(
 
     memset(pTableRecordInfo, 0, sizeof(TableRecordInfo));
 
-    char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         taos_close(taos);
         return -1;
     }
 
-    (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+    (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
             g_args.db_escape_char
             ? "USE `%s`"
             : "USE %s",
@@ -1145,12 +1145,12 @@ static int getTableRecordInfoImplNative(
 
     // check table is stb or child table
     if (tryStable) {
-        (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+        (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
                 "SELECT STABLE_NAME FROM information_schema.ins_stables "
                 "WHERE db_name='%s' AND stable_name='%s'",
                 dbName, table);
     } else {
-        (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+        (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
                 "SELECT TABLE_NAME,STABLE_NAME FROM "
                 "information_schema.ins_tables "
                 "WHERE db_name='%s' AND table_name='%s'",
@@ -1315,13 +1315,13 @@ static int getDumpDbCount() {
     TAOS     *taos = NULL;
     TAOS_RES *res     = NULL;
 
-    char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command) {
         errorPrint("%s() LN%d, memory allocation failed", __func__, __LINE__);
         return -1;
     }
 
-    (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+    (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
                  "SELECT name FROM information_schema.ins_databases");
 
     int32_t code = -1;
@@ -1443,13 +1443,13 @@ static int64_t getTbCountOfStbNative(const char *dbName, const char *stbName) {
         return -1;
     }
 
-    char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         return -1;
     }
 
-    (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+    (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
                 "SELECT COUNT(*) FROM information_schema.ins_tables "
                 "WHERE stable_name = '%s' AND db_name = '%s'",
                 stbName, dbName);
@@ -1883,13 +1883,13 @@ static int getTableTagValue(
         TableDes **ppTableDes) {
     TableDes *tableDes = *ppTableDes;
 
-    char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         return -1;
     }
 
-    (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+    (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
             "SELECT tag_name,tag_value FROM information_schema.ins_tags "
             "WHERE db_name = '%s' AND table_name = '%s'",
             dbName, table);
@@ -1948,13 +1948,13 @@ int getTableDes(TAOS *taos,
     //
     // fill tags and columns
     //
-    char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         return -1;
     }
 
-    (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+    (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
             g_args.db_escape_char
             ? "DESCRIBE `%s`.%s%s%s"
             : "DESCRIBE %s.%s%s%s",
@@ -3307,7 +3307,7 @@ int64_t queryDbForDumpOutCount(
     int64_t count = -1;
 
     for (int32_t i = 0; i <= g_args.retryCount; i++) {
-        char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+        char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
         if (NULL == command) {
             errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
             return -1;
@@ -3316,7 +3316,7 @@ int64_t queryDbForDumpOutCount(
         int64_t startTime = getStartTime(precision);
         int64_t endTime = getEndTime(precision);
 
-        (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+        (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
                 g_args.db_escape_char
                 ? "SELECT COUNT(*) FROM `%s`.%s%s%s WHERE _c0 >= %" PRId64 " "
                 "AND _c0 <= %" PRId64 ""
@@ -3369,14 +3369,14 @@ void *queryDbForDumpOutOffset(
         const int64_t end_time,
         const int64_t limit,
         const int64_t offset) {
-    char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         return NULL;
     }
 
     if (-1 == limit) {
-        (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+        (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
                 g_args.db_escape_char
                 ? "SELECT * FROM `%s`.%s%s%s WHERE _c0 >= %" PRId64 " "
                 "AND _c0 <= %" PRId64 " ORDER BY _c0 ASC ;"
@@ -3385,7 +3385,7 @@ void *queryDbForDumpOutOffset(
                 dbName, g_escapeChar, tbName, g_escapeChar,
                 start_time, end_time);
     } else {
-        (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+        (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
                 g_args.db_escape_char
                 ? "SELECT * FROM `%s`.%s%s%s WHERE _c0 >= %" PRId64 " "
                 "AND _c0 <= %" PRId64 " ORDER BY _c0 ASC LIMIT %" PRId64 " "
@@ -4506,7 +4506,7 @@ static int64_t dumpInAvroTbTagsImpl(
         partTags = stbChange->strTags;
     }
 
-    char *sqlstr = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *sqlstr = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == sqlstr) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         return -1;
@@ -4642,7 +4642,7 @@ static int64_t dumpInAvroTbTagsImpl(
                         (const char **)&tbName, &size);
 
                 // combine sql with stbName and tbName
-                curr_sqlstr_len = snprintf(sqlstr, TSDB_MAX_ALLOWED_SQL_LEN,
+                curr_sqlstr_len = snprintf(sqlstr, TOOLS_MAX_ALLOWED_SQL_LEN,
                         g_args.db_escape_char
                         ? "CREATE TABLE IF NOT EXISTS `%s`.%s%s%s  USING `%s`.%s%s%s%s TAGS("
                         : "CREATE TABLE IF NOT EXISTS %s.%s%s%s    USING  %s.%s%s%s%s  TAGS(",
@@ -4767,9 +4767,9 @@ static int64_t dumpInAvroTbTagsImpl(
             }
 
             // check curr_sqlstr_len invalid size
-            if(curr_sqlstr_len > TSDB_MAX_ALLOWED_SQL_LEN - 128) {
-                errorPrint("%s() LN%d, create child table combine tags sql length (%d) over %d (TSDB_MAX_ALLOWED_SQL_LEN - 128)!\n",
-                   __func__, __LINE__, curr_sqlstr_len, TSDB_MAX_ALLOWED_SQL_LEN - 128);
+            if(curr_sqlstr_len > TOOLS_MAX_ALLOWED_SQL_LEN - 128) {
+                errorPrint("%s() LN%d, create child table combine tags sql length (%d) over %d (TOOLS_MAX_ALLOWED_SQL_LEN - 128)!\n",
+                   __func__, __LINE__, curr_sqlstr_len, TOOLS_MAX_ALLOWED_SQL_LEN - 128);
 
                 avro_value_decref(&value);
                 avro_value_iface_decref(value_class);
@@ -5514,14 +5514,14 @@ static int32_t stmtPrepare(TAOS_STMT2 *stmt, char *tbName, StbChange *stbChange,
         partCols = stbChange->strCols;
     }
 
-    char *stmtBuffer = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *stmtBuffer = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == stmtBuffer) {
         errorPrint("%s() LN%d, memory allocation failed!\n", __func__, __LINE__);
         return -1;
     }
 
     char *pstr = stmtBuffer;
-    pstr += snprintf(pstr, TSDB_MAX_ALLOWED_SQL_LEN, "INSERT INTO %s %s VALUES(?", tbName, partCols);
+    pstr += snprintf(pstr, TOOLS_MAX_ALLOWED_SQL_LEN, "INSERT INTO %s %s VALUES(?", tbName, partCols);
 
     for (int i = 1; i < nBindCols; i++) {
         pstr += sprintf(pstr, ",?");
@@ -6529,14 +6529,14 @@ int processResultValue(
         case TSDB_DATA_TYPE_DECIMAL64:
         case TSDB_DATA_TYPE_BLOB:
             {
-                char *bbuf = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+                char *bbuf = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
                 if (NULL == bbuf) {
                     errorPrint("%s() LN%d, memory allocation failed\n",
                                __func__, __LINE__);
                     return -1;
                 }
                 convertStringToReadable((char *)value, len,
-                    bbuf, TSDB_MAX_ALLOWED_SQL_LEN);
+                    bbuf, TOOLS_MAX_ALLOWED_SQL_LEN);
                 int ret = sprintf(pstr + curr_sqlstr_len,
                     "\'%s\'", bbuf);
                 free(bbuf);
@@ -6544,14 +6544,14 @@ int processResultValue(
             }
         case TSDB_DATA_TYPE_NCHAR:
             {
-                char *nbuf = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+                char *nbuf = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
                 if (NULL == nbuf) {
                     errorPrint("%s() LN%d, memory allocation failed\n",
                                __func__, __LINE__);
                     return -1;
                 }
                 convertNCharToReadable((char *)value, len,
-                    nbuf, TSDB_MAX_ALLOWED_SQL_LEN);
+                    nbuf, TOOLS_MAX_ALLOWED_SQL_LEN);
                 int ret = sprintf(pstr + curr_sqlstr_len,
                     "\'%s\'", nbuf);
                 free(nbuf);
@@ -6655,13 +6655,13 @@ TAOS_RES *queryDbForDumpOutNative(TAOS *taos,
         const int precision,
         const int64_t start_time,
         const int64_t end_time) {
-    char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         return NULL;
     }
 
-    (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+    (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
             g_args.db_escape_char
             ? "SELECT * FROM `%s`.%s%s%s WHERE _c0 >= %" PRId64 " "
             "AND _c0 <= %" PRId64 " ORDER BY _c0 ASC;"
@@ -7765,13 +7765,13 @@ static int64_t fillTbNameArr(
         const char *stable,
         int64_t preCount) {
     //
-    char *command2 = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command2 = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command2) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         return -1;
     }
 
-    (void)snprintf(command2, TSDB_MAX_ALLOWED_SQL_LEN,
+    (void)snprintf(command2, TOOLS_MAX_ALLOWED_SQL_LEN,
             "SELECT table_name FROM information_schema.ins_tables "
             "WHERE stable_name='%s' AND db_name='%s'",
             stable, dbInfo->name);
@@ -8675,7 +8675,7 @@ static int convertNCharToReadable(char *str, int size, char *buf, int bufsize) {
 
 static void dumpExtraInfoVar(void *taos, FILE *fp) {
     char buffer[BUFFER_LEN];
-    char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         return;
@@ -8950,7 +8950,7 @@ static int64_t dumpInOneDebugFile(
     size_t    cmd_len  = 0;
     char *    line     = NULL;
 
-    cmd  = (char *)malloc(TSDB_MAX_ALLOWED_SQL_LEN);
+    cmd  = (char *)malloc(TOOLS_MAX_ALLOWED_SQL_LEN);
     if (cmd == NULL) {
         errorPrint("%s() LN%d, failed to allocate memory\n",
                 __func__, __LINE__);
@@ -8962,9 +8962,9 @@ static int64_t dumpInOneDebugFile(
     int64_t success = 0;
     int64_t failed = 0;
 #ifdef WINDOWS
-    line = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    line = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     TOOLS_ASSERT(line);
-    while (fgets(line, TSDB_MAX_ALLOWED_SQL_LEN, fp) != NULL) {
+    while (fgets(line, TOOLS_MAX_ALLOWED_SQL_LEN, fp) != NULL) {
         read_len = strlen(line?line:"");
 #else
     size_t line_len;
@@ -8987,7 +8987,7 @@ static int64_t dumpInOneDebugFile(
         if (0 == read_len) {
             continue;
         }
-        if (read_len >= TSDB_MAX_ALLOWED_SQL_LEN) {
+        if (read_len >= TOOLS_MAX_ALLOWED_SQL_LEN) {
             errorPrint("the No.%"PRId64" line is exceed "
                     "max allowed SQL length!\n", lineNo);
             debugPrint("%s() LN%d, line: %s", __func__, __LINE__, line);
@@ -9038,7 +9038,7 @@ static int64_t dumpInOneDebugFile(
                 success++;
         }
 
-        memset(cmd, 0, TSDB_MAX_ALLOWED_SQL_LEN);
+        memset(cmd, 0, TOOLS_MAX_ALLOWED_SQL_LEN);
         cmd_len = 0;
 
         if (lineNo >= lastRowsPrint) {
@@ -9694,7 +9694,7 @@ static int64_t dumpNTablesOfDb(TAOS **taos_v, SDbInfo *dbInfo) {
         return 0;
     }
 
-    char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         return -1;
@@ -9703,7 +9703,7 @@ static int64_t dumpNTablesOfDb(TAOS **taos_v, SDbInfo *dbInfo) {
     TAOS_RES *res;
     int32_t code = -1;
 
-    (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+    (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
             "SELECT TABLE_NAME,STABLE_NAME "
             " FROM information_schema.ins_tables WHERE db_name='%s'",
             dbInfo->name);
@@ -9759,13 +9759,13 @@ static int64_t dumpStbAndChildTbOfDb(
         TAOS **taos_v, SDbInfo *dbInfo, FILE *fpDbs) {
     int64_t ret = 0;
 
-    char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         return -1;
     }
 
-    (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+    (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
             g_args.db_escape_char
             ? "USE `%s`"
             : "USE %s",
@@ -9785,7 +9785,7 @@ static int64_t dumpStbAndChildTbOfDb(
     taos_free_result(res);
 
     // get all stable name
-    (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+    (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
             "SELECT STABLE_NAME FROM information_schema.ins_stables "
             "WHERE db_name='%s'",
             dbInfo->name);
@@ -10215,12 +10215,12 @@ static int fillDbExtraInfoV3Native(
         const char *dbName,
         const int dbIndex) {
     int ret = 0;
-    char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         return -1;
     }
-    (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+    (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
             "SELECT COUNT(table_name) FROM "
             "information_schema.ins_tables WHERE db_name='%s'",
             dbName);
@@ -10254,13 +10254,13 @@ static int fillDbInfoNative(void *taos) {
     int ret = 0;
     int dbIndex = 0;
 
-    char *command = calloc(1, TSDB_MAX_ALLOWED_SQL_LEN);
+    char *command = calloc(1, TOOLS_MAX_ALLOWED_SQL_LEN);
     if (NULL == command) {
         errorPrint("%s() LN%d, memory allocation failed\n", __func__, __LINE__);
         return -1;
     }
 
-    (void)snprintf(command, TSDB_MAX_ALLOWED_SQL_LEN,
+    (void)snprintf(command, TOOLS_MAX_ALLOWED_SQL_LEN,
                 "SELECT * FROM information_schema.ins_databases");
 
     int32_t code = -1;

--- a/tools/taos-tools/test/CMakeLists.txt
+++ b/tools/taos-tools/test/CMakeLists.txt
@@ -8,7 +8,7 @@ IF(TD_LINUX)
     AUX_SOURCE_DIRECTORY(${CMAKE_CURRENT_SOURCE_DIR} SOURCE_LIST)
 
     # benchmark
-    SET(BENCHMARK_SRC 
+    SET(BENCHMARK_SRC
         "../src/benchUtil.c"
         "../src/benchLog.c"
         "../src/toolstime.c"
@@ -24,12 +24,12 @@ IF(TD_LINUX)
     )
 
     target_include_directories(
-        benchmarkTest PRIVATE 
+        benchmarkTest PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/../inc"
         "${CMAKE_CURRENT_SOURCE_DIR}/../../inc"
         "${CMAKE_CURRENT_SOURCE_DIR}/../deps/toolscJson/inc/"
     )
-    
+
     add_test(
         NAME benchmarkTest
         COMMAND benchmarkTest
@@ -40,14 +40,14 @@ IF(TD_LINUX)
     DEP_ext_gtest(taosdumpTest)
     target_link_libraries(
         taosdumpTest
-        PRIVATE os
+        PUBLIC taos
     )
 
     target_include_directories(
         taosdumpTest
         PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../inc"
     )
-    
+
     add_test(
         NAME taosdumpTest
         COMMAND taosdumpTest


### PR DESCRIPTION
- [x] Fix buffer overflow in `replaceChildTblName`: compute `offset = pos - inSql`, guard against `offset >= TOOLS_MAX_ALLOWED_SQL_LEN`, and use `TOOLS_MAX_ALLOWED_SQL_LEN - offset` as the remaining capacity for `snprintf` instead of the full `TOOLS_MAX_ALLOWED_SQL_LEN - 1`
- [x] Final code review
- [x] CodeQL security check