### PR TITLE
test(os): join threads to avoid race/use-after-free in osSemaphoreTests

### DIFF
--- a/source/os/test/osSemaphoreTests.cpp
+++ b/source/os/test/osSemaphoreTests.cpp
@@ -84,13 +84,15 @@ TEST(osSemaphoreTests, WaitAndPost) {
   int    result = tsem_init(&sem, 0, 0);
   EXPECT_EQ(result, 0);
 
-  std::thread([&sem]() {
+  std::thread waiter([&sem]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     (void)tsem_post(&sem);
-  }).detach();
+  });
 
   result = tsem_wait(&sem);
   EXPECT_EQ(result, 0);
+
+  waiter.join();
 
   result = tsem_destroy(&sem);
   EXPECT_EQ(result, 0);
@@ -102,13 +104,15 @@ TEST(osSemaphoreTests, TimedWait) {
   int    result = tsem_init(&sem, 0, 0);
   EXPECT_EQ(result, 0);
 
-  std::thread([&sem]() {
+  std::thread twait([&sem]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     (void)tsem_post(&sem);
-  }).detach();
+  });
 
   result = tsem_timewait(&sem, 1000);
   EXPECT_EQ(result, 0);
+
+  twait.join();
 
   result = tsem_destroy(&sem);
   EXPECT_EQ(result, 0);
@@ -119,15 +123,16 @@ TEST(osSemaphoreTests, Performance1_1) {
   const int count = 100000;
 
   (void)tsem_init(&sem, 0, 0);
-  std::thread([&sem, count]() {
+  std::thread producer([&sem, count]() {
     for (int i = 0; i < count; ++i) {
       (void)tsem_post(&sem);
     }
-  }).detach();
+  });
 
   for (int i = 0; i < count; ++i) {
     (void)tsem_wait(&sem);
   }
+  producer.join();
   (void)tsem_destroy(&sem);
 }
 
@@ -136,15 +141,16 @@ TEST(osSemaphoreTests, Performance1_2) {
   const int count = 100000;
 
   (void)tsem2_init(&sem, 0, 0);
-  std::thread([&sem, count]() {
+  std::thread producer2([&sem, count]() {
     for (int i = 0; i < count; ++i) {
       (void)tsem2_post(&sem);
     }
-  }).detach();
+  });
 
   for (int i = 0; i < count; ++i) {
     (void)tsem2_wait(&sem);
   }
+  producer2.join();
   (void)tsem2_destroy(&sem);
 }
 
@@ -237,21 +243,22 @@ TEST(osSemaphoreTests, Performance2_1) {
   const int count = 50000;
 
   (void)tsem_init(&sem, 0, 0);
-  std::thread([&sem, count]() {
+  std::thread p1([&sem, count]() {
     for (int i = 0; i < count; ++i) {
       (void)tsem_post(&sem);
     }
-  }).detach();
-  
-  std::thread([&sem, count]() {
+  });
+  std::thread p2([&sem, count]() {
     for (int i = 0; i < count; ++i) {
       (void)tsem_post(&sem);
     }
-  }).detach();
+  });
 
   for (int i = 0; i < count * 2; ++i) {
     (void)tsem_wait(&sem);
   }
+  p1.join();
+  p2.join();
   (void)tsem_destroy(&sem);
 }
 
@@ -260,21 +267,22 @@ TEST(osSemaphoreTests, Performance2_2) {
   const int count = 50000;
 
   (void)tsem2_init(&sem, 0, 0);
-  std::thread([&sem, count]() {
+  std::thread q1([&sem, count]() {
     for (int i = 0; i < count; ++i) {
       (void)tsem2_post(&sem);
     }
-  }).detach();
-  
-  std::thread([&sem, count]() {
+  });
+  std::thread q2([&sem, count]() {
     for (int i = 0; i < count; ++i) {
       (void)tsem2_post(&sem);
     }
-  }).detach();
+  });
 
   for (int i = 0; i < count * 2; ++i) {
     (void)tsem2_wait(&sem);
   }
+  q1.join();
+  q2.join();
   (void)tsem2_destroy(&sem);
 }
 
@@ -305,11 +313,13 @@ TEST(osSemaphoreTests, Performance4_1) {
   for (int i = 0; i < count; ++i) {
     tsem_t sem;
     (void)tsem_init(&sem, 0, 0);
-    std::thread([&sem, count]() {
+    std::thread p([&sem, count]() {
       (void)tsem_post(&sem);
-    }).detach();
+    });
 
     EXPECT_EQ(tsem_timewait(&sem, 1000),0);
+
+    p.join();
 
     (void)tsem_destroy(&sem);
   }
@@ -320,11 +330,13 @@ TEST(osSemaphoreTests, Performance4_2) {
   for (int i = 0; i < count; ++i) {
     tsem2_t sem;
     (void)tsem2_init(&sem, 0, 0);
-    std::thread([&sem, count]() {
+    std::thread p2([&sem, count]() {
       (void)tsem2_post(&sem);
-    }).detach();
+    });
 
     (void)tsem2_timewait(&sem, 1000);
+
+    p2.join();
 
     (void)tsem2_destroy(&sem);
   }

--- a/source/os/test/osSemaphoreTests.cpp
+++ b/source/os/test/osSemaphoreTests.cpp
@@ -313,7 +313,7 @@ TEST(osSemaphoreTests, Performance4_1) {
   for (int i = 0; i < count; ++i) {
     tsem_t sem;
     (void)tsem_init(&sem, 0, 0);
-    std::thread p([&sem, count]() {
+    std::thread p([&sem]() {
       (void)tsem_post(&sem);
     });
 
@@ -330,7 +330,7 @@ TEST(osSemaphoreTests, Performance4_2) {
   for (int i = 0; i < count; ++i) {
     tsem2_t sem;
     (void)tsem2_init(&sem, 0, 0);
-    std::thread p2([&sem, count]() {
+    std::thread p2([&sem]() {
       (void)tsem2_post(&sem);
     });
 


### PR DESCRIPTION
# Description

<!-- Please briefly describe the code changes in this pull request. -->

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
