### PR TITLE
docs: keep CI trigger PR open

### DIFF
--- a/.github/ci-trigger-sentinel.md
+++ b/.github/ci-trigger-sentinel.md
@@ -1,0 +1,3 @@
+# CI Trigger Sentinel
+
+This file keeps the long-lived CI trigger PR open.


### PR DESCRIPTION
This PR is reserved for Codex automation to keep a stable PR number for `new-framework-test.yml` workflow_dispatch runs. The branch should stay synced to `main` except for the single sentinel markdown diff in `.github/ci-trigger-sentinel.md`.