### PR TITLE
fix: taoscleanup

### DIFF
--- a/include/libs/qcom/query.h
+++ b/include/libs/qcom/query.h
@@ -385,6 +385,8 @@ typedef struct SQueryStat {
 
 int32_t initTaskQueue();
 int32_t cleanupTaskQueue();
+void    beginAsyncWorkShutdown(void);
+bool    mayCreateAsyncWork(void);
 
 /**
  *

--- a/source/client/inc/clientInt.h
+++ b/source/client/inc/clientInt.h
@@ -426,8 +426,10 @@ void  resetConnectDB(STscObj* pTscObj);
 
 int taos_options_imp(TSDB_OPTION option, const char* str);
 
+void    closeTransporter(SAppInstInfo* pAppInfo);
 int32_t openTransporter(const char* user, const char* auth, int32_t numOfThreads, void** pDnodeConn);
 void    tscStopCrashReport();
+void    hbMgrStop();
 void    cleanupAppInfo();
 
 typedef struct AsyncArg {

--- a/source/client/src/clientEnv.c
+++ b/source/client/src/clientEnv.c
@@ -324,6 +324,7 @@ void closeTransporter(SAppInstInfo *pAppInfo) {
 
   tscDebug("free transporter:%p in app inst %p", pAppInfo->pTransporter, pAppInfo);
   rpcClose(pAppInfo->pTransporter);
+  pAppInfo->pTransporter = NULL;
 }
 
 static bool clientRpcRfp(int32_t code, tmsg_t msgType) {

--- a/source/client/src/clientHb.c
+++ b/source/client/src/clientHb.c
@@ -1628,6 +1628,8 @@ static void hbStopThread() {
   tscDebug("hb thread stopped");
 }
 
+void hbMgrStop() { hbStopThread(); }
+
 int32_t appHbMgrInit(SAppInstInfo *pAppInstInfo, char *key, SAppHbMgr **pAppHbMgr) {
   int32_t code = TSDB_CODE_SUCCESS;
   TSC_ERR_RET(hbMgrInit());

--- a/source/client/src/clientImpl.c
+++ b/source/client/src/clientImpl.c
@@ -2032,6 +2032,11 @@ void processMsgFromServer(void* parent, SRpcMsg* pMsg, SEpSet* pEpSet) {
     }
   }
 
+  if (!mayCreateAsyncWork()) {
+    tscDebug("client shutdown in progress, process msg inline");
+    goto _dispatch_inline;
+  }
+
   AsyncArg* arg = taosMemoryCalloc(1, sizeof(AsyncArg));
   if (NULL == arg) {
     code = terrno;
@@ -2043,9 +2048,20 @@ void processMsgFromServer(void* parent, SRpcMsg* pMsg, SEpSet* pEpSet) {
   arg->pEpset = tEpSet;
 
   if ((code = taosAsyncExec(doProcessMsgFromServer, arg, NULL)) != 0) {
-    pMsg->code = code;
     taosMemoryFree(arg);
+    if (code == TSDB_CODE_APP_IS_STOPPING) {
+      tscDebug("task queue is stopping, process msg inline");
+      goto _dispatch_inline;
+    }
+    pMsg->code = code;
     goto _exit;
+  }
+  return;
+
+_dispatch_inline:
+  code = doProcessMsgFromServerImpl(pMsg, tEpSet);
+  if (code != 0) {
+    tscError("failed to process msg inline during client shutdown");
   }
   return;
 

--- a/source/client/src/clientMain.c
+++ b/source/client/src/clientMain.c
@@ -46,6 +46,71 @@ extern void shellStopDaemon();
 static int32_t sentinel = TSC_VAR_NOT_RELEASE;
 static int32_t createParseContext(const SRequestObj *pRequest, SParseContext **pCxt, SSqlCallbackWrapper *pWrapper);
 
+static void drainRefPool(int32_t *pRefPool, const char *poolName) {
+  if (pRefPool == NULL || *pRefPool < 0) {
+    return;
+  }
+
+  int32_t rsetId = *pRefPool;
+  bool    isReqPool = (rsetId == clientReqRefPool);
+  bool    isConnPool = (rsetId == clientConnRefPool);
+
+  if (!isReqPool && !isConnPool) {
+    tscWarn("skip draining unknown ref pool:%s", poolName);
+    taosCloseRef(rsetId);
+    *pRefPool = -1;
+    return;
+  }
+
+  void *pObj = taosIterateRef(rsetId, 0);
+
+  while (pObj != NULL) {
+    int64_t refId = isReqPool ? ((SRequestObj *)pObj)->self : ((STscObj *)pObj)->id;
+
+    if (refId == 0) {
+      tscWarn("skip draining %s with invalid refId", poolName);
+      break;
+    }
+
+    int32_t code = taosRemoveRef(rsetId, refId);
+    if (TSDB_CODE_SUCCESS != code) {
+      tscWarn("failed to remove %s ref:%" PRId64 ", code:%s", poolName, refId, tstrerror(code));
+      code = taosReleaseRef(rsetId, refId);
+      if (code != TSDB_CODE_SUCCESS) {
+        tscWarn("failed to release %s ref:%" PRId64 ", code:%s", poolName, refId, tstrerror(code));
+      }
+      break;
+    }
+
+    pObj = taosIterateRef(rsetId, refId);
+  }
+
+  taosCloseRef(rsetId);
+  *pRefPool = -1;
+}
+
+static void stopAppTransporters(void) {
+  int32_t code = taosThreadMutexLock(&appInfo.mutex);
+  if (TSDB_CODE_SUCCESS != code) {
+    tscError("failed to lock app info, code:%s", tstrerror(TAOS_SYSTEM_ERROR(code)));
+    return;
+  }
+
+  void *pIter = taosHashIterate(appInfo.pInstMap, NULL);
+  while (pIter != NULL) {
+    SAppInstInfo **ppAppInfo = (SAppInstInfo **)pIter;
+    if (ppAppInfo != NULL && *ppAppInfo != NULL) {
+      closeTransporter(*ppAppInfo);
+    }
+    pIter = taosHashIterate(appInfo.pInstMap, pIter);
+  }
+
+  code = taosThreadMutexUnlock(&appInfo.mutex);
+  if (TSDB_CODE_SUCCESS != code) {
+    tscError("failed to unlock app info, code:%s", tstrerror(TAOS_SYSTEM_ERROR(code)));
+  }
+}
+
 int taos_options(TSDB_OPTION option, const void *arg, ...) {
   if (arg == NULL) {
     return TSDB_CODE_INVALID_PARA;
@@ -260,10 +325,16 @@ void taos_cleanup(void) {
   monitorClose();
   tscStopCrashReport();
 
-  hbMgrCleanUp();
+  hbMgrStop();
+  beginAsyncWorkShutdown();
+
+  if (TSDB_CODE_SUCCESS != cleanupTaskQueue()) {
+    tscWarn("failed to cleanup task queue");
+  }
+
+  stopAppTransporters();
 
   catalogDestroy();
-  schedulerDestroy();
 
   fmFuncMgtDestroy();
   qCleanupKeywordsTable();
@@ -273,22 +344,29 @@ void taos_cleanup(void) {
 #endif
   tmqMgmtClose();
 
-  int32_t id = clientReqRefPool;
-  clientReqRefPool = -1;
-  taosCloseRef(id);
+  // Teardown order (crash-verified dependencies):
+  //  hbStop -> shutdownGate -> taskQueue -> appTransporters
+  //    -> drainReqRefs -> drainConnRefs -> scheduler -> appInfo -> rpc -> hbCleanup
+  //
+  // Key constraints:
+  //  - Drain refs explicitly; taosCloseRef() only marks, does not destroy.
+  //  - reqRefs before connRefs: request destroy needs owning STscObj.
+  //  - connRefs before appInfo: destroyTscObj() touches pAppInfo/hb/scheduler.
+  //  - shutdownGate before taskQueue: gate async producers first.
+  //  - appTransporters before rpcCleanup: global rpc != app transporter shutdown.
+  //  - hbStop early, hbCleanup late: hb state needed until conn/app cleanup ends.
 
-  id = clientConnRefPool;
-  clientConnRefPool = -1;
-  taosCloseRef(id);
+  drainRefPool(&clientReqRefPool, "request pool");
+  drainRefPool(&clientConnRefPool, "connection pool");
 
-  nodesDestroyAllocatorSet();
+  schedulerDestroy();
+
   cleanupAppInfo();
   rpcCleanup();
   tscDebug("rpc cleanup");
+  hbMgrCleanUp();
 
-  if (TSDB_CODE_SUCCESS != cleanupTaskQueue()) {
-    tscWarn("failed to cleanup task queue");
-  }
+  nodesDestroyAllocatorSet();
 
   sessMgtDestroy();
 
@@ -1879,6 +1957,10 @@ static int32_t getAllMetaAsync(SSqlCallbackWrapper *pWrapper, catalogCallback fp
                            .requestObjRefId = pWrapper->pParseCtx->requestRid,
                            .mgmtEps = pWrapper->pParseCtx->mgmtEpSet};
 
+  if (!mayCreateAsyncWork()) {
+    return TSDB_CODE_APP_IS_STOPPING;
+  }
+
   pWrapper->pRequest->metric.ctgStart = taosGetTimestampUs();
 
   return catalogAsyncGetAllMeta(pWrapper->pParseCtx->pCatalog, &conn, pWrapper->pCatalogReq, fp, pWrapper,
@@ -2169,6 +2251,12 @@ void taos_fetch_rows_a(TAOS_RES *res, __taos_async_fn_t fp, void *param) {
     return;
   }
 
+  if (!mayCreateAsyncWork()) {
+    CLIENT_UPDATE_REQUEST_PHASE_IF_CHANGED(pRequest, QUERY_PHASE_FETCH_RETURNED);
+    fp(param, res, TSDB_CODE_APP_IS_STOPPING);
+    return;
+  }
+
   SAsyncFetchParam *pParam = taosMemoryCalloc(1, sizeof(SAsyncFetchParam));
   if (!pParam) {
     CLIENT_UPDATE_REQUEST_PHASE_IF_CHANGED(pRequest, QUERY_PHASE_FETCH_RETURNED);
@@ -2420,6 +2508,11 @@ int taos_load_table_info(TAOS *taos, const char *tableNameList) {
       .pTrans = pTscObj->pAppInfo->pTransporter, .requestId = pRequest->requestId, .requestObjRefId = pRequest->self};
 
   conn.mgmtEps = getEpSet_s(&pTscObj->pAppInfo->mgmtEp);
+
+  if (!mayCreateAsyncWork()) {
+    code = TSDB_CODE_APP_IS_STOPPING;
+    goto _return;
+  }
 
   code = catalogAsyncGetAllMeta(pCtg, &conn, &catalogReq, syncCatalogFn, pRequest->body.interParam, NULL);
   if (code) {

--- a/source/client/src/clientStmt2.c
+++ b/source/client/src/clientStmt2.c
@@ -1961,7 +1961,11 @@ static int32_t stmtFetchMetadataForQuery(STscStmt2* pStmt, SParseContext* pCxt, 
     if (tsem_init(&cbParam.sem, 0, 0) != 0) {
       code = TSDB_CODE_CTG_INTERNAL_ERROR;
     } else {
-      code = catalogAsyncGetAllMeta(pCxt->pCatalog, &conn, &catalogReq, stmtCatalogSyncGetAllMetaCb, &cbParam, NULL);
+      if (!mayCreateAsyncWork()) {
+        code = TSDB_CODE_APP_IS_STOPPING;
+      } else {
+        code = catalogAsyncGetAllMeta(pCxt->pCatalog, &conn, &catalogReq, stmtCatalogSyncGetAllMetaCb, &cbParam, NULL);
+      }
       if (TSDB_CODE_SUCCESS == code) {
         code = tsem_wait(&cbParam.sem);
         if (code != TSDB_CODE_SUCCESS) {

--- a/source/libs/qcom/src/queryUtil.c
+++ b/source/libs/qcom/src/queryUtil.c
@@ -27,7 +27,15 @@
 typedef struct STaskQueue {
   SQueryAutoQWorkerPool wrokrerPool;
   STaosQueue* pTaskQueue;
+  int8_t      state;
+  int8_t      shutdown;
 } STaskQueue;
+
+enum {
+  TASK_QUEUE_STATE_STOPPED = 0,
+  TASK_QUEUE_STATE_RUNNING = 1,
+  TASK_QUEUE_STATE_STOPPING = 2,
+};
 
 int32_t getAsofJoinReverseOp(EOperatorType op) {
   switch (op) {
@@ -173,6 +181,8 @@ static void processTaskQueue(SQueueInfo *pInfo, SSchedMsg *pSchedMsg) {
 
 int32_t initTaskQueue() {
   memset(&taskQueue, 0, sizeof(taskQueue));
+  atomic_store_8(&taskQueue.shutdown, 0);
+  atomic_store_8(&taskQueue.state, TASK_QUEUE_STATE_STOPPED);
   
   taskQueue.wrokrerPool.name = "taskWorkPool";
   taskQueue.wrokrerPool.min = tsNumOfTaskQueueThreads;
@@ -186,16 +196,45 @@ int32_t initTaskQueue() {
   taskQueue.pTaskQueue = tQueryAutoQWorkerAllocQueue(&taskQueue.wrokrerPool, NULL, (FItem)processTaskQueue);
   if (NULL == taskQueue.pTaskQueue) {
     qError("failed to init task queue");
+    tQueryAutoQWorkerCleanup(&taskQueue.wrokrerPool);
     return -1;
   }
+
+  atomic_store_8(&taskQueue.state, TASK_QUEUE_STATE_RUNNING);
 
   qInfo("task queue is initialized, numOfThreads: %d", tsNumOfTaskQueueThreads);
   return 0;
 }
 
 int32_t cleanupTaskQueue() {
+  atomic_store_8(&taskQueue.state, TASK_QUEUE_STATE_STOPPING);
+  STaosQueue* pTaskQueue = taskQueue.pTaskQueue;
   tQueryAutoQWorkerCleanup(&taskQueue.wrokrerPool);
+  if (pTaskQueue != NULL) {
+    tQueryAutoQWorkerFreeQueue(&taskQueue.wrokrerPool, pTaskQueue);
+  }
+  taskQueue.pTaskQueue = NULL;
+  atomic_store_8(&taskQueue.state, TASK_QUEUE_STATE_STOPPED);
   return 0;
+}
+
+void beginAsyncWorkShutdown(void) { atomic_store_8(&taskQueue.shutdown, 1); }
+
+bool mayCreateAsyncWork(void) { return atomic_load_8(&taskQueue.shutdown) == 0; }
+
+static int32_t enqueueTaskQueueItem(SSchedMsg* pSchedMsg) {
+  if (atomic_load_8(&taskQueue.shutdown) != 0 || atomic_load_8(&taskQueue.state) != TASK_QUEUE_STATE_RUNNING ||
+      taskQueue.pTaskQueue == NULL) {
+    taosFreeQitem(pSchedMsg);
+    return TSDB_CODE_APP_IS_STOPPING;
+  }
+
+  int32_t code = taosWriteQitem(taskQueue.pTaskQueue, pSchedMsg);
+  if (code != TSDB_CODE_SUCCESS) {
+    taosFreeQitem(pSchedMsg);
+  }
+
+  return code;
 }
 
 int32_t taosAsyncExec(__async_exec_fn_t execFn, void* execParam, int32_t* code) {
@@ -207,7 +246,7 @@ int32_t taosAsyncExec(__async_exec_fn_t execFn, void* execParam, int32_t* code) 
   pSchedMsg->thandle = execParam;
   pSchedMsg->msg = code;
 
-  return taosWriteQitem(taskQueue.pTaskQueue, pSchedMsg);
+  return enqueueTaskQueueItem(pSchedMsg);
 }
 
 int32_t taosAsyncWait() {
@@ -235,7 +274,7 @@ int32_t taosStmt2AsyncBind(__async_exec_fn_t bindFn, void* bindParam) {
   pSchedMsg->thandle = bindParam;
   // pSchedMsg->msg = code;
 
-  return taosWriteQitem(taskQueue.pTaskQueue, pSchedMsg);
+  return enqueueTaskQueueItem(pSchedMsg);
 }
 
 void destroySendMsgInfo(SMsgSendInfo* pMsgBody) {

--- a/source/libs/scheduler/src/schTask.c
+++ b/source/libs/scheduler/src/schTask.c
@@ -1262,6 +1262,10 @@ _return:
 }
 
 int32_t schAsyncLaunchTaskImpl(SSchJob *pJob, SSchTask *pTask) {
+  if (!mayCreateAsyncWork()) {
+    SCH_ERR_RET(TSDB_CODE_APP_IS_STOPPING);
+  }
+
   SSchTaskCtx *param = taosMemoryCalloc(1, sizeof(SSchTaskCtx));
   if (NULL == param) {
     SCH_ERR_RET(terrno);

--- a/test/cases/01-DataTypes/test_datatype_decimal.py
+++ b/test/cases/01-DataTypes/test_datatype_decimal.py
@@ -193,7 +193,8 @@ class TaosShell:
         self.tmp_file_path = os.path.join(os.path.dirname(__file__), "taos_shell_result")
     
     def get_file_path(self):
-        return f"{self.tmp_file_path}_{self.counter_}"
+        # Include PID to avoid collisions when tests run in multiple processes
+        return f"{self.tmp_file_path}_{os.getpid()}_{self.counter_}"
 
     def read_result(self):
         with open(self.get_file_path(), "r") as f:
@@ -209,19 +210,30 @@ class TaosShell:
                     col += 1
 
     def query(self, sql: str):
-        with open(self.get_file_path(), "a+") as f:
-            f.truncate(0)
+        # Truncate output file before execution
+        tdLog.debug(f"Executing SQL: {sql}")
+        out_path = self.get_file_path()
+        with open(out_path, "w"):
+            pass
         self.queryResult = []
         try:
-            command = f'taos -s "{sql} >> {self.get_file_path()}"'
-            result = subprocess.run(
-                command, shell=True, check=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE
+            command = ["taos", "-s", f"{sql} >> {out_path}"]
+            subprocess.run(
+                command,
+                check=True,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                text=True,
+                errors="replace",
             )
             self.read_result()
+        except subprocess.CalledProcessError as e:
+            # Surface stderr (e.g., ASAN diagnostics) without causing secondary decode errors
+            err_msg = e.stderr or ""
+            tdLog.exit(f"Command '{sql}' failed ({type(e).__name__}):\n{err_msg}")
         except Exception as e:
-            tdLog.exit(f"Command '{sql}' failed with error: {e.stderr.decode('utf-8')}")
-            self.queryResult = []
-            raise
+            extra = getattr(e, 'stderr', None) or ""
+            tdLog.exit(f"Unexpected error ({type(e).__name__}) while running '{sql}':\n{extra or str(e)}")
         return self.queryResult
 
 class DecimalColumnExpr:
@@ -2089,7 +2101,10 @@ class TestDecimal:
         self.check_add_drop_columns_with_decimal(self.no_decimal_col_tb_name, columns)
 
     def check_decimal_ddl(self):
-        tdSql.execute("create database test cachemodel 'both'", queryTimes=1)
+        tdSql.execute(f"drop database if exists {self.db_name}", queryTimes=1)
+        tdSql.execute(
+            f"create database {self.db_name} cachemodel 'both'", queryTimes=1
+        )
         self.check_decimal_column_ddl()
 
     def check_decimal_and_stream(self):
@@ -2253,8 +2268,10 @@ class TestDecimal:
                     res = self.query_allows_specified_errors(sql)
                     if len(res) > 0:
                         expr.check(res[0], tbname)
+                        tdLog.debug(f"sql: {sql} got results")
                     else:
                         tdLog.info(f"sql: {sql} got no output")
+        tdLog.debug("check decimal binary expr with col results done***************")
 
     def check_decimal_binary_expr_with_const_col_results_for_one_expr(
         self,
@@ -2323,6 +2340,7 @@ class TestDecimal:
                 res = self.query_allows_specified_errors(sql)
                 if len(res) > 0:
                     expr.check(res[0], tbname)
+                    tdLog.debug(f"sql: {sql} got results")
                 else:
                     tdLog.info(f"sql: {sql} got no output")
 

--- a/test/cases/01-DataTypes/test_datatype_decimal64.py
+++ b/test/cases/01-DataTypes/test_datatype_decimal64.py
@@ -13,7 +13,6 @@ import re
 import platform
 if platform.system().lower() == 'windows':
     import wexpect
-
 from new_test_framework.utils import tdLog, tdSql, TDSql
 from decimal import *
 from multiprocessing import Value, Lock
@@ -215,7 +214,7 @@ class TaosShell:
         self.tmp_file_path = os.path.join(os.path.dirname(__file__), "taos_shell_result")
     
     def get_file_path(self):
-        return f"{self.tmp_file_path}_{self.counter_}"
+        return f"{self.tmp_file_path}_{os.getpid()}_{self.counter_}"
 
     def read_result(self):
         with open(self.get_file_path(), "r") as f:
@@ -231,8 +230,9 @@ class TaosShell:
                     col += 1
 
     def query(self, sql: str):
-        with open(self.get_file_path(), "a+") as f:
-            f.truncate(0)
+        out_path = self.get_file_path()
+        with open(out_path, "w"):
+            pass
         self.queryResult = []
         try:
             if platform.system().lower() == "windows":
@@ -240,7 +240,7 @@ class TaosShell:
                 child = wexpect.spawn("taos", timeout=60)
                 try:
                     child.expect("> ")
-                    child.sendline(f"{sql} >> {self.get_file_path()};")
+                    child.sendline(f"{sql} >> {out_path};")
                     child.expect("> ")
                     child.sendline("quit")
                     child.expect("> ")
@@ -250,16 +250,24 @@ class TaosShell:
                     tdLog.error(f"wexpect failed, child.before:\n{child.before}")
                     raise
             else:
-                command = f'taos -s "{sql} >> {self.get_file_path()}"'
+                command = ["taos", "-s", f"{sql} >> {out_path}"]
                 tdLog.debug(f"exec command: {command}")
-                result = subprocess.run(
-                    command, shell=True, check=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE
+                subprocess.run(
+                    command,
+                    check=True,
+                    stderr=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    text=True,
+                    errors="replace",
                 )
             self.read_result()
+        except subprocess.CalledProcessError as e:
+            # Surface stderr (e.g., ASAN diagnostics) without causing secondary decode errors
+            err_msg = e.stderr or ""
+            tdLog.exit(f"Command '{sql}' failed ({type(e).__name__}):\n{err_msg}")
         except Exception as e:
-            tdLog.exit(f"Command '{sql}' failed with error: {e.stderr.decode('utf-8')}")
-            self.queryResult = []
-            raise
+            extra = getattr(e, 'stderr', None) or ""
+            tdLog.exit(f"Unexpected error ({type(e).__name__}) while running '{sql}':\n{extra or str(e)}")
         return self.queryResult
 
 class DecimalColumnExpr:
@@ -1934,7 +1942,10 @@ class TestDecimal2:
 
     def check_decimal_ddl(self):
         self.log_test("test_decimal_ddl")
-        tdSql.execute("create database test cachemodel 'both'", queryTimes=1)
+        tdSql.execute(f"drop database if exists {self.db_name}", queryTimes=1)
+        tdSql.execute(
+            f"create database {self.db_name} cachemodel 'both'", queryTimes=1
+        )
         self.check_decimal_column_ddl()
         self.log_test("test_decimal_ddl finished")
 

--- a/test/cases/01-DataTypes/test_datatype_decimal_last.py
+++ b/test/cases/01-DataTypes/test_datatype_decimal_last.py
@@ -225,7 +225,7 @@ class TaosShell:
         self.tmp_file_path = os.path.join(os.path.dirname(__file__), "taos_shell_result")
     
     def get_file_path(self):
-        return f"{self.tmp_file_path}_{self.counter_}"
+        return f"{self.tmp_file_path}_{os.getpid()}_{self.counter_}"
 
     def read_result(self):
         with open(self.get_file_path(), "r") as f:
@@ -241,8 +241,9 @@ class TaosShell:
                     col += 1
 
     def query(self, sql: str):
-        with open(self.get_file_path(), "a+") as f:
-            f.truncate(0)
+        out_path = self.get_file_path()
+        with open(out_path, "w"):
+            pass
         self.queryResult = []
         try:
             if platform.system().lower() == "windows":
@@ -250,7 +251,7 @@ class TaosShell:
                 child = wexpect.spawn("taos", timeout=60)
                 try:
                     child.expect("> ")
-                    child.sendline(f"{sql} >> {self.get_file_path()};")
+                    child.sendline(f"{sql} >> {out_path};")
                     child.expect("> ")
                     child.sendline("quit")
                     child.expect("> ")
@@ -259,14 +260,24 @@ class TaosShell:
                     tdLog.error(f"wexpect failed, child.before:\n{child.before}")
                     raise
             else:
-                command = f'taos -s "{sql} >> {self.get_file_path()}"'
+                command = ["taos", "-s", f"{sql} >> {out_path}"]
                 tdLog.debug(f"exec command: {command}")
-                result = subprocess.run(
-                    command, shell=True, check=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE
+                subprocess.run(
+                    command,
+                    check=True,
+                    stderr=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    text=True,
+                    errors="replace",
                 )
             self.read_result()
+        except subprocess.CalledProcessError as e:
+            # Surface stderr (e.g., ASAN diagnostics) without causing secondary decode errors
+            err_msg = e.stderr or ""
+            tdLog.exit(f"Command '{sql}' failed ({type(e).__name__}):\n{err_msg}")
         except Exception as e:
-            tdLog.exit(f"Command '{sql}' failed with error: {e.stderr.decode('utf-8')}")
+            extra = getattr(e, 'stderr', None) or ""
+            tdLog.exit(f"Unexpected error ({type(e).__name__}) while running '{sql}':\n{extra or str(e)}")
         return self.queryResult
 
 class DecimalColumnExpr:
@@ -1909,7 +1920,10 @@ class TestDecimal3:
 
     def check_decimal_ddl(self):
         self.log_test("test_decimal_ddl")
-        tdSql.execute("create database test cachemodel 'both'", queryTimes=1)
+        tdSql.execute(f"drop database if exists {self.db_name}", queryTimes=1)
+        tdSql.execute(
+            f"create database {self.db_name} cachemodel 'both'", queryTimes=1
+        )
         self.check_decimal_column_ddl()
 
     def check_decimal_and_stream(self):


### PR DESCRIPTION
问题：taos_cleanup() 退出时存在竞态和 use-after-free：异步回调仍在入队/执行，而资源已被销毁。
修改内容
一、引入 async-work shutdown gate（全局关闭闸门）
二、所有异步入口加闸门检查
三、强化 taskQueue 状态管理
四、重排 taos_cleanup() 顺序

<!-- Please briefly describe the code changes in this pull request. -->

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
