### PR TITLE
enh: delay auto ssmigrate to avoid conflict

### DIFF
--- a/source/dnode/mnode/impl/src/mndMain.c
+++ b/source/dnode/mnode/impl/src/mndMain.c
@@ -434,8 +434,17 @@ void mndDoTimerPullupTask(SMnode *pMnode, int64_t sec) {
     if (sec % tsQuerySsMigrateIntervalSec == 0) {
       mndPullupUpdateSsMigrateProgress(pMnode);
     }
-    if (tsSsEnabled == 2 && sec % tsSsAutoMigrateIntervalSec == 0) {
-      mndPullupSsMigrateDb(pMnode);
+    if (tsSsEnabled == 2) {
+      // By default, both tsTrimVDbIntervalSec and tsSsAutoMigrateIntervalSec are 3600 seconds,
+      // so, delay half interval to do ss migrate to avoid conflict.
+      //
+      // NOTE: this solution is not perfect, there could still be conflict if user changes the
+      // default value, but it is good enough as user is unlikely to change the default value.
+      // The best solution is adding a new offset config to all cron tasks, but that would add
+      // extra complexity.
+      if ((sec % tsSsAutoMigrateIntervalSec) == (tsSsAutoMigrateIntervalSec / 2)) {
+        mndPullupSsMigrateDb(pMnode);
+      }
     }
   }
 #endif


### PR DESCRIPTION
# Description

By default, both tsTrimVDbIntervalSec and tsSsAutoMigrateIntervalSec are 3600 seconds, this result in a conlict and then result in the fail of the ssmigrate.

This PR delays half interval to do ss migrate to avoid conflict.

# Issue(s)

- resolve: https://project.feishu.cn/taosdata_td/feature/detail/6952596147

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
