### PR TITLE
perf: optimize compact progress query from O(m*n) to O(n+m)

### DIFF
--- a/include/common/tmsg.h
+++ b/include/common/tmsg.h
@@ -3122,6 +3122,23 @@ typedef struct {
 int32_t tSerializeSQueryCompactProgressRsp(void* buf, int32_t bufLen, SQueryCompactProgressRsp* pReq);
 int32_t tDeserializeSQueryCompactProgressRsp(void* buf, int32_t bufLen, SQueryCompactProgressRsp* pReq);
 
+typedef struct {
+  int32_t compactId;
+} SDnodeQueryCompactProgressReq;
+
+int32_t tSerializeSDnodeQueryCompactProgressReq(void *buf, int32_t bufLen, SDnodeQueryCompactProgressReq *pReq);
+int32_t tDeserializeSDnodeQueryCompactProgressReq(void *buf, int32_t bufLen, SDnodeQueryCompactProgressReq *pReq);
+
+typedef struct {
+  int32_t                   dnodeId;
+  int32_t                   numOfVnodes;
+  SQueryCompactProgressRsp *vnodeProgress;  // array of numOfVnodes elements
+} SDnodeQueryCompactProgressRsp;
+
+int32_t tSerializeSDnodeQueryCompactProgressRsp(void *buf, int32_t bufLen, SDnodeQueryCompactProgressRsp *pRsp);
+int32_t tDeserializeSDnodeQueryCompactProgressRsp(void *buf, int32_t bufLen, SDnodeQueryCompactProgressRsp *pRsp);
+void    tFreeSDnodeQueryCompactProgressRsp(SDnodeQueryCompactProgressRsp *pRsp);
+
 typedef SQueryCompactProgressReq SQueryRetentionProgressReq;
 typedef SQueryCompactProgressRsp SQueryRetentionProgressRsp;
 

--- a/include/common/tmsgdef.h
+++ b/include/common/tmsgdef.h
@@ -125,7 +125,6 @@
   TD_DEF_MSG_TYPE(TDMT_DND_ALTER_VNODE_TYPE, "dnode-alter-vnode-type", NULL, NULL)
   TD_DEF_MSG_TYPE(TDMT_DND_CHECK_VNODE_LEARNER_CATCHUP, "dnode-check-vnode-learner-catchup", NULL, NULL)
   TD_DEF_MSG_TYPE(TDMT_DND_CREATE_ENCRYPT_KEY, "create-encrypt-key", NULL, NULL)
-  TD_DEF_MSG_TYPE(TDMT_DND_QUERY_COMPACT_PROGRESS, "dnode-query-compact-progress", NULL, NULL)
   // mnode msg overload
   TD_DEF_MSG_TYPE(TDMT_MND_CREATE_ANODE, "create-anode", NULL, NULL)
   TD_DEF_MSG_TYPE(TDMT_MND_UPDATE_ANODE, "update-anode", NULL, NULL)
@@ -163,6 +162,7 @@
   TD_DEF_MSG_TYPE(TDMT_MND_CREATE_TOTP_SECRET, "create-totp-secret", NULL, NULL)
   TD_DEF_MSG_TYPE(TDMT_MND_DROP_TOTP_SECRET, "drop-totp-secret", NULL, NULL)
   TD_DEF_MSG_TYPE(TDMT_MND_ALTER_KEY_EXPIRATION, "alter-key-expiration", NULL, NULL)
+  TD_DEF_MSG_TYPE(TDMT_DND_QUERY_COMPACT_PROGRESS, "dnode-query-compact-progress", NULL, NULL)
   TD_CLOSE_MSG_SEG(TDMT_DND_MSG)
 
   TD_NEW_MSG_SEG(TDMT_MND_MSG)  // 1<<8

--- a/include/common/tmsgdef.h
+++ b/include/common/tmsgdef.h
@@ -125,6 +125,7 @@
   TD_DEF_MSG_TYPE(TDMT_DND_ALTER_VNODE_TYPE, "dnode-alter-vnode-type", NULL, NULL)
   TD_DEF_MSG_TYPE(TDMT_DND_CHECK_VNODE_LEARNER_CATCHUP, "dnode-check-vnode-learner-catchup", NULL, NULL)
   TD_DEF_MSG_TYPE(TDMT_DND_CREATE_ENCRYPT_KEY, "create-encrypt-key", NULL, NULL)
+  TD_DEF_MSG_TYPE(TDMT_DND_QUERY_COMPACT_PROGRESS, "dnode-query-compact-progress", NULL, NULL)
   // mnode msg overload
   TD_DEF_MSG_TYPE(TDMT_MND_CREATE_ANODE, "create-anode", NULL, NULL)
   TD_DEF_MSG_TYPE(TDMT_MND_UPDATE_ANODE, "update-anode", NULL, NULL)

--- a/source/common/src/msg/tmsg.c
+++ b/source/common/src/msg/tmsg.c
@@ -11165,6 +11165,119 @@ _exit:
   return code;
 }
 
+int32_t tSerializeSDnodeQueryCompactProgressReq(void *buf, int32_t bufLen,
+                                                 SDnodeQueryCompactProgressReq *pReq) {
+  SEncoder encoder = {0};
+  int32_t  code = 0;
+  int32_t  lino;
+  int32_t  tlen;
+  tEncoderInit(&encoder, buf, bufLen);
+
+  TAOS_CHECK_EXIT(tStartEncode(&encoder));
+  TAOS_CHECK_EXIT(tEncodeI32(&encoder, pReq->compactId));
+  tEndEncode(&encoder);
+
+_exit:
+  if (code) {
+    tlen = code;
+  } else {
+    tlen = encoder.pos;
+  }
+  tEncoderClear(&encoder);
+  return tlen;
+}
+
+int32_t tDeserializeSDnodeQueryCompactProgressReq(void *buf, int32_t bufLen,
+                                                   SDnodeQueryCompactProgressReq *pReq) {
+  SDecoder decoder = {0};
+  int32_t  code = 0;
+  int32_t  lino;
+  tDecoderInit(&decoder, (uint8_t *)buf + sizeof(SMsgHead), bufLen - sizeof(SMsgHead));
+
+  TAOS_CHECK_EXIT(tStartDecode(&decoder));
+  TAOS_CHECK_EXIT(tDecodeI32(&decoder, &pReq->compactId));
+  tEndDecode(&decoder);
+
+_exit:
+  tDecoderClear(&decoder);
+  return code;
+}
+
+int32_t tSerializeSDnodeQueryCompactProgressRsp(void *buf, int32_t bufLen,
+                                                 SDnodeQueryCompactProgressRsp *pRsp) {
+  SEncoder encoder = {0};
+  int32_t  code = 0;
+  int32_t  lino;
+  int32_t  tlen;
+  tEncoderInit(&encoder, buf, bufLen);
+
+  TAOS_CHECK_EXIT(tStartEncode(&encoder));
+  TAOS_CHECK_EXIT(tEncodeI32(&encoder, pRsp->dnodeId));
+  TAOS_CHECK_EXIT(tEncodeI32(&encoder, pRsp->numOfVnodes));
+  for (int32_t i = 0; i < pRsp->numOfVnodes; i++) {
+    SQueryCompactProgressRsp *p = &pRsp->vnodeProgress[i];
+    TAOS_CHECK_EXIT(tEncodeI32(&encoder, p->compactId));
+    TAOS_CHECK_EXIT(tEncodeI32(&encoder, p->vgId));
+    TAOS_CHECK_EXIT(tEncodeI32(&encoder, p->dnodeId));
+    TAOS_CHECK_EXIT(tEncodeI32(&encoder, p->numberFileset));
+    TAOS_CHECK_EXIT(tEncodeI32(&encoder, p->finished));
+    TAOS_CHECK_EXIT(tEncodeI32v(&encoder, p->progress));
+    TAOS_CHECK_EXIT(tEncodeI64v(&encoder, p->remainingTime));
+  }
+  tEndEncode(&encoder);
+
+_exit:
+  if (code) {
+    tlen = code;
+  } else {
+    tlen = encoder.pos;
+  }
+  tEncoderClear(&encoder);
+  return tlen;
+}
+
+int32_t tDeserializeSDnodeQueryCompactProgressRsp(void *buf, int32_t bufLen,
+                                                   SDnodeQueryCompactProgressRsp *pRsp) {
+  SDecoder decoder = {0};
+  int32_t  code = 0;
+  int32_t  lino;
+  tDecoderInit(&decoder, buf, bufLen);
+
+  TAOS_CHECK_EXIT(tStartDecode(&decoder));
+  TAOS_CHECK_EXIT(tDecodeI32(&decoder, &pRsp->dnodeId));
+  TAOS_CHECK_EXIT(tDecodeI32(&decoder, &pRsp->numOfVnodes));
+
+  if (pRsp->numOfVnodes > 0) {
+    pRsp->vnodeProgress = taosMemoryCalloc(pRsp->numOfVnodes, sizeof(SQueryCompactProgressRsp));
+    if (pRsp->vnodeProgress == NULL) {
+      code = TSDB_CODE_OUT_OF_MEMORY;
+      goto _exit;
+    }
+    for (int32_t i = 0; i < pRsp->numOfVnodes; i++) {
+      SQueryCompactProgressRsp *p = &pRsp->vnodeProgress[i];
+      TAOS_CHECK_EXIT(tDecodeI32(&decoder, &p->compactId));
+      TAOS_CHECK_EXIT(tDecodeI32(&decoder, &p->vgId));
+      TAOS_CHECK_EXIT(tDecodeI32(&decoder, &p->dnodeId));
+      TAOS_CHECK_EXIT(tDecodeI32(&decoder, &p->numberFileset));
+      TAOS_CHECK_EXIT(tDecodeI32(&decoder, &p->finished));
+      TAOS_CHECK_EXIT(tDecodeI32v(&decoder, &p->progress));
+      TAOS_CHECK_EXIT(tDecodeI64v(&decoder, &p->remainingTime));
+    }
+  } else {
+    pRsp->vnodeProgress = NULL;
+  }
+  tEndDecode(&decoder);
+
+_exit:
+  tDecoderClear(&decoder);
+  return code;
+}
+
+void tFreeSDnodeQueryCompactProgressRsp(SDnodeQueryCompactProgressRsp *pRsp) {
+  if (pRsp == NULL) return;
+  taosMemoryFreeClear(pRsp->vnodeProgress);
+}
+
 int32_t tSerializeSDropVnodeReq(void *buf, int32_t bufLen, SDropVnodeReq *pReq) {
   SEncoder encoder = {0};
   int32_t  code = 0;

--- a/source/dnode/mgmt/mgmt_dnode/src/dmHandle.c
+++ b/source/dnode/mgmt/mgmt_dnode/src/dmHandle.c
@@ -1821,7 +1821,6 @@ SArray *dmGetMsgHandles() {
   if (dmSetMgmtHandle(pArray, TDMT_DND_SYSTABLE_RETRIEVE, dmPutNodeMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_DND_ALTER_MNODE_TYPE, dmPutNodeMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_DND_CREATE_ENCRYPT_KEY, dmPutNodeMsgToMgmtQueue, 0) == NULL) goto _OVER;
-  if (dmSetMgmtHandle(pArray, TDMT_DND_QUERY_COMPACT_PROGRESS, dmPutNodeMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_MND_ALTER_ENCRYPT_KEY, dmPutNodeMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_MND_ALTER_KEY_EXPIRATION, dmPutNodeMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_MND_STREAM_HEARTBEAT_RSP, dmPutMsgToStreamMgmtQueue, 0) == NULL) goto _OVER;

--- a/source/dnode/mgmt/mgmt_dnode/src/dmHandle.c
+++ b/source/dnode/mgmt/mgmt_dnode/src/dmHandle.c
@@ -1821,6 +1821,7 @@ SArray *dmGetMsgHandles() {
   if (dmSetMgmtHandle(pArray, TDMT_DND_SYSTABLE_RETRIEVE, dmPutNodeMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_DND_ALTER_MNODE_TYPE, dmPutNodeMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_DND_CREATE_ENCRYPT_KEY, dmPutNodeMsgToMgmtQueue, 0) == NULL) goto _OVER;
+  if (dmSetMgmtHandle(pArray, TDMT_DND_QUERY_COMPACT_PROGRESS, dmPutNodeMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_MND_ALTER_ENCRYPT_KEY, dmPutNodeMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_MND_ALTER_KEY_EXPIRATION, dmPutNodeMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_MND_STREAM_HEARTBEAT_RSP, dmPutMsgToStreamMgmtQueue, 0) == NULL) goto _OVER;

--- a/source/dnode/mgmt/mgmt_mnode/src/mmHandle.c
+++ b/source/dnode/mgmt/mgmt_mnode/src/mmHandle.c
@@ -133,6 +133,7 @@ SArray *mmGetMsgHandles() {
   if (dmSetMgmtHandle(pArray, TDMT_DND_CHECK_VNODE_LEARNER_CATCHUP_RSP, mmPutMsgToWriteQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_SYNC_CONFIG_CHANGE_RSP, mmPutMsgToWriteQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_DND_CREATE_ENCRYPT_KEY_RSP, mmPutMsgToReadQueue, 0) == NULL) goto _OVER;
+  if (dmSetMgmtHandle(pArray, TDMT_DND_QUERY_COMPACT_PROGRESS_RSP, mmPutMsgToReadQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_DND_RETRIEVE_MOUNT_PATH_RSP, mmPutMsgToReadQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_DND_RELOAD_DNODE_TLS_RSP, mmPutMsgToReadQueue, 0) == NULL) goto _OVER;
 

--- a/source/dnode/mgmt/mgmt_vnode/inc/vmInt.h
+++ b/source/dnode/mgmt/mgmt_vnode/inc/vmInt.h
@@ -168,6 +168,8 @@ int32_t vmPutMsgToMergeQueue(SVnodeMgmt *pMgmt, SRpcMsg *pMsg);
 int32_t vmPutMsgToMgmtQueue(SVnodeMgmt *pMgmt, SRpcMsg *pMsg);
 int32_t vmPutMsgToMultiMgmtQueue(SVnodeMgmt *pMgmt, SRpcMsg *pMsg);
 
+int32_t vmProcessDnodeQueryCompactProgressReq(SVnodeMgmt *pMgmt, SRpcMsg *pMsg);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/dnode/mgmt/mgmt_vnode/src/vmHandle.c
+++ b/source/dnode/mgmt/mgmt_vnode/src/vmHandle.c
@@ -2030,6 +2030,7 @@ SArray *vmGetMsgHandles() {
   if (dmSetMgmtHandle(pArray, TDMT_DND_MOUNT_VNODE, vmPutMsgToMultiMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_DND_RETRIEVE_MOUNT_PATH, vmPutMsgToMultiMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_DND_DROP_VNODE, vmPutMsgToMgmtQueue, 0) == NULL) goto _OVER;
+  if (dmSetMgmtHandle(pArray, TDMT_DND_QUERY_COMPACT_PROGRESS, vmPutMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_DND_ALTER_VNODE_TYPE, vmPutMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_DND_CHECK_VNODE_LEARNER_CATCHUP, vmPutMsgToMgmtQueue, 0) == NULL) goto _OVER;
   if (dmSetMgmtHandle(pArray, TDMT_SYNC_CONFIG_CHANGE, vmPutMsgToWriteQueue, 0) == NULL) goto _OVER;

--- a/source/dnode/mgmt/mgmt_vnode/src/vmHandle.c
+++ b/source/dnode/mgmt/mgmt_vnode/src/vmHandle.c
@@ -1929,7 +1929,7 @@ int32_t vmProcessDnodeQueryCompactProgressReq(SVnodeMgmt *pMgmt, SRpcMsg *pMsg) 
 
   int32_t rspLen = tSerializeSDnodeQueryCompactProgressRsp(NULL, 0, &rsp);
   if (rspLen < 0) {
-    code = TSDB_CODE_OUT_OF_MEMORY;
+    code = rspLen;
     taosArrayDestroy(pProgressArray);
     goto _exit;
   }

--- a/source/dnode/mgmt/mgmt_vnode/src/vmHandle.c
+++ b/source/dnode/mgmt/mgmt_vnode/src/vmHandle.c
@@ -23,6 +23,11 @@
 
 extern taos_counter_t *tsInsertCounter;
 
+#ifdef TD_ENTERPRISE
+// Forward declaration for enterprise function
+extern int32_t vnodeGetCompactProgress(SVnode *pVnode, int32_t compactId, SQueryCompactProgressRsp *pRsp);
+#endif
+
 // Forward declaration for function defined in metrics.c
 extern int32_t addWriteMetrics(int32_t vgId, int32_t dnodeId, int64_t clusterId, const char *dnodeEp,
                                const char *dbname, const SRawWriteMetrics *pRawMetrics);

--- a/source/dnode/mgmt/mgmt_vnode/src/vmHandle.c
+++ b/source/dnode/mgmt/mgmt_vnode/src/vmHandle.c
@@ -1863,6 +1863,95 @@ _OVER:
   return terrno;
 }
 
+int32_t vmProcessDnodeQueryCompactProgressReq(SVnodeMgmt *pMgmt, SRpcMsg *pMsg) {
+  int32_t                       code = 0;
+  SDnodeQueryCompactProgressReq req = {0};
+  void                         *pRsp = NULL;
+  SVnodeObj                   **ppVnodes = NULL;
+  int32_t                       numOfVnodes = 0;
+
+  code = tDeserializeSDnodeQueryCompactProgressReq(pMsg->pCont, pMsg->contLen, &req);
+  if (code != 0) {
+    dError("dnode:%d, failed to deserialize dnode-query-compact-progress req, code:%s",
+           pMgmt->pData->dnodeId, tstrerror(code));
+    goto _exit;
+  }
+
+  dDebug("dnode:%d, receive dnode-query-compact-progress req, compactId:%d", pMgmt->pData->dnodeId, req.compactId);
+
+  // collect compact progress from all running vnodes
+  SArray *pProgressArray = taosArrayInit(16, sizeof(SQueryCompactProgressRsp));
+  if (pProgressArray == NULL) {
+    code = TSDB_CODE_OUT_OF_MEMORY;
+    goto _exit;
+  }
+
+  code = vmGetVnodeListFromHash(pMgmt, &numOfVnodes, &ppVnodes);
+  if (code != 0) {
+    dError("dnode:%d, failed to get vnode list, code:%s", pMgmt->pData->dnodeId, tstrerror(code));
+    taosArrayDestroy(pProgressArray);
+    goto _exit;
+  }
+
+  for (int32_t i = 0; i < numOfVnodes; i++) {
+    SVnodeObj *pVnode = ppVnodes[i];
+    if (pVnode == NULL) {
+      continue;
+    }
+    if (pVnode->failed || pVnode->pImpl == NULL) {
+      vmReleaseVnode(pMgmt, pVnode);
+      continue;
+    }
+#ifdef TD_ENTERPRISE
+    SQueryCompactProgressRsp vnodeRsp = {0};
+    vnodeRsp.dnodeId = pMgmt->pData->dnodeId;
+    if (vnodeGetCompactProgress(pVnode->pImpl, req.compactId, &vnodeRsp) == 0 && vnodeRsp.compactId != 0) {
+      if (taosArrayPush(pProgressArray, &vnodeRsp) == NULL) {
+        dError("dnode:%d, vgId:%d, failed to push compact progress", pMgmt->pData->dnodeId, pVnode->vgId);
+      }
+    }
+#endif
+    vmReleaseVnode(pMgmt, pVnode);
+  }
+  taosMemoryFree(ppVnodes);
+
+  SDnodeQueryCompactProgressRsp rsp = {0};
+  rsp.dnodeId       = pMgmt->pData->dnodeId;
+  rsp.numOfVnodes   = (int32_t)taosArrayGetSize(pProgressArray);
+  rsp.vnodeProgress = (rsp.numOfVnodes > 0) ? (SQueryCompactProgressRsp *)taosArrayGet(pProgressArray, 0) : NULL;
+
+  dInfo("dnode:%d, send dnode-query-compact-progress rsp, numOfVnodes:%d", rsp.dnodeId, rsp.numOfVnodes);
+
+  int32_t rspLen = tSerializeSDnodeQueryCompactProgressRsp(NULL, 0, &rsp);
+  if (rspLen < 0) {
+    code = TSDB_CODE_OUT_OF_MEMORY;
+    taosArrayDestroy(pProgressArray);
+    goto _exit;
+  }
+
+  pRsp = rpcMallocCont(rspLen);
+  if (pRsp == NULL) {
+    code = TSDB_CODE_OUT_OF_MEMORY;
+    taosArrayDestroy(pProgressArray);
+    goto _exit;
+  }
+
+  if (tSerializeSDnodeQueryCompactProgressRsp(pRsp, rspLen, &rsp) < 0) {
+    code = TSDB_CODE_INVALID_MSG;
+    rpcFreeCont(pRsp);
+    pRsp = NULL;
+    taosArrayDestroy(pProgressArray);
+    goto _exit;
+  }
+
+  taosArrayDestroy(pProgressArray);
+  pMsg->info.rsp    = pRsp;
+  pMsg->info.rspLen = rspLen;
+
+_exit:
+  return code;
+}
+
 SArray *vmGetMsgHandles() {
   int32_t code = -1;
   SArray *pArray = taosArrayInit(32, sizeof(SMgmtHandle));

--- a/source/dnode/mgmt/mgmt_vnode/src/vmWorker.c
+++ b/source/dnode/mgmt/mgmt_vnode/src/vmWorker.c
@@ -17,6 +17,9 @@
 #include "vmInt.h"
 #include "vnodeInt.h"
 
+// Forward declaration
+int32_t vmProcessDnodeQueryCompactProgressReq(SVnodeMgmt *pMgmt, SRpcMsg *pMsg);
+
 static inline void vmSendRsp(SRpcMsg *pMsg, int32_t code) {
   if (pMsg->info.handle == NULL) return;
   SRpcMsg rsp = {

--- a/source/dnode/mgmt/mgmt_vnode/src/vmWorker.c
+++ b/source/dnode/mgmt/mgmt_vnode/src/vmWorker.c
@@ -17,9 +17,6 @@
 #include "vmInt.h"
 #include "vnodeInt.h"
 
-// Forward declaration
-int32_t vmProcessDnodeQueryCompactProgressReq(SVnodeMgmt *pMgmt, SRpcMsg *pMsg);
-
 static inline void vmSendRsp(SRpcMsg *pMsg, int32_t code) {
   if (pMsg->info.handle == NULL) return;
   SRpcMsg rsp = {

--- a/source/dnode/mgmt/mgmt_vnode/src/vmWorker.c
+++ b/source/dnode/mgmt/mgmt_vnode/src/vmWorker.c
@@ -98,6 +98,9 @@ static void vmProcessMgmtQueue(SQueueInfo *pInfo, SRpcMsg *pMsg) {
     case TDMT_VND_ALTER_ELECTBASELINE:
       code = vmProcessAlterVnodeElectBaselineReq(pMgmt, pMsg);
       break;
+    case TDMT_DND_QUERY_COMPACT_PROGRESS:
+      code = vmProcessDnodeQueryCompactProgressReq(pMgmt, pMsg);
+      break;
     default:
       terrno = TSDB_CODE_MSG_NOT_PROCESSED;
       dGError("msg:%p, not processed in vnode-mgmt queue", pMsg);

--- a/source/dnode/mnode/impl/inc/mndCompact.h
+++ b/source/dnode/mnode/impl/inc/mndCompact.h
@@ -47,7 +47,9 @@ int32_t mndProcessQueryCompactRsp(SRpcMsg *pReq);
 SCompactObj *mndAcquireCompact(SMnode *pMnode, int64_t compactId);
 void mndReleaseCompact(SMnode *pMnode, SCompactObj *pCompact);
 
-void mndCompactSendProgressReq(SMnode *pMnode, SCompactObj *pCompact);
+int32_t mndCompactGetDbName(SMnode *pMnode, int32_t compactId, char *dbname, int32_t len);
+void    mndCompactSendProgressReq(SMnode *pMnode, SCompactObj *pCompact);
+int32_t mndProcessDnodeCompactProgressRsp(SRpcMsg *pReq);
 
 #ifdef __cplusplus
 }

--- a/source/dnode/mnode/impl/inc/mndCompact.h
+++ b/source/dnode/mnode/impl/inc/mndCompact.h
@@ -47,7 +47,6 @@ int32_t mndProcessQueryCompactRsp(SRpcMsg *pReq);
 SCompactObj *mndAcquireCompact(SMnode *pMnode, int64_t compactId);
 void mndReleaseCompact(SMnode *pMnode, SCompactObj *pCompact);
 
-int32_t mndCompactGetDbName(SMnode *pMnode, int32_t compactId, char *dbname, int32_t len);
 void    mndCompactSendProgressReq(SMnode *pMnode, SCompactObj *pCompact);
 int32_t mndProcessDnodeCompactProgressRsp(SRpcMsg *pReq);
 

--- a/source/dnode/mnode/impl/src/mndCompact.c
+++ b/source/dnode/mnode/impl/src/mndCompact.c
@@ -34,6 +34,7 @@ int32_t mndInitCompact(SMnode *pMnode) {
   mndAddShowRetrieveHandle(pMnode, TSDB_MGMT_TABLE_COMPACT, mndRetrieveCompact);
   mndSetMsgHandle(pMnode, TDMT_MND_KILL_COMPACT, mndProcessKillCompactReq);
   mndSetMsgHandle(pMnode, TDMT_VND_QUERY_COMPACT_PROGRESS_RSP, mndProcessQueryCompactRsp);
+  mndSetMsgHandle(pMnode, TDMT_DND_QUERY_COMPACT_PROGRESS_RSP, mndProcessDnodeCompactProgressRsp);
   mndSetMsgHandle(pMnode, TDMT_MND_COMPACT_TIMER, mndProcessCompactTimer);
   mndSetMsgHandle(pMnode, TDMT_VND_KILL_COMPACT_RSP, mndTransProcessRsp);
 
@@ -637,71 +638,56 @@ int32_t mndProcessQueryCompactRsp(SRpcMsg *pReq) {
 
 // timer
 void mndCompactSendProgressReq(SMnode *pMnode, SCompactObj *pCompact) {
+  SSdb *pSdb = pMnode->pSdb;
   void *pIter = NULL;
 
+  mDebug("compact:%d, broadcast progress query to all dnodes", pCompact->compactId);
+
   while (1) {
-    SCompactDetailObj *pDetail = NULL;
-    pIter = sdbFetch(pMnode->pSdb, SDB_COMPACT_DETAIL, pIter, (void **)&pDetail);
+    SDnodeObj *pDnode = NULL;
+    pIter = sdbFetch(pSdb, SDB_DNODE, pIter, (void **)&pDnode);
     if (pIter == NULL) break;
 
-    if (pDetail->compactId == pCompact->compactId) {
-      SEpSet epSet = {0};
+    SDnodeQueryCompactProgressReq req = {.compactId = pCompact->compactId};
 
-      SDnodeObj *pDnode = mndAcquireDnode(pMnode, pDetail->dnodeId);
-      if (pDnode == NULL) break;
-      if (addEpIntoEpSet(&epSet, pDnode->fqdn, pDnode->port) != 0) {
-        sdbRelease(pMnode->pSdb, pDetail);
-        continue;
-      }
-      mndReleaseDnode(pMnode, pDnode);
+    int32_t contLen = tSerializeSDnodeQueryCompactProgressReq(NULL, 0, &req);
+    if (contLen < 0) {
+      sdbRelease(pSdb, pDnode);
+      continue;
+    }
+    contLen += sizeof(SMsgHead);
 
-      SQueryCompactProgressReq req;
-      req.compactId = pDetail->compactId;
-      req.vgId = pDetail->vgId;
-      req.dnodeId = pDetail->dnodeId;
+    SMsgHead *pHead = rpcMallocCont(contLen);
+    if (pHead == NULL) {
+      sdbRelease(pSdb, pDnode);
+      continue;
+    }
+    pHead->contLen = htonl(contLen);
+    pHead->vgId    = htonl(0);
 
-      int32_t contLen = tSerializeSQueryCompactProgressReq(NULL, 0, &req);
-      if (contLen < 0) {
-        sdbRelease(pMnode->pSdb, pDetail);
-        continue;
-      }
-
-      contLen += sizeof(SMsgHead);
-
-      SMsgHead *pHead = rpcMallocCont(contLen);
-      if (pHead == NULL) {
-        sdbRelease(pMnode->pSdb, pDetail);
-        continue;
-      }
-
-      pHead->contLen = htonl(contLen);
-      pHead->vgId = htonl(pDetail->vgId);
-
-      if (tSerializeSQueryCompactProgressReq((char *)pHead + sizeof(SMsgHead), contLen - sizeof(SMsgHead), &req) <= 0) {
-        sdbRelease(pMnode->pSdb, pDetail);
-        continue;
-      }
-
-      SRpcMsg rpcMsg = {.msgType = TDMT_VND_QUERY_COMPACT_PROGRESS, .contLen = contLen};
-
-      rpcMsg.pCont = pHead;
-
-      char    detail[1024] = {0};
-      int32_t len = snprintf(detail, sizeof(detail), "msgType:%s numOfEps:%d inUse:%d",
-                             TMSG_INFO(TDMT_VND_QUERY_COMPACT_PROGRESS), epSet.numOfEps, epSet.inUse);
-      for (int32_t i = 0; i < epSet.numOfEps; ++i) {
-        len += snprintf(detail + len, sizeof(detail) - len, " ep:%d-%s:%u", i, epSet.eps[i].fqdn, epSet.eps[i].port);
-      }
-
-      mDebug("compact:%d, send update progress msg to %s", pDetail->compactId, detail);
-
-      if (tmsgSendReq(&epSet, &rpcMsg) < 0) {
-        sdbRelease(pMnode->pSdb, pDetail);
-        continue;
-      }
+    if (tSerializeSDnodeQueryCompactProgressReq((char *)pHead + sizeof(SMsgHead),
+                                                contLen - sizeof(SMsgHead), &req) < 0) {
+      rpcFreeCont(pHead);
+      sdbRelease(pSdb, pDnode);
+      continue;
     }
 
-    sdbRelease(pMnode->pSdb, pDetail);
+    SEpSet  epSet = mndGetDnodeEpset(pDnode);
+    SRpcMsg rpcMsg = {.msgType = TDMT_DND_QUERY_COMPACT_PROGRESS, .pCont = pHead, .contLen = contLen};
+
+    char    detail[256] = {0};
+    int32_t len = tsnprintf(detail, sizeof(detail), "msgType:%s numOfEps:%d inUse:%d",
+                            TMSG_INFO(TDMT_DND_QUERY_COMPACT_PROGRESS), epSet.numOfEps, epSet.inUse);
+    for (int32_t i = 0; i < epSet.numOfEps; ++i) {
+      len += tsnprintf(detail + len, sizeof(detail) - len, " ep:%d-%s:%u", i, epSet.eps[i].fqdn, epSet.eps[i].port);
+    }
+    mDebug("compact:%d, send progress query to dnode:%d %s", pCompact->compactId, pDnode->id, detail);
+
+    if (tmsgSendReq(&epSet, &rpcMsg) < 0) {
+      mError("compact:%d, failed to send progress query to dnode:%d", pCompact->compactId, pDnode->id);
+    }
+
+    sdbRelease(pSdb, pDnode);
   }
 }
 
@@ -1060,4 +1046,76 @@ static int32_t mndProcessCompactTimer(SRpcMsg *pReq) {
   TAOS_UNUSED(mndCompactDispatch(pReq));
 #endif
   return 0;
+}
+
+int32_t mndProcessDnodeCompactProgressRsp(SRpcMsg *pReq) {
+  int32_t                       code = 0;
+  SDnodeQueryCompactProgressRsp rsp = {0};
+  SHashObj                     *pProgressMap = NULL;
+
+  if (pReq->code != 0) {
+    mError("received dnode compact progress rsp with error: %s", tstrerror(pReq->code));
+    code = pReq->code;
+    goto _exit;
+  }
+
+  code = tDeserializeSDnodeQueryCompactProgressRsp(pReq->pCont, pReq->contLen, &rsp);
+  if (code != 0) {
+    mError("failed to deserialize dnode-query-compact-progress-rsp, code:%s", tstrerror(code));
+    goto _exit;
+  }
+
+  mDebug("compact progress rsp from dnode:%d, numOfVnodes:%d", rsp.dnodeId, rsp.numOfVnodes);
+
+  SMnode *pMnode = pReq->info.node;
+
+  // batch update all vnodes for this dnode in memory (no SDB write, safe in read thread)
+  // Optimized from O(m*n) to O(n+m):
+  //   step1 — build a (compactId,vgId)->rsp lookup map in O(m)
+  //   step2 — single SDB scan in O(n), O(1) lookup per matched entry
+  pProgressMap =
+      taosHashInit(rsp.numOfVnodes * 2, taosGetDefaultHashFunction(TSDB_DATA_TYPE_BIGINT), false, HASH_NO_LOCK);
+  if (pProgressMap == NULL) {
+    code = TSDB_CODE_OUT_OF_MEMORY;
+    goto _exit;
+  }
+
+  for (int32_t i = 0; i < rsp.numOfVnodes; i++) {
+    SQueryCompactProgressRsp *pVnodeRsp = &rsp.vnodeProgress[i];
+    mDebug("compact:%d, update progress from dnode:%d vgId:%d, "
+           "numberFileset:%d, finished:%d, progress:%d, remainingTime:%" PRId64,
+           pVnodeRsp->compactId, pVnodeRsp->dnodeId, pVnodeRsp->vgId,
+           pVnodeRsp->numberFileset, pVnodeRsp->finished, pVnodeRsp->progress, pVnodeRsp->remainingTime);
+    // pack (compactId, vgId) into a single int64 key
+    int64_t key = ((int64_t)(uint32_t)pVnodeRsp->compactId << 32) | (uint32_t)pVnodeRsp->vgId;
+    code = taosHashPut(pProgressMap, &key, sizeof(key), &pVnodeRsp, sizeof(SQueryCompactProgressRsp *));
+    if (code != 0) goto _exit;
+  }
+
+  // single pass over SDB_COMPACT_DETAIL — O(n)
+  void *pIter = NULL;
+  while (1) {
+    SCompactDetailObj *pDetail = NULL;
+    pIter = sdbFetch(pMnode->pSdb, SDB_COMPACT_DETAIL, pIter, (void **)&pDetail);
+    if (pIter == NULL) break;
+
+    if (pDetail->dnodeId == rsp.dnodeId) {
+      int64_t                    key = ((int64_t)(uint32_t)pDetail->compactId << 32) | (uint32_t)pDetail->vgId;
+      SQueryCompactProgressRsp **ppVnodeRsp = taosHashGet(pProgressMap, &key, sizeof(key));
+      if (ppVnodeRsp != NULL) {
+        SQueryCompactProgressRsp *pVnodeRsp = *ppVnodeRsp;
+        pDetail->newNumberFileset = pVnodeRsp->numberFileset;
+        pDetail->newFinished      = pVnodeRsp->finished;
+        pDetail->progress         = pVnodeRsp->progress;
+        pDetail->remainingTime    = pVnodeRsp->remainingTime;
+      }
+    }
+
+    sdbRelease(pMnode->pSdb, pDetail);
+  }
+
+_exit:
+  taosHashCleanup(pProgressMap);
+  tFreeSDnodeQueryCompactProgressRsp(&rsp);
+  TAOS_RETURN(code);
 }


### PR DESCRIPTION
Replace per-vnode progress requests with dnode-level broadcast:
- Add TDMT_DND_QUERY_COMPACT_PROGRESS message type
- Add SDnodeQueryCompactProgressReq/Rsp structures and serialization
- Refactor mndCompactSendProgressReq to broadcast to all dnodes
- Add mndProcessDnodeCompactProgressRsp with hash-based O(n+m) lookup
- Add vmProcessDnodeQueryCompactProgressReq to collect vnode progress
- Register new message handler in mnode and vnode management queue

This optimization reduces the number of RPC calls from O(m*n) to O(n)
where m is the number of vnodes and n is the number of dnodes.

Reference: PR #35093

# Description

<!-- Please briefly describe the code changes in this pull request. -->

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
