### PR TITLE
fix(parser): relax stream tag type modifier checks for stream tags

### DIFF
--- a/source/libs/parser/src/parTranslater.c
+++ b/source/libs/parser/src/parTranslater.c
@@ -16819,8 +16819,13 @@ static int32_t createStreamReqBuildStreamTagExprStr(STranslateContext* pCxt, SNo
     if (pTag->pTagExpr) {
       PAR_ERR_JRET(translateCreateStreamTagSubtableExpr(pCxt, pPartitionByList, &pTag->pTagExpr));
       SExprNode* pTagExpr = (SExprNode*)pTag->pTagExpr;
-      if (pTagExpr->resType.type != pTag->dataType.type || pTagExpr->resType.precision != pTag->dataType.precision ||
-          pTagExpr->resType.scale != pTag->dataType.scale) {
+      bool typeMatch = (pTagExpr->resType.type == pTag->dataType.type);
+      bool typeModMatch = true;
+      if (IS_DECIMAL_TYPE(pTag->dataType.type)) {
+        typeModMatch = (pTagExpr->resType.precision == pTag->dataType.precision &&
+                        pTagExpr->resType.scale == pTag->dataType.scale);
+      }
+      if (!typeMatch || !typeModMatch) {
         PAR_ERR_JRET(generateSyntaxErrMsgExt(&pCxt->msgBuf, TSDB_CODE_STREAM_INVALID_OUT_TABLE,
                                              "Tag data type does not match tag expression data type: %s, %d",
                                              pTag->tagName, pTagExpr->resType.type));

--- a/source/libs/parser/test/parStreamTest.cpp
+++ b/source/libs/parser/test/parStreamTest.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 
 #include "cJSON.h"
+#include "mockCatalogService.h"
 #include "parTestUtil.h"
 #include "plannodes.h"
 
@@ -1725,6 +1726,27 @@ TEST_F(ParserStreamTest, TestQueryFromPartTbnamePlaceholder) {
   run("create stream stream_streamdb.s1 count_window(1, c1) from stream_triggerdb.st1 partition by tbname "
       "into stream_outdb.stream_out as select _twstart ts, %%tbname as tb, count(c1) c1, avg(c1) c2 "
       "from %%tbname where ts >= _twstart and ts < _twstart + 5m");
+}
+
+TEST_F(ParserStreamTest, TestOutTagExprSpecialCases) {
+  setAsyncFlag("-1");
+  useDb("root", "testus");
+
+  ITableBuilder& builder = g_mockCatalogService->createTableBuilder("stream_triggerdb", "stn_tag_precision",
+                                                                    TSDB_SUPER_TABLE, 1, 1)
+                               .setPrecision(TSDB_TIME_PRECISION_NANO)
+                               .addColumn("ts", TSDB_DATA_TYPE_TIMESTAMP)
+                               .addTag("tag1", TSDB_DATA_TYPE_TIMESTAMP);
+  builder.done();
+  g_mockCatalogService->createSubTable("stream_triggerdb", "stn_tag_precision", "stn_tag_precision_s1", 2);
+
+  run("create stream testus.s_tag_precision interval(1s) sliding(1s) "
+      "from stream_triggerdb.stn_tag_precision partition by tag1 into stream_outdb.stream_out "
+      "tags(out_tag1 timestamp as tag1) as select ts, c1 from stream_querydb.stream_t1");
+
+  run("create stream testus.s_tag_const count_window(1, c1) "
+      "from stream_triggerdb.st1 partition by tbname, tag1 into stream_outdb.stream_out "
+      "tags(addr varchar(20) as 'aaaa', out_tag1 int as tag1) as select * from %%tbname");
 }
 
 TEST_F(ParserStreamTest, TestErrorName) {


### PR DESCRIPTION
# Description

fix(parser): relax stream tag type modifier checks for stream tags

Relax stream tag expression validation to compare precision and scale only for decimal types, so non-decimal tags do not fail on unrelated type modifier differences during create stream translation.

Add a focused parser regression test that covers a nano-precision timestamp tag expression in stream output.

# Issue(s)

- Fix: https://project.feishu.cn/taosdata_td/defect/detail/6949810559

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
