### PR TITLE
fix：clean build directory in CI workflow for docs

### DIFF
--- a/.github/workflows/tdengine-docs-ci.yml
+++ b/.github/workflows/tdengine-docs-ci.yml
@@ -169,7 +169,7 @@ jobs:
         if: ${{ steps.check-doc-lang.outputs.zh_doc_changed == 'true'}}
         run: |
           cd ${{ env.DOC_WKC }}/${{ env.ZH_DOC_REPO }}
-          rm -rf docs/* && git restore docs/ 
+          rm -rf build/* && rm -rf docs/* && git restore docs/ 
           git checkout -f master && git pull origin master 
           yarn install 
           yarn ass local
@@ -178,7 +178,7 @@ jobs:
         if: ${{ steps.check-doc-lang.outputs.en_doc_changed == 'true'}}
         run: |
           cd ${{ env.DOC_WKC }}/${{ env.EN_DOC_REPO }}
-          rm -rf docs/* && git restore docs/
+          rm -rf build/* && rm -rf docs/* && git restore docs/
           git checkout -f main && git pull origin main 
           yarn install 
           yarn ass local


### PR DESCRIPTION
Updated the CI workflow to clean the build directory before restoring docs

https://project.feishu.cn/taosdata_td/job/detail/6953809993?parentUrl=%2Fworkbench
