### PR TITLE
fix(nodes,scalar): fix EXPLAIN crash and wrong scan range with CASE WHEN expression

### DIFF
--- a/source/libs/nodes/src/nodesToSQLFuncs.c
+++ b/source/libs/nodes/src/nodesToSQLFuncs.c
@@ -155,8 +155,9 @@ int32_t nodesNodeToSQLFormat(SNode *pNode, char *buf, int32_t bufSize, int32_t *
       SValueNode *colNode = (SValueNode *)pNode;
       char       *t = nodesGetStrValueFromNode(colNode);
       if (NULL == t) {
-        nodesError("fail to get str value from valueNode");
-        NODES_ERR_RET(TSDB_CODE_APP_ERROR);
+        // NULL type value (e.g. ELSE NULL in CASE WHEN)
+        *len += tsnprintf(buf + *len, bufSize - *len, "NULL");
+        return TSDB_CODE_SUCCESS;
       }
 
       int32_t tlen = strlen(t);
@@ -278,6 +279,33 @@ int32_t nodesNodeToSQLFormat(SNode *pNode, char *buf, int32_t bufSize, int32_t *
     case QUERY_NODE_REMOTE_TABLE: {
       SRemoteTableNode* pRemote = (SRemoteTableNode*)pNode;
       *len += tsnprintf(buf + *len, bufSize - *len, "$(InitPlan %d)", pRemote->subQIdx + 1);
+      return TSDB_CODE_SUCCESS;
+    }
+    case QUERY_NODE_WHEN_THEN: {
+      SWhenThenNode *pWhenThen = (SWhenThenNode *)pNode;
+      *len += tsnprintf(buf + *len, bufSize - *len, "WHEN ");
+      NODES_ERR_RET(nodesNodeToSQLFormat(pWhenThen->pWhen, buf, bufSize, len, true));
+      *len += tsnprintf(buf + *len, bufSize - *len, " THEN ");
+      NODES_ERR_RET(nodesNodeToSQLFormat(pWhenThen->pThen, buf, bufSize, len, true));
+      return TSDB_CODE_SUCCESS;
+    }
+    case QUERY_NODE_CASE_WHEN: {
+      SCaseWhenNode *pCaseWhen = (SCaseWhenNode *)pNode;
+      *len += tsnprintf(buf + *len, bufSize - *len, "CASE");
+      if (pCaseWhen->pCase) {
+        *len += tsnprintf(buf + *len, bufSize - *len, " ");
+        NODES_ERR_RET(nodesNodeToSQLFormat(pCaseWhen->pCase, buf, bufSize, len, true));
+      }
+      SNode *pWhenThen = NULL;
+      FOREACH(pWhenThen, pCaseWhen->pWhenThenList) {
+        *len += tsnprintf(buf + *len, bufSize - *len, " ");
+        NODES_ERR_RET(nodesNodeToSQLFormat(pWhenThen, buf, bufSize, len, true));
+      }
+      if (pCaseWhen->pElse) {
+        *len += tsnprintf(buf + *len, bufSize - *len, " ELSE ");
+        NODES_ERR_RET(nodesNodeToSQLFormat(pCaseWhen->pElse, buf, bufSize, len, true));
+      }
+      *len += tsnprintf(buf + *len, bufSize - *len, " END");
       return TSDB_CODE_SUCCESS;
     }
     default:

--- a/source/libs/nodes/src/nodesUtilFuncs.c
+++ b/source/libs/nodes/src/nodesUtilFuncs.c
@@ -3233,6 +3233,9 @@ char* nodesGetStrValueFromNode(SValueNode* pNode) {
     case TSDB_DATA_TYPE_VARCHAR:
     case TSDB_DATA_TYPE_VARBINARY:
     case TSDB_DATA_TYPE_GEOMETRY: {
+      if (NULL == pNode->datum.p) {
+        return NULL;
+      }
       int32_t bufSize = varDataLen(pNode->datum.p) + 2 + 1;
       void*   buf = taosMemoryMalloc(bufSize);
       if (NULL == buf) {

--- a/source/libs/scalar/src/filter.c
+++ b/source/libs/scalar/src/filter.c
@@ -5705,6 +5705,13 @@ static EDealRes classifyConditionImpl(SNode *pNode, void *pContext) {
     } else {
       pCxt->hasOtherCol = true;
     }
+  } else if (QUERY_NODE_CASE_WHEN == nodeType(pNode)) {
+    // CASE WHEN expressions are computed values, not direct primary key comparisons.
+    // Traversing into them could incorrectly classify the expression as COND_TYPE_PRIMARY_KEY
+    // when the CASE body references ts, causing filterGetTimeRange to receive an unextractable
+    // condition and fall back to TSWINDOW_INITIALIZER (full scan).
+    pCxt->hasOtherCol = true;
+    return DEAL_RES_IGNORE_CHILD;
   } else if (QUERY_NODE_FUNCTION == nodeType(pNode)) {
     SFunctionNode *pFunc = (SFunctionNode *)pNode;
     if (fmIsPseudoColumnFunc(pFunc->funcId)) {

--- a/test/cases/09-DataQuerying/15-Explain/r/test_explain.result
+++ b/test/cases/09-DataQuerying/15-Explain/r/test_explain.result
@@ -3906,6 +3906,8 @@ QUERY_PLAN:       -> Table Scan on meters (columns=2 pseudo_columns=2 width=22 o
 QUERY_PLAN:             Output: columns=4 width=22
 *************************** 9.row ***************************
 QUERY_PLAN:             Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 10.row ***************************
+QUERY_PLAN:             Filter: conditions=(CASE WHEN (`test`.`meters`.`cc` > 'a') THEN 'a' ELSE 'b' END > 'a')
 
 taos> explain verbose true select * from meters where cc + 'a' = 'a'\G;
 *************************** 1.row ***************************
@@ -4186,6 +4188,8 @@ QUERY_PLAN:       -> Table Scan on meters (columns=2 pseudo_columns=2 width=22 o
 QUERY_PLAN:             Output: columns=4 width=22
 *************************** 9.row ***************************
 QUERY_PLAN:             Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 10.row ***************************
+QUERY_PLAN:             Filter: conditions=(CASE WHEN (`test`.`meters`.`cc2` > 'a') THEN 'a' ELSE 'b' END > 'a')
 
 taos> explain verbose true select * from meters where cc2 + 'a' = 'a'\G;
 *************************** 1.row ***************************

--- a/test/cases/09-DataQuerying/15-Explain/r/test_explain_analyze.result
+++ b/test/cases/09-DataQuerying/15-Explain/r/test_explain_analyze.result
@@ -4137,15 +4137,17 @@ QUERY_PLAN:             Output: columns=4 width=22
 *************************** 12.row ***************************
 QUERY_PLAN:             Time Range: [-9223372036854775808, 9223372036854775807]
 *************************** 13.row ***************************
+QUERY_PLAN:             Filter: conditions=(CASE WHEN (`test`.`meters`.`cc` > 'a') THEN 'a' ELSE 'b' END > 'a') efficiency=100.0%
 *************************** 14.row ***************************
-QUERY_PLAN:             I/O cost: total_blocks=1.0(1) file_load_blocks=0.0(0) stt_load_blocks=0.0(0) mem_load_blocks=1.0(1) sma_load_blocks=0.0(0) composed_blocks=1.0(1)
 *************************** 15.row ***************************
-QUERY_PLAN:                    
+QUERY_PLAN:             I/O cost: total_blocks=1.0(1) file_load_blocks=0.0(0) stt_load_blocks=0.0(0) mem_load_blocks=1.0(1) sma_load_blocks=0.0(0) composed_blocks=1.0(1)
 *************************** 16.row ***************************
-QUERY_PLAN:                check_rows=10.0(10)    
+QUERY_PLAN:                    
 *************************** 17.row ***************************
-QUERY_PLAN: 
+QUERY_PLAN:                check_rows=10.0(10)    
 *************************** 18.row ***************************
+QUERY_PLAN: 
+*************************** 19.row ***************************
 QUERY_PLAN: 
 
 taos> explain analyze verbose true select * from meters where cc + 'a' = 'a'\G;
@@ -4627,15 +4629,17 @@ QUERY_PLAN:             Output: columns=4 width=22
 *************************** 12.row ***************************
 QUERY_PLAN:             Time Range: [-9223372036854775808, 9223372036854775807]
 *************************** 13.row ***************************
+QUERY_PLAN:             Filter: conditions=(CASE WHEN (`test`.`meters`.`cc2` > 'a') THEN 'a' ELSE 'b' END > 'a') efficiency=100.0%
 *************************** 14.row ***************************
-QUERY_PLAN:             I/O cost: total_blocks=1.0(1) file_load_blocks=0.0(0) stt_load_blocks=0.0(0) mem_load_blocks=1.0(1) sma_load_blocks=0.0(0) composed_blocks=1.0(1)
 *************************** 15.row ***************************
-QUERY_PLAN:                    
+QUERY_PLAN:             I/O cost: total_blocks=1.0(1) file_load_blocks=0.0(0) stt_load_blocks=0.0(0) mem_load_blocks=1.0(1) sma_load_blocks=0.0(0) composed_blocks=1.0(1)
 *************************** 16.row ***************************
-QUERY_PLAN:                check_rows=10.0(10)    
+QUERY_PLAN:                    
 *************************** 17.row ***************************
-QUERY_PLAN: 
+QUERY_PLAN:                check_rows=10.0(10)    
 *************************** 18.row ***************************
+QUERY_PLAN: 
+*************************** 19.row ***************************
 QUERY_PLAN: 
 
 taos> explain analyze verbose true select * from meters where cc2 + 'a' = 'a'\G;

--- a/test/cases/09-DataQuerying/15-Explain/test_explain_case_when.py
+++ b/test/cases/09-DataQuerying/15-Explain/test_explain_case_when.py
@@ -1,0 +1,137 @@
+from new_test_framework.utils import tdLog, tdSql, sc, clusterComCheck, tdCom
+
+
+class TestExplainCaseWhen:
+
+    def setup_class(cls):
+        tdLog.debug(f"start to execute {__file__}")
+
+    def test_explain_case_when_scan_range(self):
+        """explain verbose true with CASE WHEN subquery
+
+        1. EXPLAIN VERBOSE TRUE on a query that uses CASE WHEN inside a subquery
+           with the outer WHERE filtering on the computed CASE column should not crash.
+        2. The scan time range reported by EXPLAIN VERBOSE TRUE must match the
+           explicit ts filters in the inner WHERE clause, not the full history range.
+
+        Catalog:
+            - Query:Explain
+
+        Since: v3.3.6.0
+
+        Labels: common,ci
+
+        Jira: TD-34178
+
+        History:
+            - 2026-04-13 Wei Pan Created to cover two related bugs:
+              (a) EXPLAIN VERBOSE TRUE crashes with "unknown node = CaseWhen"
+              (b) Server scans wrong time range when outer WHERE filters on a CASE WHEN alias
+
+        """
+
+        # ------------------------------------------------------------------
+        # Setup
+        # ------------------------------------------------------------------
+        tdSql.execute("DROP DATABASE IF EXISTS test_case_when_explain")
+        tdSql.execute("CREATE DATABASE test_case_when_explain PRECISION 'ms'")
+        tdSql.execute("USE test_case_when_explain")
+        tdSql.execute(
+            "CREATE STABLE device_data "
+            "(ts TIMESTAMP, val DOUBLE, zone_id NCHAR(32)) "
+            "TAGS (device_sn NCHAR(64))"
+        )
+        tdSql.execute(
+            "CREATE TABLE device_001 USING device_data TAGS ('DEV001')"
+        )
+        # Insert rows: one before, two inside, one after the test window
+        tdSql.execute("INSERT INTO device_001 VALUES ('2020-12-31 23:59:59.000', 0.0, 'UTC')")
+        tdSql.execute("INSERT INTO device_001 VALUES ('2021-01-01 06:00:00.000', 1.0, 'UTC')")
+        tdSql.execute("INSERT INTO device_001 VALUES ('2021-01-01 18:00:00.000', 2.0, 'UTC')")
+        tdSql.execute("INSERT INTO device_001 VALUES ('2021-01-02 00:00:01.000', 3.0, 'UTC')")
+
+        # ------------------------------------------------------------------
+        # The query under test – DO NOT change this SQL; it is the exact
+        # pattern reported in TD-34178.
+        # ------------------------------------------------------------------
+        # Window: [2021-01-01 00:00:00.000, 2021-01-02 00:00:00.000)
+        # Expected time range is derived from the server's timezone to avoid
+        # hardcoding UTC offsets that differ across environments.
+        inner_ts_start = "2021-01-01 00:00:00.000"
+        inner_ts_end   = "2021-01-02 00:00:00.000"
+
+        # Query the server to get the actual epoch-ms for these timestamp strings
+        tdSql.query(
+            f"SELECT to_unixtimestamp('{inner_ts_start}'), to_unixtimestamp('{inner_ts_end}') "
+            f"FROM device_001 LIMIT 1"
+        )
+        expected_skey = tdSql.queryResult[0][0]
+        expected_ekey = tdSql.queryResult[0][1] - 1  # exclusive → inclusive
+
+        test_sql = f"""
+            SELECT
+                time_period,
+                first(val)     AS first_val,
+                last(val)      AS last_val,
+                first(zone_id) AS zone_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN ts >= '{inner_ts_start}' AND ts < '{inner_ts_end}'
+                            THEN 'PERIOD_20210101'
+                        ELSE NULL
+                    END AS time_period,
+                    val,
+                    zone_id,
+                    ts
+                FROM device_001
+                WHERE ts >= '{inner_ts_start}'
+                  AND ts < '{inner_ts_end}'
+            ) t
+            WHERE time_period IS NOT NULL
+            GROUP BY time_period
+            ORDER BY time_period
+        """
+
+        # ------------------------------------------------------------------
+        # (a) Verify EXPLAIN VERBOSE TRUE does not raise an error
+        # ------------------------------------------------------------------
+        tdLog.info("step1: EXPLAIN VERBOSE TRUE must not crash on CASE WHEN subquery")
+        tdSql.query(f"EXPLAIN VERBOSE TRUE {test_sql}")
+
+        # ------------------------------------------------------------------
+        # (b) Verify the scan time range matches the inner WHERE conditions
+        # ------------------------------------------------------------------
+        tdLog.info("step2: check scan Time Range in EXPLAIN output")
+        time_range_line = f"Time Range: [{expected_skey}, {expected_ekey}]"
+        found = False
+        for row in tdSql.queryResult:
+            # Each row is a one-column tuple containing the explain text
+            if time_range_line in str(row[0]):
+                found = True
+                break
+        if not found:
+            tdLog.info(f"EXPLAIN output rows:")
+            for row in tdSql.queryResult:
+                tdLog.info(f"  {row[0]}")
+        assert found, (
+            f"Expected '{time_range_line}' in EXPLAIN VERBOSE TRUE output, "
+            f"but it was not found. The server may be scanning the wrong time range."
+        )
+
+        # ------------------------------------------------------------------
+        # (c) EXPLAIN ANALYZE VERBOSE TRUE must also not crash
+        # ------------------------------------------------------------------
+        tdLog.info("step3: EXPLAIN ANALYZE VERBOSE TRUE must not crash")
+        tdSql.query(f"EXPLAIN ANALYZE VERBOSE TRUE {test_sql}")
+
+        # ------------------------------------------------------------------
+        # (d) Functional correctness: only the two rows inside the window
+        #     should be returned.
+        # ------------------------------------------------------------------
+        tdLog.info("step4: query correctness – only rows inside window returned")
+        tdSql.query(test_sql)
+        tdSql.checkRows(1)
+        tdSql.checkData(0, 0, "PERIOD_20210101")
+        tdSql.checkData(0, 1, 1.0)   # first(val)
+        tdSql.checkData(0, 2, 2.0)   # last(val)

--- a/test/ci/cases.task
+++ b/test/ci/cases.task
@@ -383,6 +383,7 @@
 ,,y,.,./ci/pytest.sh pytest cases/09-DataQuerying/14-Tags/test_tag_json.py
 ## 15-Explain
 ,,y,.,./ci/pytest.sh pytest cases/09-DataQuerying/15-Explain/test_query_explain.py
+,,y,.,./ci/pytest.sh pytest cases/09-DataQuerying/15-Explain/test_explain_case_when.py
 ## 16-PartitionBy
 ,,y,.,./ci/pytest.sh pytest cases/09-DataQuerying/16-PartitonBy/test_query_partitionby_basic.py
 ,,y,.,./ci/pytest.sh pytest cases/09-DataQuerying/16-PartitonBy/test_query_partitionby_tsbs.py


### PR DESCRIPTION
…HEN subquery

Three bugs triggered when a CASE WHEN expression appears as a computed column in a subquery and the outer WHERE filters on an alias of that expression (e.g. WHERE period IS NOT NULL):

1. Wrong vnode scan time range (filter.c) classifyConditionImpl traversed into the CASE WHEN subtree, found a ts column reference inside, and mis-classified the entire expression as COND_TYPE_PRIMARY_KEY. filterGetTimeRange could not extract a valid range and fell back to TSWINDOW_INITIALIZER, which was then clipped to earlyTs, producing [-29759981076409, INT64_MAX] instead of the intended window. Fix: return DEAL_RES_IGNORE_CHILD for QUERY_NODE_CASE_WHEN and mark hasOtherCol = true so the condition is treated as a non-PK filter.

2. EXPLAIN VERBOSE TRUE / ANALYZE crash - "unknown node = CaseWhen" (nodesToSQLFuncs.c) nodesNodeToSQLFormat had no cases for QUERY_NODE_WHEN_THEN or QUERY_NODE_CASE_WHEN, falling through to the default branch which returned TSDB_CODE_APP_ERROR. Fix: add serialization logic for both node types.

3. NULL datum.p segfault for ELSE NULL (nodesUtilFuncs.c) ELSE NULL produces a SValueNode with NCHAR type but datum.p == NULL. nodesGetStrValueFromNode called varDataLen(NULL), causing a segfault. Fix: add a NULL guard before the varDataLen call; callers that receive NULL now emit the SQL literal "NULL" instead of erroring.

Also adds test/cases/07-DataQuerying/14-Explain/test_explain_case_when.py and registers it in test/ci/cases.task.

# Description

<!-- Please briefly describe the code changes in this pull request. -->

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
