### PR TITLE
[3.3.6] backport Linux non-root packaging scripts

### DIFF
--- a/packaging/smokeTest/test_install_sh_client_uninstall_entrypoint.sh
+++ b/packaging/smokeTest/test_install_sh_client_uninstall_entrypoint.sh
@@ -13,25 +13,38 @@ NC='\033[0m'
 pass=0
 fail=0
 
-check_client_branch_contains() {
-  local description="$1"
-  local pattern="$2"
+extract_install_bin_client_branch() {
+  awk '
+    /^[[:space:]]*function install_bin\(\)/ { in_function = 1 }
+    in_function { print }
+    in_function && /^[[:space:]]*}/ { exit }
+  ' "$INSTALL_SH" | awk '
+    /^[[:space:]]*if \[ "\$\{verType\}" == "client" \]; then$/ { in_branch = 1; next }
+    in_branch && /^[[:space:]]*else$/ { exit }
+    in_branch { print }
+  '
+}
 
-  if awk '/if \[ "\$verType" == "client" \]; then/,/^[[:space:]]*else$/' "$INSTALL_SH" | grep -qF "$pattern"; then
-    echo -e "  ${GREEN}PASS${NC}: $description"
-    ((pass++)) || true
-  else
-    echo -e "  ${RED}FAIL${NC}: $description"
-    echo "       Expected client branch in $INSTALL_SH to contain: '$pattern'"
-    ((fail++)) || true
-  fi
+extract_client_remove_name_branch() {
+  awk '
+    !in_branch && /^[[:space:]]*if \[ "\$verType" == "client" \]; then$/ { in_branch = 1 }
+    in_branch { print }
+    in_branch && /^[[:space:]]*else$/ { exit }
+  ' "$INSTALL_SH"
 }
 
 check_client_branch_absent() {
   local description="$1"
   local pattern="$2"
+  local client_branch
 
-  if awk '/if \[ "\$verType" == "client" \]; then/,/^[[:space:]]*else$/' "$INSTALL_SH" | grep -qF "$pattern"; then
+  client_branch="$(extract_install_bin_client_branch)"
+
+  if [[ -z "${client_branch}" ]]; then
+    echo -e "  ${RED}FAIL${NC}: ${description}"
+    echo "       Failed to locate install_bin() client branch in $INSTALL_SH"
+    ((fail++)) || true
+  elif grep -qF "$pattern" <<<"$client_branch"; then
     echo -e "  ${RED}FAIL${NC}: $description"
     echo "       Found forbidden pattern '$pattern' in client branch of $INSTALL_SH"
     ((fail++)) || true
@@ -43,15 +56,26 @@ check_client_branch_absent() {
 
 check_client_uninstall_backend() {
   local client_branch
+  local remove_name_branch
 
-  client_branch="$(awk '/if \[ "\$verType" == "client" \]; then/,/^[[:space:]]*else$/' "$INSTALL_SH")"
+  client_branch="$(extract_install_bin_client_branch)"
+  remove_name_branch="$(extract_client_remove_name_branch)"
 
-  if grep -qF 'remove_name="remove.sh"' <<<"$client_branch" || grep -qF 'cp -r ${script_dir}/bin/remove.sh ${install_main_dir}/bin' "$INSTALL_SH"; then
+  if [[ -z "${client_branch}" ]]; then
+    echo -e "  ${RED}FAIL${NC}: client mode uses remove.sh as uninstall backend"
+    echo "       Failed to locate install_bin() client branch in $INSTALL_SH"
+    ((fail++)) || true
+  elif grep -qF 'cp -r ${script_dir}/bin/remove.sh ${install_main_dir}/bin' <<<"$client_branch"; then
+    echo -e "  ${GREEN}PASS${NC}: client mode uses remove.sh as uninstall backend"
+    ((pass++)) || true
+  elif grep -qF 'cp -r ${script_dir}/bin/${remove_name} ${install_main_dir}/bin' <<<"$client_branch" \
+    && grep -qF 'remove_name="remove.sh"' <<<"$remove_name_branch" \
+    && ! grep -qF 'remove_name="remove_client.sh"' <<<"$remove_name_branch"; then
     echo -e "  ${GREEN}PASS${NC}: client mode uses remove.sh as uninstall backend"
     ((pass++)) || true
   else
     echo -e "  ${RED}FAIL${NC}: client mode uses remove.sh as uninstall backend"
-    echo "       Expected install.sh client flow to select or copy remove.sh"
+    echo "       Expected install.sh client flow to copy remove.sh directly or via remove_name=remove.sh"
     ((fail++)) || true
   fi
 }

--- a/packaging/smokeTest/test_install_sh_client_uninstall_entrypoint.sh
+++ b/packaging/smokeTest/test_install_sh_client_uninstall_entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGING_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+INSTALL_SH="${PACKAGING_DIR}/tools/install.sh"
+
+RED='\033[0;31m'
+GREEN='\033[1;32m'
+NC='\033[0m'
+
+pass=0
+fail=0
+
+check_client_branch_contains() {
+  local description="$1"
+  local pattern="$2"
+
+  if awk '/if \[ "\$verType" == "client" \]; then/,/^[[:space:]]*else$/' "$INSTALL_SH" | grep -qF "$pattern"; then
+    echo -e "  ${GREEN}PASS${NC}: $description"
+    ((pass++)) || true
+  else
+    echo -e "  ${RED}FAIL${NC}: $description"
+    echo "       Expected client branch in $INSTALL_SH to contain: '$pattern'"
+    ((fail++)) || true
+  fi
+}
+
+check_client_branch_absent() {
+  local description="$1"
+  local pattern="$2"
+
+  if awk '/if \[ "\$verType" == "client" \]; then/,/^[[:space:]]*else$/' "$INSTALL_SH" | grep -qF "$pattern"; then
+    echo -e "  ${RED}FAIL${NC}: $description"
+    echo "       Found forbidden pattern '$pattern' in client branch of $INSTALL_SH"
+    ((fail++)) || true
+  else
+    echo -e "  ${GREEN}PASS${NC}: $description"
+    ((pass++)) || true
+  fi
+}
+
+check_client_uninstall_backend() {
+  local client_branch
+
+  client_branch="$(awk '/if \[ "\$verType" == "client" \]; then/,/^[[:space:]]*else$/' "$INSTALL_SH")"
+
+  if grep -qF 'remove_name="remove.sh"' <<<"$client_branch" || grep -qF 'cp -r ${script_dir}/bin/remove.sh ${install_main_dir}/bin' "$INSTALL_SH"; then
+    echo -e "  ${GREEN}PASS${NC}: client mode uses remove.sh as uninstall backend"
+    ((pass++)) || true
+  else
+    echo -e "  ${RED}FAIL${NC}: client mode uses remove.sh as uninstall backend"
+    echo "       Expected install.sh client flow to select or copy remove.sh"
+    ((fail++)) || true
+  fi
+}
+
+echo "=== install.sh client uninstall entrypoint guard ==="
+echo
+
+check_client_uninstall_backend
+check_client_branch_absent "client mode does not select remove_client.sh" 'remove_name="remove_client.sh"'
+
+echo
+if [[ $fail -gt 0 ]]; then
+  echo -e "${RED}FAILED${NC}: $fail check(s) failed, $pass passed"
+  exit 1
+else
+  echo -e "${GREEN}install.sh client uninstall entrypoint guard passed${NC} ($pass/$((pass+fail)))"
+  exit 0
+fi

--- a/packaging/smokeTest/test_install_sh_client_uninstall_entrypoint_guard_selftest.sh
+++ b/packaging/smokeTest/test_install_sh_client_uninstall_entrypoint_guard_selftest.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD_SCRIPT="${SCRIPT_DIR}/test_install_sh_client_uninstall_entrypoint.sh"
+
+RED='\033[0;31m'
+GREEN='\033[1;32m'
+NC='\033[0m'
+
+pass=0
+fail=0
+
+create_fixture() {
+  local fixture_dir="$1"
+  local prelude_block="$2"
+  local client_block="$3"
+  local server_block="$4"
+
+  mkdir -p "${fixture_dir}/smokeTest" "${fixture_dir}/tools"
+  cp "${GUARD_SCRIPT}" "${fixture_dir}/smokeTest/test_install_sh_client_uninstall_entrypoint.sh"
+
+  cat > "${fixture_dir}/tools/install.sh" <<EOF
+#!/bin/bash
+
+${prelude_block}
+
+function install_bin() {
+  if [ "\${verType}" == "client" ]; then
+${client_block}
+  else
+${server_block}
+  fi
+}
+
+elif [ "\$verType" == "client" ]; then
+  interactiveFqdn=no
+  if [ -x \${bin_dir}/\${clientName} ]; then
+    update_flag=1
+    updateProduct client
+  else
+    installProduct client
+  fi
+else
+  echo "please input correct verType"
+fi
+EOF
+}
+
+run_case() {
+  local description="$1"
+  local expected_status="$2"
+  local fixture_dir="$3"
+
+  local status=0
+  set +e
+  bash "${fixture_dir}/smokeTest/test_install_sh_client_uninstall_entrypoint.sh" >/tmp/guard-selftest.log 2>&1
+  status=$?
+  set -e
+
+  if [[ "${expected_status}" == "pass" && ${status} -eq 0 ]] || [[ "${expected_status}" == "fail" && ${status} -ne 0 ]]; then
+    echo -e "  ${GREEN}PASS${NC}: ${description}"
+    ((pass++)) || true
+  else
+    echo -e "  ${RED}FAIL${NC}: ${description}"
+    cat /tmp/guard-selftest.log | sed 's/^/       /'
+    ((fail++)) || true
+  fi
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}" /tmp/guard-selftest.log' EXIT
+
+create_fixture "${tmp_dir}/good-direct" \
+"" \
+"    cp -r \${script_dir}/bin/remove.sh \${install_main_dir}/bin" \
+"    cp -r \${script_dir}/bin/remove.sh \${install_main_dir}/bin"
+
+create_fixture "${tmp_dir}/good-variable" \
+"if [ \"\$verType\" == \"client\" ]; then
+  remove_name=\"remove.sh\"
+else
+  remove_name=\"remove.sh\"
+fi" \
+"    remove_name=\"remove.sh\"
+    cp -r \${script_dir}/bin/\${remove_name} \${install_main_dir}/bin" \
+"    remove_name=\"remove.sh\"
+    cp -r \${script_dir}/bin/\${remove_name} \${install_main_dir}/bin"
+
+create_fixture "${tmp_dir}/bad-direct" \
+"" \
+"    cp -r \${script_dir}/bin/remove_client.sh \${install_main_dir}/bin" \
+"    cp -r \${script_dir}/bin/remove.sh \${install_main_dir}/bin"
+
+create_fixture "${tmp_dir}/bad-variable" \
+"if [ \"\$verType\" == \"client\" ]; then
+  remove_name=\"remove_client.sh\"
+else
+  remove_name=\"remove.sh\"
+fi" \
+"    remove_name=\"remove_client.sh\"
+    cp -r \${script_dir}/bin/\${remove_name} \${install_main_dir}/bin" \
+"    remove_name=\"remove.sh\"
+    cp -r \${script_dir}/bin/\${remove_name} \${install_main_dir}/bin"
+
+echo "=== install.sh client uninstall entrypoint guard self-test ==="
+echo
+
+run_case "accepts direct-copy remove.sh client branch" pass "${tmp_dir}/good-direct"
+run_case "accepts variable-based remove.sh client branch" pass "${tmp_dir}/good-variable"
+run_case "rejects direct-copy remove_client.sh client branch" fail "${tmp_dir}/bad-direct"
+run_case "rejects variable-based remove_client.sh client branch" fail "${tmp_dir}/bad-variable"
+
+echo
+if [[ $fail -gt 0 ]]; then
+  echo -e "${RED}FAILED${NC}: $fail check(s) failed, $pass passed"
+  exit 1
+else
+  echo -e "${GREEN}guard self-test passed${NC} ($pass/$((pass+fail)))"
+fi

--- a/packaging/smokeTest/test_non_root_client_packaging_backport.sh
+++ b/packaging/smokeTest/test_non_root_client_packaging_backport.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Regression guard for client packaging non-root support.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGING_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+INSTALL_CLIENT_SH="${PACKAGING_DIR}/tools/install_client.sh"
+REMOVE_CLIENT_SH="${PACKAGING_DIR}/tools/remove_client.sh"
+
+RED='\033[0;31m'
+GREEN='\033[1;32m'
+NC='\033[0m'
+
+pass=0
+fail=0
+
+check() {
+  local description="$1"
+  local file="$2"
+  local pattern="$3"
+
+  if grep -qF "$pattern" "$file"; then
+    echo -e "  ${GREEN}PASS${NC}: $description"
+    ((pass++)) || true
+  else
+    echo -e "  ${RED}FAIL${NC}: $description"
+    echo "       Expected to find: '$pattern' in $file"
+    ((fail++)) || true
+  fi
+}
+
+check_absent() {
+  local description="$1"
+  local file="$2"
+  local pattern="$3"
+
+  if grep -qE "$pattern" "$file"; then
+    echo -e "  ${RED}FAIL${NC}: $description"
+    echo "       Found forbidden pattern '$pattern' in $file:"
+    grep -nE "$pattern" "$file" | head -5 | sed 's/^/         /'
+    ((fail++)) || true
+  else
+    echo -e "  ${GREEN}PASS${NC}: $description"
+    ((pass++)) || true
+  fi
+}
+
+check_function_contains() {
+  local description="$1"
+  local file="$2"
+  local function_name="$3"
+  local pattern="$4"
+
+  if awk "/^function ${function_name}\\(\\)/,/^}/" "$file" | grep -qE "$pattern"; then
+    echo -e "  ${GREEN}PASS${NC}: $description"
+    ((pass++)) || true
+  else
+    echo -e "  ${RED}FAIL${NC}: $description"
+    echo "       Expected function ${function_name}() in $file to contain pattern: '$pattern'"
+    ((fail++)) || true
+  fi
+}
+
+echo "=== community client packaging regression guard ==="
+echo
+
+echo "--- install_client.sh checks ---"
+check "function setup_env() exists" "$INSTALL_CLIENT_SH" "function setup_env()"
+check '$HOME/.local/bin in install_client.sh' "$INSTALL_CLIENT_SH" '$HOME/.local/bin'
+check ".install_path written in install_client.sh" "$INSTALL_CLIENT_SH" ".install_path"
+check "non-root client install checks for conflicting system-wide install" "$INSTALL_CLIENT_SH" "check_conflicting_system_installation"
+check "non-root client install explains conflicting system-wide install" "$INSTALL_CLIENT_SH" "A system-wide TDengine installation was detected"
+check "log self-link guard in install_client.sh" "$INSTALL_CLIENT_SH" '!= "${install_main_dir}/log"'
+check "config self-link guard in install_client.sh" "$INSTALL_CLIENT_SH" '!= "${install_main_dir}/cfg"'
+check_function_contains "install_main_path preserves user config" "$INSTALL_CLIENT_SH" "install_main_path" 'if \[ "\$user_mode" -eq 0 \]; then'
+check "non-root install_client.sh exports LD_LIBRARY_PATH" "$INSTALL_CLIENT_SH" 'export LD_LIBRARY_PATH=\"${lib_link_dir}:\$LD_LIBRARY_PATH\"'
+check "non-root install_client.sh updates shell rc file" "$INSTALL_CLIENT_SH" 'env_file="${HOME}/.bashrc"'
+check "non-root install_client.sh chooses rc file from login shell" "$INSTALL_CLIENT_SH" 'login_shell="${SHELL##*/}"'
+check_function_contains "install_lib cache refresh is root-only" "$INSTALL_CLIENT_SH" "install_lib" 'if \[ "\$user_mode" -eq 0 \]; then'
+check_function_contains "install_jemalloc skips user mode" "$INSTALL_CLIENT_SH" "install_jemalloc" 'if \[ "\$user_mode" -ne 0 \]; then'
+check_absent "no sudo/csudo in install_client.sh" "$INSTALL_CLIENT_SH" 'sudo|csudo'
+
+echo
+echo "--- remove_client.sh checks ---"
+check "validate_safe_path() in remove_client.sh" "$REMOVE_CLIENT_SH" "validate_safe_path"
+check '$HOME/.local/bin in remove_client.sh' "$REMOVE_CLIENT_SH" '$HOME/.local/bin'
+check ".install_path used in remove_client.sh" "$REMOVE_CLIENT_SH" ".install_path"
+check "preserve internal cfg/log in remove_client.sh" "$REMOVE_CLIENT_SH" 'find "${install_main_dir}" -mindepth 1 -maxdepth 1'
+check_absent "portable process lookup in remove_client.sh" "$REMOVE_CLIENT_SH" 'ps -C'
+check "remove_client.sh uses exact command matching" "$REMOVE_CLIENT_SH" 'ps -eo pid=,user=,comm='
+check "remove_client.sh limits user-mode kill to current user" "$REMOVE_CLIENT_SH" 'current_user=$(id -un)'
+check "remove_client.sh filters by exact tool names" "$REMOVE_CLIENT_SH" 'client_processes=('
+check_absent "remove_client.sh avoids broad grep by clientName2" "$REMOVE_CLIENT_SH" 'grep "\$\{clientName2\}"'
+check_absent "no sudo/csudo in remove_client.sh" "$REMOVE_CLIENT_SH" 'sudo|csudo'
+
+echo
+if [[ $fail -gt 0 ]]; then
+  echo -e "${RED}FAILED${NC}: $fail check(s) failed, $pass passed"
+  exit 1
+else
+  echo -e "${GREEN}community client packaging guards passed${NC} ($pass/$((pass+fail)))"
+  exit 0
+fi

--- a/packaging/smokeTest/test_non_root_server_packaging_backport.sh
+++ b/packaging/smokeTest/test_non_root_server_packaging_backport.sh
@@ -126,7 +126,7 @@ check "remove.sh removes xnode data when present" "$REMOVE_SH" '${data_dir}/xnod
 check "remove.sh removes taosx data" "$REMOVE_SH" '${data_dir}/${PREFIX}x'
 check "remove.sh removes explorer data" "$REMOVE_SH" '${data_dir}/explorer'
 check "remove.sh removes backup data" "$REMOVE_SH" '${data_dir}/backup'
-check "remove.sh cleans bundled taosx uninstall hook" "$REMOVE_SH" 'rm -f ${install_main_dir}/uninstall_${PREFIX}x.sh'
+check "remove.sh cleans bundled taosx uninstall hook" "$REMOVE_SH" '"${install_main_dir}/uninstall_${PREFIX}x.sh"'
 check_absent "remove.sh does not execute bundled taosx uninstall hook" "$REMOVE_SH" 'bash \${install_main_dir}/uninstall_\$\{PREFIX\}x\.sh'
 check_absent "no sudo/csudo in remove.sh"     "$REMOVE_SH"  'sudo|csudo'
 

--- a/packaging/smokeTest/test_non_root_server_packaging_backport.sh
+++ b/packaging/smokeTest/test_non_root_server_packaging_backport.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Regression guard: verifies that the 3.3.6 server packaging scripts have
+# been backported with the non-root (user-mode) support from main.
+#
+# Checks:
+#   install.sh  - function setup_env(), systemctl --user, .install_path
+#   remove.sh   - validate_safe_path(), systemctl --user, .install_path
+#
+# Exit 0 on success, 1 on failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGING_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+INSTALL_SH="${PACKAGING_DIR}/tools/install.sh"
+REMOVE_SH="${PACKAGING_DIR}/tools/remove.sh"
+
+RED='\033[0;31m'
+GREEN='\033[1;32m'
+NC='\033[0m'
+
+pass=0
+fail=0
+
+check() {
+  local description="$1"
+  local file="$2"
+  local pattern="$3"
+
+  if grep -qF "$pattern" "$file"; then
+    echo -e "  ${GREEN}PASS${NC}: $description"
+    ((pass++)) || true
+  else
+    echo -e "  ${RED}FAIL${NC}: $description"
+    echo "       Expected to find: '$pattern' in $file"
+    ((fail++)) || true
+  fi
+}
+
+echo "=== community server packaging regression guard ==="
+echo
+
+echo "--- install.sh checks ---"
+check "function setup_env() exists"           "$INSTALL_SH" "function setup_env()"
+check "systemctl --user in install.sh"        "$INSTALL_SH" "systemctl --user"
+check ".install_path written in install.sh"   "$INSTALL_SH" ".install_path"
+
+echo
+echo "--- remove.sh checks ---"
+check "validate_safe_path() in remove.sh"     "$REMOVE_SH"  "validate_safe_path"
+check "systemctl --user in remove.sh"         "$REMOVE_SH"  "systemctl --user"
+check ".install_path used in remove.sh"       "$REMOVE_SH"  ".install_path"
+
+echo
+if [[ $fail -gt 0 ]]; then
+  echo -e "${RED}FAILED${NC}: $fail check(s) failed, $pass passed"
+  exit 1
+else
+  echo -e "${GREEN}community server packaging guards passed${NC} ($pass/$((pass+fail)))"
+  exit 0
+fi

--- a/packaging/smokeTest/test_non_root_server_packaging_backport.sh
+++ b/packaging/smokeTest/test_non_root_server_packaging_backport.sh
@@ -14,6 +14,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PACKAGING_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 INSTALL_SH="${PACKAGING_DIR}/tools/install.sh"
 REMOVE_SH="${PACKAGING_DIR}/tools/remove.sh"
+START_PRE_SH="${PACKAGING_DIR}/tools/startPre.sh"
 
 RED='\033[0;31m'
 GREEN='\033[1;32m'
@@ -53,6 +54,22 @@ check_absent() {
   fi
 }
 
+check_function_contains() {
+  local description="$1"
+  local file="$2"
+  local function_name="$3"
+  local pattern="$4"
+
+  if awk "/^function ${function_name}\\(\\)/,/^}/" "$file" | grep -qE "$pattern"; then
+    echo -e "  ${GREEN}PASS${NC}: $description"
+    ((pass++)) || true
+  else
+    echo -e "  ${RED}FAIL${NC}: $description"
+    echo "       Expected function ${function_name}() in $file to contain pattern: '$pattern'"
+    ((fail++)) || true
+  fi
+}
+
 echo "=== community server packaging regression guard ==="
 echo
 
@@ -60,6 +77,31 @@ echo "--- install.sh checks ---"
 check "function setup_env() exists"           "$INSTALL_SH" "function setup_env()"
 check "systemctl --user in install.sh"        "$INSTALL_SH" "systemctl --user"
 check ".install_path written in install.sh"   "$INSTALL_SH" ".install_path"
+check "non-root install checks for conflicting system-wide install" "$INSTALL_SH" "check_conflicting_system_installation"
+check "non-root install explains conflicting system-wide install" "$INSTALL_SH" "A system-wide TDengine installation was detected"
+check "log self-link guard in install.sh"     "$INSTALL_SH" '!= "${install_main_dir}/log"'
+check "config self-link guard in install.sh"  "$INSTALL_SH" '!= "${install_main_dir}/cfg"'
+check "x/explorer units sourced from taosx systemd dir" "$INSTALL_SH" '${script_dir}/${xname}/etc/systemd/system'
+check "taosx appended to services when packaged" "$INSTALL_SH" 'services=(${services[@]} ${xname})'
+check_function_contains "install_main_path preserves user config" "$INSTALL_SH" "install_main_path" 'if \[\[ \$user_mode -eq 0 \]\]; then'
+check "non-root install.sh exports LD_LIBRARY_PATH" "$INSTALL_SH" 'export LD_LIBRARY_PATH=\"${lib_link_dir}:\$LD_LIBRARY_PATH\"'
+check "non-root install.sh updates shell rc file" "$INSTALL_SH" 'env_file="${HOME}/.bashrc"'
+check "non-root install.sh chooses rc file from login shell" "$INSTALL_SH" 'login_shell="${SHELL##*/}"'
+check_function_contains "install_lib cache refresh is root-only" "$INSTALL_SH" "install_lib" 'if \[ "\$user_mode" -eq 0 \]; then'
+check_function_contains "install_jemalloc skips user mode" "$INSTALL_SH" "install_jemalloc" 'if \[ "\$user_mode" -ne 0 \]; then'
+check_function_contains "install_service_on_systemd skips missing units" "$INSTALL_SH" "install_service_on_systemd" 'if \[ ! -f \${cfg_source_dir}/\$1\.service \]; then'
+check "user-mode systemd units export LD_LIBRARY_PATH" "$INSTALL_SH" 'Environment=\"LD_LIBRARY_PATH=${lib_link_dir}\"'
+check "user-mode taos.cfg rewrite helper" "$INSTALL_SH" 'set_taos_cfg_value'
+check_function_contains "taosx config rewrites data_dir for user mode" "$INSTALL_SH" "install_taosx_config" 'dataDir}/\${xname}'
+check_function_contains "taosx config rewrites log path for user mode" "$INSTALL_SH" "install_taosx_config" 'logDir'
+check "explorer config prefers packaged taosx source" "$INSTALL_SH" '${script_dir}/${xname}/etc/${PREFIX}/explorer.toml'
+check_function_contains "explorer config rewrites data_dir for user mode" "$INSTALL_SH" "install_explorer_config" 'dataDir}/explorer'
+check_function_contains "adapter config rewrites taosConfigDir" "$INSTALL_SH" "install_adapter_config" 'taosConfigDir'
+check_function_contains "keeper config rewrites log path" "$INSTALL_SH" "install_keeper_config" 'logDir'
+check "user-mode taosd unit rewrite" "$INSTALL_SH" '${install_main_dir}/bin/${serverName} -c ${configDir}'
+check "user-mode taosadapter unit rewrite" "$INSTALL_SH" '${install_main_dir}/bin/${adapterName} -c ${configDir}/${adapterName}.toml'
+check "user-mode taos-explorer unit rewrite" "$INSTALL_SH" '${install_main_dir}/bin/${explorerName} -c ${configDir}/explorer.toml'
+check "user-mode taosx unit rewrite" "$INSTALL_SH" '${install_main_dir}/bin/${xname} serve -c ${configDir}/${xname}.toml'
 check_absent "no sudo/csudo in install.sh"    "$INSTALL_SH" 'sudo|csudo'
 
 echo
@@ -67,7 +109,31 @@ echo "--- remove.sh checks ---"
 check "validate_safe_path() in remove.sh"     "$REMOVE_SH"  "validate_safe_path"
 check "systemctl --user in remove.sh"         "$REMOVE_SH"  "systemctl --user"
 check ".install_path used in remove.sh"       "$REMOVE_SH"  ".install_path"
+check 'user-mode data_dir default in remove.sh' "$REMOVE_SH" 'data_dir="${installDir}/data"'
+check 'user-mode log_dir default in remove.sh'  "$REMOVE_SH" 'log_dir="${installDir}/log"'
+check "preserve internal data/cfg/log in remove.sh" "$REMOVE_SH" 'find "${install_main_dir}" -mindepth 1 -maxdepth 1'
+check "remove.sh user-mode kill only targets current user" "$REMOVE_SH" 'current_user=$(id -un)'
+check_absent "remove.sh avoids broad ps aux grep for service kill" "$REMOVE_SH" 'ps aux \| grep -w \$_service'
+check "remove.sh root-mode kill inspects process args" "$REMOVE_SH" 'ps -eo pid=,args='
+check "remove.sh root-mode kill scopes by exact -c target" "$REMOVE_SH" 'cfg_arg == config_dir || index(cfg_arg, config_dir "/") == 1'
+check "remove.sh root-mode kill handles default root config without -c" "$REMOVE_SH" 'cfg_match == -1 && allow_default_root_config == 1'
+check_absent "remove.sh root-mode kill avoids raw substring config matching" "$REMOVE_SH" 'index\(cmd, config_dir\) > 0'
+check_absent "remove.sh avoids command-name-only root matching" "$REMOVE_SH" 'ps -eo pid=,comm='
+check "remove.sh full cluster includes taosx service" "$REMOVE_SH" 'services=(${PREFIX}"d" ${PREFIX}"adapter" ${PREFIX}"keeper" ${PREFIX}"x" ${PREFIX}"-explorer")'
+check "remove.sh appends taosx service when packaged" "$REMOVE_SH" 'services=(${services[@]} ${xName})'
+check "remove.sh removes snode data" "$REMOVE_SH" '${data_dir}/snode'
+check "remove.sh removes xnode data when present" "$REMOVE_SH" '${data_dir}/xnode'
+check "remove.sh removes taosx data" "$REMOVE_SH" '${data_dir}/${PREFIX}x'
+check "remove.sh removes explorer data" "$REMOVE_SH" '${data_dir}/explorer'
+check "remove.sh removes backup data" "$REMOVE_SH" '${data_dir}/backup'
+check "remove.sh cleans bundled taosx uninstall hook" "$REMOVE_SH" 'rm -f ${install_main_dir}/uninstall_${PREFIX}x.sh'
+check_absent "remove.sh does not execute bundled taosx uninstall hook" "$REMOVE_SH" 'bash \${install_main_dir}/uninstall_\$\{PREFIX\}x\.sh'
 check_absent "no sudo/csudo in remove.sh"     "$REMOVE_SH"  'sudo|csudo'
+
+echo
+echo "--- startPre.sh checks ---"
+check 'startPre.sh uses user service dir' "$START_PRE_SH" '$HOME/.config/systemd/user'
+check 'startPre.sh uses systemctl --user' "$START_PRE_SH" 'systemctl --user'
 
 echo
 if [[ $fail -gt 0 ]]; then

--- a/packaging/smokeTest/test_non_root_server_packaging_backport.sh
+++ b/packaging/smokeTest/test_non_root_server_packaging_backport.sh
@@ -3,8 +3,8 @@
 # been backported with the non-root (user-mode) support from main.
 #
 # Checks:
-#   install.sh  - function setup_env(), systemctl --user, .install_path
-#   remove.sh   - validate_safe_path(), systemctl --user, .install_path
+#   install.sh  - function setup_env(), systemctl --user, .install_path, no sudo/csudo
+#   remove.sh   - validate_safe_path(), systemctl --user, .install_path, no sudo/csudo
 #
 # Exit 0 on success, 1 on failure.
 
@@ -37,6 +37,22 @@ check() {
   fi
 }
 
+check_absent() {
+  local description="$1"
+  local file="$2"
+  local pattern="$3"
+
+  if grep -qE "$pattern" "$file"; then
+    echo -e "  ${RED}FAIL${NC}: $description"
+    echo "       Found forbidden pattern '$pattern' in $file:"
+    grep -nE "$pattern" "$file" | head -5 | sed 's/^/         /'
+    ((fail++)) || true
+  else
+    echo -e "  ${GREEN}PASS${NC}: $description"
+    ((pass++)) || true
+  fi
+}
+
 echo "=== community server packaging regression guard ==="
 echo
 
@@ -44,12 +60,14 @@ echo "--- install.sh checks ---"
 check "function setup_env() exists"           "$INSTALL_SH" "function setup_env()"
 check "systemctl --user in install.sh"        "$INSTALL_SH" "systemctl --user"
 check ".install_path written in install.sh"   "$INSTALL_SH" ".install_path"
+check_absent "no sudo/csudo in install.sh"    "$INSTALL_SH" 'sudo|csudo'
 
 echo
 echo "--- remove.sh checks ---"
 check "validate_safe_path() in remove.sh"     "$REMOVE_SH"  "validate_safe_path"
 check "systemctl --user in remove.sh"         "$REMOVE_SH"  "systemctl --user"
 check ".install_path used in remove.sh"       "$REMOVE_SH"  ".install_path"
+check_absent "no sudo/csudo in remove.sh"     "$REMOVE_SH"  'sudo|csudo'
 
 echo
 if [[ $fail -gt 0 ]]; then

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -71,23 +71,9 @@ prompt_force=0
 
 initd_mod=0
 service_mod=2
-if ps aux | grep -v grep | grep systemd &>/dev/null; then
-  service_mod=0
-elif $(which service &>/dev/null); then
-  service_mod=1
-  service_config_dir="/etc/init.d"
-  if $(which chkconfig &>/dev/null); then
-    initd_mod=1
-  elif $(which insserv &>/dev/null); then
-    initd_mod=2
-  elif $(which update-rc.d &>/dev/null); then
-    initd_mod=3
-  else
-    service_mod=2
-  fi
-else
-  service_mod=2
-fi
+# User mode and service command are initialized in setup_env() below.
+user_mode=0
+sysctl_cmd="systemctl"
 
 # get the operating system type for using the corresponding init file
 # ubuntu/debian(deb), centos/fedora(rpm), others: opensuse, redhat, ..., no verification
@@ -180,6 +166,69 @@ else
 fi
 driver_path=${install_main_dir}/driver
 
+function setup_env() {
+  # Service manager detection
+  if ps aux | grep -v grep | grep systemd &>/dev/null; then
+    service_mod=0
+  elif $(which service &>/dev/null); then
+    service_mod=1
+    service_config_dir="/etc/init.d"
+    if $(which chkconfig &>/dev/null); then
+      initd_mod=1
+    elif $(which insserv &>/dev/null); then
+      initd_mod=2
+    elif $(which update-rc.d &>/dev/null); then
+      initd_mod=3
+    else
+      service_mod=2
+    fi
+  else
+    service_mod=2
+  fi
+
+  # User mode detection
+  if [[ "$(id -u)" -ne 0 ]]; then
+    if ! systemctl --user show-environment &>/dev/null; then
+      echo -e "${RED}Current user is not root and no systemd user session (user bus) is available.${NC}"
+      echo -e "A systemd user session is required so the installer can manage per-user systemd services."
+      exit 1
+    fi
+    user_mode=1
+    installDir="$HOME/${PREFIX}"
+    mode_desc="user ($(whoami))"
+  else
+    user_mode=0
+    mode_desc="root (system-wide)"
+  fi
+
+  # Directory initialization based on user mode
+  if [[ $user_mode -eq 0 ]]; then
+    dataDir="/var/lib/${PREFIX}"
+    logDir="/var/log/${PREFIX}"
+    configDir="/etc/${PREFIX}"
+    bin_link_dir="/usr/bin"
+    lib_link_dir="/usr/lib"
+    lib64_link_dir="/usr/lib64"
+    inc_link_dir="/usr/include"
+    service_config_dir="/etc/systemd/system"
+    sysctl_cmd="systemctl"
+  else
+    dataDir="${installDir}/data"
+    logDir="${installDir}/log"
+    configDir="${installDir}/cfg"
+    bin_link_dir="$HOME/.local/bin"
+    lib_link_dir="$HOME/.local/lib"
+    lib64_link_dir="$HOME/.local/lib64"
+    inc_link_dir="$HOME/.local/include"
+    service_config_dir="$HOME/.config/systemd/user"
+    sysctl_cmd="systemctl --user"
+    mkdir -p "$bin_link_dir" "$lib_link_dir" "$inc_link_dir" "$lib64_link_dir" "$service_config_dir"
+  fi
+
+  install_main_dir="${installDir}"
+  bin_dir="${installDir}/bin"
+  driver_path="${install_main_dir}/driver"
+}
 
 function install_services() {
   for service in "${services[@]}"; do
@@ -951,6 +1000,7 @@ function updateProduct() {
   fi
 
   install_main_path
+  echo "${install_main_dir}" > "${install_main_dir}/.install_path"
 
   install_log
   install_header
@@ -1039,6 +1089,7 @@ function installProduct() {
   echo "Start to install ${productName}..."
 
   install_main_path
+  echo "${install_main_dir}" > "${install_main_dir}/.install_path"
 
   if [ -z $1 ]; then
     install_data
@@ -1151,6 +1202,8 @@ check_java_env() {
 }
 
 ## ==============================Main program starts from here============================
+# Initialize environment: user mode, service manager, and directory variables
+setup_env
 serverFqdn=$(hostname)
 if [ "$verType" == "server" ]; then
   if [ -x ${script_dir}/${xname}/bin/${xname} ]; then

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -573,9 +573,10 @@ function add_newHostname_to_hosts() {
 
   if grep -q "127.0.0.1  $1" /etc/hosts; then
     return
-  else
-    chmod 666 /etc/hosts
+  elif [ -w /etc/hosts ]; then
     echo "127.0.0.1  $1" >>/etc/hosts
+  else
+    echo "Warning: /etc/hosts is not writable, skipping hostname addition"
   fi
 }
 
@@ -956,7 +957,7 @@ function install_service_on_sysvinit() {
     chkconfig --add $1 || :
     chkconfig --level 2345 $1 on || :
   elif ((${initd_mod} == 2)); then
-    insserv $1} || :
+    insserv $1 || :
     insserv -d $1 || :
   elif ((${initd_mod} == 3)); then
     update-rc.d $1 defaults || :

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -1055,6 +1055,7 @@ function rewrite_systemd_service_for_user_mode() {
   sed -i \
     -e '/^Environment="LD_LIBRARY_PATH=.*"$/d' \
     -e "/^\[Service\]/a Environment=\"LD_LIBRARY_PATH=${lib_link_dir}\"" \
+    -e 's|^WantedBy=multi-user.target|WantedBy=default.target|' \
     "${service_file}"
 }
 

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -195,9 +195,19 @@ function setup_env() {
 
   # User mode detection
   if [[ "$(id -u)" -ne 0 ]]; then
+    # Check systemd version >= 232 for user service support
+    local sd_ver
+    sd_ver=$(systemctl --version 2>/dev/null | head -1 | awk '{print $2}')
+    if [ -z "$sd_ver" ] || [ "$sd_ver" -lt 232 ] 2>/dev/null; then
+      echo -e "${RED}Non-root install requires systemd >= 232, current version: ${sd_ver:-unknown}${NC}"
+      echo -e "Supported: CentOS/RHEL 8+, Ubuntu 18.04+, Debian 9+, SUSE 15+"
+      echo -e "CentOS/RHEL 7 (systemd 219) does not support non-root installation."
+      exit 1
+    fi
     if ! systemctl --user show-environment &>/dev/null; then
       echo -e "${RED}Current user is not root and no systemd user session (user bus) is available.${NC}"
-      echo -e "A systemd user session is required so the installer can manage per-user systemd services."
+      echo -e "Please log in via SSH (not su or privilege escalation) to activate the user session."
+      echo -e "If the problem persists, ask root to run: loginctl enable-linger $(whoami)"
       exit 1
     fi
     user_mode=1
@@ -1335,6 +1345,15 @@ function installProduct() {
 
     echo
     echo "${productName} is installed successfully!"
+
+    if [ "$user_mode" -eq 1 ]; then
+      if ! loginctl show-user "$(whoami)" 2>/dev/null | grep -q "Linger=yes"; then
+        echo
+        echo -e "${RED}IMPORTANT: To ensure services auto-start after reboot, ask root to run:${NC}"
+        echo -e "  loginctl enable-linger $(whoami)"
+      fi
+    fi
+
     echo
 
     echo -e "\033[44;32;1mTo start all the components                 : start-all.sh${NC}"

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -160,6 +160,17 @@ elif [ "${verMode}" == "edge" ]; then
 else
   services=(${serverName} ${adapterName} ${xname} ${explorerName} ${keeperName})
 fi
+
+if [ "${verType}" != "client" ] && [ -d "${script_dir}/${xname}/bin" ]; then
+  case " ${services[*]} " in
+  *" ${xname} "*)
+    ;;
+  *)
+    services=(${services[@]} ${xname})
+    ;;
+  esac
+fi
+
 driver_path=${install_main_dir}/driver
 
 function setup_env() {
@@ -225,6 +236,60 @@ function setup_env() {
   driver_path="${install_main_dir}/driver"
 }
 
+function check_conflicting_system_installation() {
+  if [ "$user_mode" -ne 1 ]; then
+    return 0
+  fi
+
+  local detected=()
+  local candidate=""
+  local resolved=""
+
+  for candidate in \
+    "/usr/local/${PREFIX}/bin/${serverName}" \
+    "/usr/local/${PREFIX}/bin/${clientName}" \
+    "/usr/bin/${serverName}" \
+    "/usr/bin/${clientName}" \
+    "/etc/systemd/system/${serverName}.service" \
+    "/usr/lib/libtaos.so" \
+    "/usr/lib64/libtaos.so" \
+    "/usr/lib/libtaosnative.so" \
+    "/usr/lib64/libtaosnative.so" \
+    "/usr/lib/libtaosws.so" \
+    "/usr/lib64/libtaosws.so"; do
+    [ -e "$candidate" ] && detected+=("$candidate")
+  done
+
+  for candidate in "${serverName}" "${clientName}"; do
+    resolved=$(command -v "$candidate" 2>/dev/null || true)
+    if [ -n "$resolved" ]; then
+      resolved=$(readlink -f "$resolved" 2>/dev/null || echo "$resolved")
+      case "$resolved" in
+        /usr/*|/usr/local/*|/opt/homebrew/*)
+          detected+=("$resolved")
+          ;;
+      esac
+    fi
+  done
+
+  if command -v rpm >/dev/null 2>&1 && rpm -q tdengine >/dev/null 2>&1; then
+    detected+=("rpm:tdengine")
+  fi
+
+  if command -v dpkg >/dev/null 2>&1 && dpkg -l tdengine 2>/dev/null | grep -q '^ii'; then
+    detected+=("dpkg:tdengine")
+  fi
+
+  if [ "${#detected[@]}" -gt 0 ]; then
+    echo -e "${RED}A system-wide TDengine installation was detected.${NC}"
+    echo "Non-root installation is blocked while a system-wide TDengine installation is present."
+    echo "Please uninstall the system-wide TDengine installation as root before continuing."
+    echo "Detected system-wide TDengine paths:"
+    printf '  %s\n' "${detected[@]}"
+    exit 1
+  fi
+}
+
 function install_services() {
   for service in "${services[@]}"; do
     install_service ${service}
@@ -240,13 +305,21 @@ function kill_process() {
 
 function install_main_path() {
   #create install main dir and all sub dir
-  rm -rf ${install_main_dir}/cfg || :
-  rm -rf ${install_main_dir}/bin || :
-  rm -rf ${driver_path}/ || :
-  rm -rf ${install_main_dir}/examples || :
-  rm -rf ${install_main_dir}/include || :
-  rm -rf ${install_main_dir}/share || :
-  rm -rf ${install_main_dir}/log || :
+  if [[ $user_mode -eq 0 ]]; then
+    rm -rf ${install_main_dir}/cfg || :
+    rm -rf ${install_main_dir}/bin || :
+    rm -rf ${driver_path}/ || :
+    rm -rf ${install_main_dir}/examples || :
+    rm -rf ${install_main_dir}/include || :
+    rm -rf ${install_main_dir}/share || :
+    rm -rf ${install_main_dir}/log || :
+  else
+    rm -rf ${install_main_dir}/bin || :
+    rm -rf ${driver_path}/ || :
+    rm -rf ${install_main_dir}/examples || :
+    rm -rf ${install_main_dir}/include || :
+    rm -rf ${install_main_dir}/share || :
+  fi
 
   mkdir -p ${install_main_dir}
   mkdir -p ${install_main_dir}/cfg
@@ -288,7 +361,7 @@ function install_bin() {
     cp ${script_dir}/stop-all.sh ${install_main_dir}/bin
   fi
 
-  if [[ "${verMode}" == "cluster" && "${verType}" != "client" ]]; then
+  if [ "${verType}" != "client" ] && [ -d ${script_dir}/${xname}/bin ]; then
     if [ -d ${script_dir}/${xname}/bin ]; then
       cp -r ${script_dir}/${xname}/bin/* ${install_main_dir}/bin
     fi
@@ -326,6 +399,27 @@ function install_bin() {
   done
 
   [ -x ${install_main_dir}/uninstall_${xname}.sh ] && ln -sf ${install_main_dir}/uninstall_${xname}.sh ${bin_link_dir}/uninstall_${xname}.sh || :
+
+  if [ "$user_mode" -eq 1 ]; then
+    local env_file=""
+    local login_shell="${SHELL##*/}"
+    if [ "$login_shell" = "zsh" ]; then
+      env_file="${HOME}/.zshrc"
+    elif [ "$login_shell" = "bash" ] || [ -z "$login_shell" ]; then
+      env_file="${HOME}/.bashrc"
+    else
+      env_file="${HOME}/.profile"
+    fi
+
+    if ! grep -q "${bin_link_dir}" "$env_file" 2>/dev/null; then
+      echo -e "\n# ${productName} install path" >>"$env_file"
+      echo "export PATH=\"${bin_link_dir}:\$PATH\"" >>"$env_file"
+    fi
+
+    if ! grep -q "${lib_link_dir}" "$env_file" 2>/dev/null; then
+      echo "export LD_LIBRARY_PATH=\"${lib_link_dir}:\$LD_LIBRARY_PATH\"" >>"$env_file"
+    fi
+  fi
 }
 
 function install_lib() {
@@ -364,7 +458,9 @@ function install_lib() {
     ln -sf ${driver_path}/libtaosws.so.* ${lib64_link_dir}/libtaosws.so || :
   fi
 
-  ldconfig
+  if [ "$user_mode" -eq 0 ]; then
+    ldconfig
+  fi
 }
 
 function install_avro() {
@@ -392,6 +488,10 @@ function install_avro() {
 
 function install_jemalloc() {
   jemalloc_dir=${script_dir}/jemalloc
+
+  if [ "$user_mode" -ne 0 ]; then
+    return 0
+  fi
 
   if [ -d ${jemalloc_dir} ]; then
     /usr/bin/install -c -d /usr/local/bin
@@ -605,6 +705,8 @@ function install_taosx_config() {
   file_name="${script_dir}/${xname}/etc/${PREFIX}/${xname}.toml"
   if [ -f ${file_name} ]; then
     sed -i -r "s/#*\s*(fqdn\s*=\s*).*/\1\"${serverFqdn}\"/" ${file_name}
+    sed -i -r "0,/data_dir\s*=\s*/s|#*\s*(data_dir\s*=\s*).*|\1\"${dataDir}/${xname}\"|" ${file_name}
+    sed -i -r "0,/path\s*=\s*/s|#*\s*(path\s*=\s*).*|\1\"${logDir}\"|" ${file_name}
 
     if [ -f "${configDir}/${xname}.toml" ]; then
       cp ${file_name} ${configDir}/${xname}.toml.new
@@ -617,7 +719,7 @@ function install_taosx_config() {
 function install_explorer_config() {
   [ ! -z $1 ] && return 0 || : # only install client
 
-  if [ "$verMode" == "cluster" ] && [ "${entMode}" != "lite" ]; then
+  if [ -f "${script_dir}/${xname}/etc/${PREFIX}/explorer.toml" ]; then
     file_name="${script_dir}/${xname}/etc/${PREFIX}/explorer.toml"
   else
     file_name="${script_dir}/cfg/explorer.toml"
@@ -625,6 +727,8 @@ function install_explorer_config() {
 
   if [ -f ${file_name} ]; then
     sed -i "s/localhost/${serverFqdn}/g" ${file_name}
+    sed -i -r "0,/data_dir\s*=\s*/s|#*\s*(data_dir\s*=\s*).*|\1\"${dataDir}/explorer\"|" ${file_name}
+    sed -i -r "0,/path\s*=\s*/s|#*\s*(path\s*=\s*).*|\1\"${logDir}\"|" ${file_name}
 
     if [ -f "${configDir}/explorer.toml" ]; then
       cp ${file_name} ${configDir}/explorer.toml.new
@@ -640,6 +744,8 @@ function install_adapter_config() {
   file_name="${script_dir}/cfg/${adapterName}.toml"
   if [ -f ${file_name} ]; then
     sed -i -r "s/localhost/${serverFqdn}/g" ${file_name}
+    sed -i -r "s|#*\s*(path\s*=\s*).*|\1\"${logDir}\"|" ${file_name}
+    sed -i -r "s|#*\s*(taosConfigDir\s*=\s*).*|\1\"${configDir}\"|" ${file_name}
 
     if [ -f "${configDir}/${adapterName}.toml" ]; then
       cp ${file_name} ${configDir}/${adapterName}.toml.new
@@ -655,12 +761,25 @@ function install_keeper_config() {
   file_name="${script_dir}/cfg/${keeperName}.toml"
   if [ -f ${file_name} ]; then
     sed -i -r "s/127.0.0.1/${serverFqdn}/g" ${file_name}
+    sed -i -r "s|#*\s*(path\s*=\s*).*|\1\"${logDir}\"|" ${file_name}
 
     if [ -f "${configDir}/${keeperName}.toml" ]; then
       cp ${file_name} ${configDir}/${keeperName}.toml.new
     else
       cp ${file_name} ${configDir}/${keeperName}.toml
     fi
+  fi
+}
+
+function set_taos_cfg_value() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+
+  if grep -qE "^[#[:space:]]*${key}[[:space:]]+" "${file}"; then
+    sed -i -r "s#^[#[:space:]]*(${key}[[:space:]]+).*\$#\\1${value}#" "${file}"
+  else
+    echo "${key} ${value}" >> "${file}"
   fi
 }
 
@@ -673,15 +792,25 @@ function install_taosd_config() {
     if [ "$verMode" == "cluster" ]; then
       echo "audit 1" >>${script_dir}/cfg/${configFile}
     fi
+    if [ "$user_mode" -eq 1 ]; then
+      set_taos_cfg_value "${script_dir}/cfg/${configFile}" "dataDir" "${dataDir}"
+      set_taos_cfg_value "${script_dir}/cfg/${configFile}" "logDir" "${logDir}"
+    fi
 
     if [ -f "${configDir}/${configFile}" ]; then
       cp ${file_name} ${configDir}/${configFile}.new
+      if [ "$user_mode" -eq 1 ]; then
+        set_taos_cfg_value "${configDir}/${configFile}" "dataDir" "${dataDir}"
+        set_taos_cfg_value "${configDir}/${configFile}" "logDir" "${logDir}"
+      fi
     else
       cp ${file_name} ${configDir}/${configFile}
     fi
   fi
 
-  ln -sf ${configDir}/${configFile} ${install_main_dir}/cfg
+  if [ "${configDir}" != "${install_main_dir}/cfg" ]; then
+    ln -sf ${configDir}/${configFile} ${install_main_dir}/cfg
+  fi
 }
 
 function install_taosinspect_config() {
@@ -694,7 +823,9 @@ function install_taosinspect_config() {
     fi
   fi
 
-  ln -sf ${configDir}/inspect.cfg ${install_main_dir}/cfg
+  if [ "${configDir}" != "${install_main_dir}/cfg" ]; then
+    ln -sf ${configDir}/inspect.cfg ${install_main_dir}/cfg
+  fi
 }
 
 function install_config() {
@@ -749,13 +880,17 @@ function install_config() {
 function install_log() {
   mkdir -p ${logDir} &&  mkdir -p ${logDir}/tcmalloc &&  mkdir -p ${logDir}/jemalloc && chmod 777 ${logDir}
 
-  ln -sf ${logDir} ${install_main_dir}/log
+  if [ "${logDir}" != "${install_main_dir}/log" ]; then
+    ln -sf ${logDir} ${install_main_dir}/log
+  fi
 }
 
 function install_data() {
   mkdir -p ${dataDir}
 
-  ln -sf ${dataDir} ${install_main_dir}/data
+  if [ "${dataDir}" != "${install_main_dir}/data" ]; then
+    ln -sf ${dataDir} ${install_main_dir}/data
+  fi
 }
 
 function install_connector() {
@@ -843,17 +978,16 @@ function install_service_on_systemd() {
   clean_service_on_systemd $1
 
   cfg_source_dir=${script_dir}/cfg
-  if [[ "$1" == "${xname}" || "$1" == "${explorerName}" ]]; then
-    if [ "$verMode" == "cluster" ] && [ "${entMode}" != "lite" ]; then
-      cfg_source_dir=${script_dir}/${xname}/etc/systemd/system
-    else
-      cfg_source_dir=${script_dir}/cfg
-    fi
+  if [[ "$1" == "${xname}" || "$1" == "${explorerName}" ]] && [ -d ${script_dir}/${xname}/etc/systemd/system ]; then
+    cfg_source_dir=${script_dir}/${xname}/etc/systemd/system
   fi
 
-  if [ -f ${cfg_source_dir}/$1.service ]; then
-    cp ${cfg_source_dir}/$1.service ${service_config_dir}/ || :
+  if [ ! -f ${cfg_source_dir}/$1.service ]; then
+    return 0
   fi
+
+  cp ${cfg_source_dir}/$1.service ${service_config_dir}/ || :
+  rewrite_systemd_service_for_user_mode "$1"
 
   # # set default malloc config for cluster(enterprise) and edge(community)
   # if [ "$verMode" == "cluster" ] && [ "$ostype" == "Linux" ]; then
@@ -865,6 +999,49 @@ function install_service_on_systemd() {
 
   ${sysctl_cmd} enable $1
   ${sysctl_cmd} daemon-reload
+}
+
+function rewrite_systemd_service_for_user_mode() {
+  local service_name="$1"
+  local service_file="${service_config_dir}/${service_name}.service"
+
+  if [ "$user_mode" -ne 1 ] || [ ! -f "${service_file}" ]; then
+    return 0
+  fi
+
+  case "${service_name}" in
+  "${serverName}")
+    sed -i \
+      -e "s#^ExecStart=/usr/bin/${serverName}.*#ExecStart=${install_main_dir}/bin/${serverName} -c ${configDir}#" \
+      -e "s#^ExecStartPre=/usr/local/taos/bin/startPre.sh.*#ExecStartPre=${install_main_dir}/bin/startPre.sh#" \
+      "${service_file}"
+    ;;
+  "${adapterName}")
+    sed -i \
+      -e "s#^ExecStart=/usr/bin/${adapterName}.*#ExecStart=${install_main_dir}/bin/${adapterName} -c ${configDir}/${adapterName}.toml#" \
+      "${service_file}"
+    ;;
+  "${keeperName}")
+    sed -i \
+      -e "s#^ExecStart=/usr/bin/${keeperName}.*#ExecStart=${install_main_dir}/bin/${keeperName} -c ${configDir}/${keeperName}.toml#" \
+      "${service_file}"
+    ;;
+  "${explorerName}")
+    sed -i \
+      -e "s#^ExecStart=/usr/bin/${explorerName}.*#ExecStart=${install_main_dir}/bin/${explorerName} -c ${configDir}/explorer.toml#" \
+      "${service_file}"
+    ;;
+  "${xname}")
+    sed -i \
+      -e "s#^ExecStart=/usr/bin/${xname} serve.*#ExecStart=${install_main_dir}/bin/${xname} serve -c ${configDir}/${xname}.toml#" \
+      "${service_file}"
+    ;;
+  esac
+
+  sed -i \
+    -e '/^Environment="LD_LIBRARY_PATH=.*"$/d' \
+    -e "/^\[Service\]/a Environment=\"LD_LIBRARY_PATH=${lib_link_dir}\"" \
+    "${service_file}"
 }
 
 function install_service() {
@@ -1199,6 +1376,7 @@ check_java_env() {
 ## ==============================Main program starts from here============================
 # Initialize environment: user mode, service manager, and directory variables
 setup_env
+check_conflicting_system_installation
 serverFqdn=$(hostname)
 if [ "$verType" == "server" ]; then
   if [ -x ${script_dir}/${xname}/bin/${xname} ]; then

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -194,6 +194,7 @@ function setup_env() {
       exit 1
     fi
     user_mode=1
+    csudo=""
     installDir="$HOME/${PREFIX}"
     mode_desc="user ($(whoami))"
   else
@@ -836,11 +837,11 @@ function install_service_on_sysvinit() {
 function clean_service_on_systemd() {
   service_config="${service_config_dir}/$1.service"
 
-  if systemctl is-active --quiet $1; then
+  if ${sysctl_cmd} is-active --quiet $1; then
     echo "$1 is running, stopping it..."
-    ${csudo}systemctl stop $1 &>/dev/null || echo &>/dev/null
+    ${sysctl_cmd} stop $1 &>/dev/null || echo &>/dev/null
   fi
-  ${csudo}systemctl disable $1 &>/dev/null || echo &>/dev/null
+  ${sysctl_cmd} disable $1 &>/dev/null || echo &>/dev/null
   ${csudo}rm -f ${service_config}
 }
 
@@ -868,8 +869,8 @@ function install_service_on_systemd() {
   #   fi
   # fi
 
-  ${csudo}systemctl enable $1
-  ${csudo}systemctl daemon-reload
+  ${sysctl_cmd} enable $1
+  ${sysctl_cmd} daemon-reload
 }
 
 function install_service() {
@@ -990,7 +991,7 @@ function updateProduct() {
   # Stop the service if running
   if ps aux | grep -v grep | grep ${serverName} &>/dev/null; then
     if ((${service_mod} == 0)); then
-      ${csudo}systemctl stop ${serverName} || :
+      ${sysctl_cmd} stop ${serverName} || :
     elif ((${service_mod} == 1)); then
       ${csudo}service ${serverName} stop || :
     else

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -61,10 +61,6 @@ GREEN_DARK='\033[0;32m'
 GREEN_UNDERLINE='\033[4;32m'
 NC='\033[0m'
 
-csudo=""
-if command -v sudo >/dev/null; then
-  csudo="sudo "
-fi
 
 update_flag=0
 prompt_force=0
@@ -194,7 +190,6 @@ function setup_env() {
       exit 1
     fi
     user_mode=1
-    csudo=""
     installDir="$HOME/${PREFIX}"
     mode_desc="user ($(whoami))"
   else
@@ -239,155 +234,155 @@ function install_services() {
 function kill_process() {
   pid=$(ps -ef | grep "$1" | grep -v "grep" | awk '{print $2}')
   if [ -n "$pid" ]; then
-    ${csudo}kill -9 $pid || :
+    kill -9 $pid || :
   fi
 }
 
 function install_main_path() {
   #create install main dir and all sub dir
-  ${csudo}rm -rf ${install_main_dir}/cfg || :
-  ${csudo}rm -rf ${install_main_dir}/bin || :
-  ${csudo}rm -rf ${driver_path}/ || :
-  ${csudo}rm -rf ${install_main_dir}/examples || :
-  ${csudo}rm -rf ${install_main_dir}/include || :
-  ${csudo}rm -rf ${install_main_dir}/share || :
-  ${csudo}rm -rf ${install_main_dir}/log || :
+  rm -rf ${install_main_dir}/cfg || :
+  rm -rf ${install_main_dir}/bin || :
+  rm -rf ${driver_path}/ || :
+  rm -rf ${install_main_dir}/examples || :
+  rm -rf ${install_main_dir}/include || :
+  rm -rf ${install_main_dir}/share || :
+  rm -rf ${install_main_dir}/log || :
 
-  ${csudo}mkdir -p ${install_main_dir}
-  ${csudo}mkdir -p ${install_main_dir}/cfg
-  ${csudo}mkdir -p ${install_main_dir}/bin
-  #  ${csudo}mkdir -p ${install_main_dir}/connector
-  ${csudo}mkdir -p ${driver_path}/
-  ${csudo}mkdir -p ${install_main_dir}/examples
-  ${csudo}mkdir -p ${install_main_dir}/include
-  ${csudo}mkdir -p ${configDir}
-  #  ${csudo}mkdir -p ${install_main_dir}/init.d
+  mkdir -p ${install_main_dir}
+  mkdir -p ${install_main_dir}/cfg
+  mkdir -p ${install_main_dir}/bin
+  #  mkdir -p ${install_main_dir}/connector
+  mkdir -p ${driver_path}/
+  mkdir -p ${install_main_dir}/examples
+  mkdir -p ${install_main_dir}/include
+  mkdir -p ${configDir}
+  #  mkdir -p ${install_main_dir}/init.d
   if [ "$verMode" == "cluster" ]; then
-    ${csudo}mkdir -p ${install_main_dir}/share
+    mkdir -p ${install_main_dir}/share
   fi
 
   if [[ -e ${script_dir}/email ]]; then
-    ${csudo}cp ${script_dir}/email ${install_main_dir}/ || :
+    cp ${script_dir}/email ${install_main_dir}/ || :
   fi
 }
 
 function install_bin() {
   # Remove links
   for tool in "${tools[@]}"; do
-    ${csudo}rm -f ${bin_link_dir}/${tool} || :
+    rm -f ${bin_link_dir}/${tool} || :
   done
 
   for service in "${services[@]}"; do
-    ${csudo}rm -f ${bin_link_dir}/${service} || :
+    rm -f ${bin_link_dir}/${service} || :
   done
 
   if [ "${verType}" == "client" ]; then
-    ${csudo}cp -r ${script_dir}/bin/${clientName} ${install_main_dir}/bin
-    ${csudo}cp -r ${script_dir}/bin/${benchmarkName} ${install_main_dir}/bin
-    ${csudo}cp -r ${script_dir}/bin/${dumpName} ${install_main_dir}/bin
-    ${csudo}cp -r ${script_dir}/bin/${inspect_name} ${install_main_dir}/bin
-    ${csudo}cp -r ${script_dir}/bin/remove.sh ${install_main_dir}/bin
+    cp -r ${script_dir}/bin/${clientName} ${install_main_dir}/bin
+    cp -r ${script_dir}/bin/${benchmarkName} ${install_main_dir}/bin
+    cp -r ${script_dir}/bin/${dumpName} ${install_main_dir}/bin
+    cp -r ${script_dir}/bin/${inspect_name} ${install_main_dir}/bin
+    cp -r ${script_dir}/bin/remove.sh ${install_main_dir}/bin
   else
-    ${csudo}cp -r ${script_dir}/bin/* ${install_main_dir}/bin
-    ${csudo}cp ${script_dir}/start-all.sh ${install_main_dir}/bin
-    ${csudo}cp ${script_dir}/stop-all.sh ${install_main_dir}/bin
+    cp -r ${script_dir}/bin/* ${install_main_dir}/bin
+    cp ${script_dir}/start-all.sh ${install_main_dir}/bin
+    cp ${script_dir}/stop-all.sh ${install_main_dir}/bin
   fi
 
   if [[ "${verMode}" == "cluster" && "${verType}" != "client" ]]; then
     if [ -d ${script_dir}/${xname}/bin ]; then
-      ${csudo}cp -r ${script_dir}/${xname}/bin/* ${install_main_dir}/bin
+      cp -r ${script_dir}/${xname}/bin/* ${install_main_dir}/bin
     fi
     if [ -e ${script_dir}/${xname}/uninstall_${xname}.sh ]; then
-      ${csudo}cp -r ${script_dir}/${xname}/uninstall_${xname}.sh ${install_main_dir}/uninstall_${xname}.sh
+      cp -r ${script_dir}/${xname}/uninstall_${xname}.sh ${install_main_dir}/uninstall_${xname}.sh
     fi
   fi
 
   if [ -f ${script_dir}/bin/quick_deploy.sh ]; then
-    ${csudo}cp -r ${script_dir}/bin/quick_deploy.sh ${install_main_dir}/bin
+    cp -r ${script_dir}/bin/quick_deploy.sh ${install_main_dir}/bin
   fi
 
   # set taos_malloc.sh as bin script
   if [ -f ${script_dir}/bin/${set_malloc_bin} ] && [ "${verType}" != "client" ]; then
-    ${csudo}cp -r ${script_dir}/bin/${set_malloc_bin} ${install_main_dir}/bin
+    cp -r ${script_dir}/bin/${set_malloc_bin} ${install_main_dir}/bin
   else
     echo -e "${RED}Warning: ${set_malloc_bin} not found in bin directory.${NC}"
   fi
 
 
-  ${csudo}chmod 0555 ${install_main_dir}/bin/*
-  [ -x ${install_main_dir}/bin/remove.sh ] && ${csudo}mv ${install_main_dir}/bin/remove.sh ${install_main_dir}/uninstall.sh || :
+  chmod 0555 ${install_main_dir}/bin/*
+  [ -x ${install_main_dir}/bin/remove.sh ] && mv ${install_main_dir}/bin/remove.sh ${install_main_dir}/uninstall.sh || :
 
   #Make link
   for tool in "${tools[@]}"; do
     if [ "${tool}" == "remove.sh" ]; then
-      [ -x ${install_main_dir}/uninstall.sh ] && ${csudo}ln -sf ${install_main_dir}/uninstall.sh ${bin_link_dir}/${uninstallScript} || :
+      [ -x ${install_main_dir}/uninstall.sh ] && ln -sf ${install_main_dir}/uninstall.sh ${bin_link_dir}/${uninstallScript} || :
     else
-      [ -x ${install_main_dir}/bin/${tool} ] && ${csudo}ln -sf ${install_main_dir}/bin/${tool} ${bin_link_dir}/${tool} || :
+      [ -x ${install_main_dir}/bin/${tool} ] && ln -sf ${install_main_dir}/bin/${tool} ${bin_link_dir}/${tool} || :
     fi
   done
 
   for service in "${services[@]}"; do
-    [ -x ${install_main_dir}/bin/${service} ] && ${csudo}ln -sf ${install_main_dir}/bin/${service} ${bin_link_dir}/${service} || :
+    [ -x ${install_main_dir}/bin/${service} ] && ln -sf ${install_main_dir}/bin/${service} ${bin_link_dir}/${service} || :
   done
 
-  [ -x ${install_main_dir}/uninstall_${xname}.sh ] && ${csudo}ln -sf ${install_main_dir}/uninstall_${xname}.sh ${bin_link_dir}/uninstall_${xname}.sh || :
+  [ -x ${install_main_dir}/uninstall_${xname}.sh ] && ln -sf ${install_main_dir}/uninstall_${xname}.sh ${bin_link_dir}/uninstall_${xname}.sh || :
 }
 
 function install_lib() {
   # Remove links
-  ${csudo}rm -f ${lib_link_dir}/libtaos.* || :
-  ${csudo}rm -f ${lib64_link_dir}/libtaos.* || :
-  ${csudo}rm -f ${lib_link_dir}/libtaosnative.* || :
-  ${csudo}rm -f ${lib64_link_dir}/libtaosnative.* || :
-  ${csudo}rm -f ${lib_link_dir}/libtaosws.* || :
-  ${csudo}rm -f ${lib64_link_dir}/libtaosws.* || :
-  #${csudo}rm -rf ${v15_java_app_dir}              || :
-  ${csudo}cp -rf ${script_dir}/driver/* ${driver_path}/ && ${csudo}chmod 777 ${driver_path}/*
+  rm -f ${lib_link_dir}/libtaos.* || :
+  rm -f ${lib64_link_dir}/libtaos.* || :
+  rm -f ${lib_link_dir}/libtaosnative.* || :
+  rm -f ${lib64_link_dir}/libtaosnative.* || :
+  rm -f ${lib_link_dir}/libtaosws.* || :
+  rm -f ${lib64_link_dir}/libtaosws.* || :
+  #rm -rf ${v15_java_app_dir}              || :
+  cp -rf ${script_dir}/driver/* ${driver_path}/ && chmod 777 ${driver_path}/*
 
   #link lib/link_dir
-  ${csudo}ln -sf ${driver_path}/libtaos.* ${lib_link_dir}/libtaos.so.1
-  ${csudo}ln -sf ${lib_link_dir}/libtaos.so.1 ${lib_link_dir}/libtaos.so
-  ${csudo}ln -sf ${driver_path}/libtaosnative.* ${lib_link_dir}/libtaosnative.so.1
-  ${csudo}ln -sf ${lib_link_dir}/libtaosnative.so.1 ${lib_link_dir}/libtaosnative.so
+  ln -sf ${driver_path}/libtaos.* ${lib_link_dir}/libtaos.so.1
+  ln -sf ${lib_link_dir}/libtaos.so.1 ${lib_link_dir}/libtaos.so
+  ln -sf ${driver_path}/libtaosnative.* ${lib_link_dir}/libtaosnative.so.1
+  ln -sf ${lib_link_dir}/libtaosnative.so.1 ${lib_link_dir}/libtaosnative.so
 
-  ${csudo}ln -sf ${driver_path}/libtaosws.so.* ${lib_link_dir}/libtaosws.so || :
+  ln -sf ${driver_path}/libtaosws.so.* ${lib_link_dir}/libtaosws.so || :
 
   #link jemalloc.so and tcmalloc.so
   jemalloc_file="${driver_path}/libjemalloc.so.2"
   tcmalloc_file="${driver_path}/libtcmalloc.so.4.5.18"
-  [ -f "${jemalloc_file}" ] && ${csudo}ln -sf "${jemalloc_file}" "${driver_path}/libjemalloc.so" || echo "jemalloc file not found: ${jemalloc_file}"
-  [ -f "${tcmalloc_file}" ] && ${csudo}ln -sf "${tcmalloc_file}" "${driver_path}/libtcmalloc.so" || echo "tcmalloc file not found: ${tcmalloc_file}"
+  [ -f "${jemalloc_file}" ] && ln -sf "${jemalloc_file}" "${driver_path}/libjemalloc.so" || echo "jemalloc file not found: ${jemalloc_file}"
+  [ -f "${tcmalloc_file}" ] && ln -sf "${tcmalloc_file}" "${driver_path}/libtcmalloc.so" || echo "tcmalloc file not found: ${tcmalloc_file}"
 
 
   #link lib64/link_dir
   if [[ -d ${lib64_link_dir} && ! -e ${lib64_link_dir}/libtaos.so ]]; then
-    ${csudo}ln -sf ${driver_path}/libtaos.* ${lib64_link_dir}/libtaos.so.1 || :
-    ${csudo}ln -sf ${lib64_link_dir}/libtaos.so.1 ${lib64_link_dir}/libtaos.so || :
-    ${csudo}ln -sf ${driver_path}/libtaosnative.* ${lib64_link_dir}/libtaosnative.so.1 || :
-    ${csudo}ln -sf ${lib64_link_dir}/libtaosnative.so.1 ${lib64_link_dir}/libtaosnative.so || :
+    ln -sf ${driver_path}/libtaos.* ${lib64_link_dir}/libtaos.so.1 || :
+    ln -sf ${lib64_link_dir}/libtaos.so.1 ${lib64_link_dir}/libtaos.so || :
+    ln -sf ${driver_path}/libtaosnative.* ${lib64_link_dir}/libtaosnative.so.1 || :
+    ln -sf ${lib64_link_dir}/libtaosnative.so.1 ${lib64_link_dir}/libtaosnative.so || :
 
-    ${csudo}ln -sf ${driver_path}/libtaosws.so.* ${lib64_link_dir}/libtaosws.so || :
+    ln -sf ${driver_path}/libtaosws.so.* ${lib64_link_dir}/libtaosws.so || :
   fi
 
-  ${csudo}ldconfig
+  ldconfig
 }
 
 function install_avro() {
   if [ "$ostype" != "Darwin" ]; then
     avro_dir=${script_dir}/avro
     if [ -f "${avro_dir}/lib/libavro.so.23.0.0" ] && [ -d /usr/local/$1 ]; then
-      ${csudo}/usr/bin/install -c -d /usr/local/$1
-      ${csudo}/usr/bin/install -c -m 755 ${avro_dir}/lib/libavro.so.23.0.0 /usr/local/$1
-      ${csudo}ln -sf /usr/local/$1/libavro.so.23.0.0 /usr/local/$1/libavro.so.23
-      ${csudo}ln -sf /usr/local/$1/libavro.so.23 /usr/local/$1/libavro.so
+      /usr/bin/install -c -d /usr/local/$1
+      /usr/bin/install -c -m 755 ${avro_dir}/lib/libavro.so.23.0.0 /usr/local/$1
+      ln -sf /usr/local/$1/libavro.so.23.0.0 /usr/local/$1/libavro.so.23
+      ln -sf /usr/local/$1/libavro.so.23 /usr/local/$1/libavro.so
 
-      ${csudo}/usr/bin/install -c -d /usr/local/$1
+      /usr/bin/install -c -d /usr/local/$1
       [ -f ${avro_dir}/lib/libavro.a ] &&
-        ${csudo}/usr/bin/install -c -m 755 ${avro_dir}/lib/libavro.a /usr/local/$1
+        /usr/bin/install -c -m 755 ${avro_dir}/lib/libavro.a /usr/local/$1
 
       if [ -d /etc/ld.so.conf.d ]; then
-        echo "/usr/local/$1" | ${csudo}tee /etc/ld.so.conf.d/libavro.conf >/dev/null || echo -e "failed to write /etc/ld.so.conf.d/libavro.conf"
-        ${csudo}ldconfig
+        echo "/usr/local/$1" | tee /etc/ld.so.conf.d/libavro.conf >/dev/null || echo -e "failed to write /etc/ld.so.conf.d/libavro.conf"
+        ldconfig
       else
         echo "/etc/ld.so.conf.d not found!"
       fi
@@ -399,49 +394,49 @@ function install_jemalloc() {
   jemalloc_dir=${script_dir}/jemalloc
 
   if [ -d ${jemalloc_dir} ]; then
-    ${csudo}/usr/bin/install -c -d /usr/local/bin
+    /usr/bin/install -c -d /usr/local/bin
 
     if [ -f ${jemalloc_dir}/bin/jemalloc-config ]; then
-      ${csudo}/usr/bin/install -c -m 755 ${jemalloc_dir}/bin/jemalloc-config /usr/local/bin
+      /usr/bin/install -c -m 755 ${jemalloc_dir}/bin/jemalloc-config /usr/local/bin
     fi
     if [ -f ${jemalloc_dir}/bin/jemalloc.sh ]; then
-      ${csudo}/usr/bin/install -c -m 755 ${jemalloc_dir}/bin/jemalloc.sh /usr/local/bin
+      /usr/bin/install -c -m 755 ${jemalloc_dir}/bin/jemalloc.sh /usr/local/bin
     fi
     if [ -f ${jemalloc_dir}/bin/jeprof ]; then
-      ${csudo}/usr/bin/install -c -m 755 ${jemalloc_dir}/bin/jeprof /usr/local/bin
+      /usr/bin/install -c -m 755 ${jemalloc_dir}/bin/jeprof /usr/local/bin
     fi
     if [ -f ${jemalloc_dir}/include/jemalloc/jemalloc.h ]; then
-      ${csudo}/usr/bin/install -c -d /usr/local/include/jemalloc
-      ${csudo}/usr/bin/install -c -m 644 ${jemalloc_dir}/include/jemalloc/jemalloc.h /usr/local/include/jemalloc
+      /usr/bin/install -c -d /usr/local/include/jemalloc
+      /usr/bin/install -c -m 644 ${jemalloc_dir}/include/jemalloc/jemalloc.h /usr/local/include/jemalloc
     fi
     if [ -f ${jemalloc_dir}/lib/libjemalloc.so.2 ]; then
-      ${csudo}/usr/bin/install -c -d /usr/local/lib
-      ${csudo}/usr/bin/install -c -m 755 ${jemalloc_dir}/lib/libjemalloc.so.2 /usr/local/lib
-      ${csudo}ln -sf libjemalloc.so.2 /usr/local/lib/libjemalloc.so
-      ${csudo}/usr/bin/install -c -d /usr/local/lib
+      /usr/bin/install -c -d /usr/local/lib
+      /usr/bin/install -c -m 755 ${jemalloc_dir}/lib/libjemalloc.so.2 /usr/local/lib
+      ln -sf libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+      /usr/bin/install -c -d /usr/local/lib
       # if [ -f ${jemalloc_dir}/lib/libjemalloc.a ]; then
-      #   ${csudo}/usr/bin/install -c -m 755 ${jemalloc_dir}/lib/libjemalloc.a /usr/local/lib
+      #   /usr/bin/install -c -m 755 ${jemalloc_dir}/lib/libjemalloc.a /usr/local/lib
       # fi
       # if [ -f ${jemalloc_dir}/lib/libjemalloc_pic.a ]; then
-      #   ${csudo}/usr/bin/install -c -m 755 ${jemalloc_dir}/lib/libjemalloc_pic.a /usr/local/lib
+      #   /usr/bin/install -c -m 755 ${jemalloc_dir}/lib/libjemalloc_pic.a /usr/local/lib
       # fi
       if [ -f ${jemalloc_dir}/lib/pkgconfig/jemalloc.pc ]; then
-        ${csudo}/usr/bin/install -c -d /usr/local/lib/pkgconfig
-        ${csudo}/usr/bin/install -c -m 644 ${jemalloc_dir}/lib/pkgconfig/jemalloc.pc /usr/local/lib/pkgconfig
+        /usr/bin/install -c -d /usr/local/lib/pkgconfig
+        /usr/bin/install -c -m 644 ${jemalloc_dir}/lib/pkgconfig/jemalloc.pc /usr/local/lib/pkgconfig
       fi
     fi
     if [ -f ${jemalloc_dir}/share/doc/jemalloc/jemalloc.html ]; then
-      ${csudo}/usr/bin/install -c -d /usr/local/share/doc/jemalloc
-      ${csudo}/usr/bin/install -c -m 644 ${jemalloc_dir}/share/doc/jemalloc/jemalloc.html /usr/local/share/doc/jemalloc
+      /usr/bin/install -c -d /usr/local/share/doc/jemalloc
+      /usr/bin/install -c -m 644 ${jemalloc_dir}/share/doc/jemalloc/jemalloc.html /usr/local/share/doc/jemalloc
     fi
     if [ -f ${jemalloc_dir}/share/man/man3/jemalloc.3 ]; then
-      ${csudo}/usr/bin/install -c -d /usr/local/share/man/man3
-      ${csudo}/usr/bin/install -c -m 644 ${jemalloc_dir}/share/man/man3/jemalloc.3 /usr/local/share/man/man3
+      /usr/bin/install -c -d /usr/local/share/man/man3
+      /usr/bin/install -c -m 644 ${jemalloc_dir}/share/man/man3/jemalloc.3 /usr/local/share/man/man3
     fi
 
     if [ -d /etc/ld.so.conf.d ]; then
-      echo "/usr/local/lib" | ${csudo}tee /etc/ld.so.conf.d/jemalloc.conf >/dev/null || echo -e "failed to write /etc/ld.so.conf.d/jemalloc.conf"
-      ${csudo}ldconfig
+      echo "/usr/local/lib" | tee /etc/ld.so.conf.d/jemalloc.conf >/dev/null || echo -e "failed to write /etc/ld.so.conf.d/jemalloc.conf"
+      ldconfig
     else
       echo "/etc/ld.so.conf.d not found!"
     fi
@@ -449,18 +444,18 @@ function install_jemalloc() {
 }
 
 function install_header() {
-  ${csudo}rm -f ${inc_link_dir}/taos.h ${inc_link_dir}/taosdef.h ${inc_link_dir}/taoserror.h ${inc_link_dir}/tdef.h ${inc_link_dir}/taosudf.h || :
+  rm -f ${inc_link_dir}/taos.h ${inc_link_dir}/taosdef.h ${inc_link_dir}/taoserror.h ${inc_link_dir}/tdef.h ${inc_link_dir}/taosudf.h || :
 
-  [ -f ${inc_link_dir}/taosws.h ] && ${csudo}rm -f ${inc_link_dir}/taosws.h || :
+  [ -f ${inc_link_dir}/taosws.h ] && rm -f ${inc_link_dir}/taosws.h || :
 
-  ${csudo}cp -f ${script_dir}/inc/* ${install_main_dir}/include && ${csudo}chmod 644 ${install_main_dir}/include/*
-  ${csudo}ln -sf ${install_main_dir}/include/taos.h ${inc_link_dir}/taos.h
-  ${csudo}ln -sf ${install_main_dir}/include/taosdef.h ${inc_link_dir}/taosdef.h
-  ${csudo}ln -sf ${install_main_dir}/include/taoserror.h ${inc_link_dir}/taoserror.h
-  ${csudo}ln -sf ${install_main_dir}/include/tdef.h ${inc_link_dir}/tdef.h
-  ${csudo}ln -sf ${install_main_dir}/include/taosudf.h ${inc_link_dir}/taosudf.h
+  cp -f ${script_dir}/inc/* ${install_main_dir}/include && chmod 644 ${install_main_dir}/include/*
+  ln -sf ${install_main_dir}/include/taos.h ${inc_link_dir}/taos.h
+  ln -sf ${install_main_dir}/include/taosdef.h ${inc_link_dir}/taosdef.h
+  ln -sf ${install_main_dir}/include/taoserror.h ${inc_link_dir}/taoserror.h
+  ln -sf ${install_main_dir}/include/tdef.h ${inc_link_dir}/tdef.h
+  ln -sf ${install_main_dir}/include/taosudf.h ${inc_link_dir}/taosudf.h
 
-  [ -f ${install_main_dir}/include/taosws.h ] && ${csudo}ln -sf ${install_main_dir}/include/taosws.h ${inc_link_dir}/taosws.h || :
+  [ -f ${install_main_dir}/include/taosws.h ] && ln -sf ${install_main_dir}/include/taosws.h ${inc_link_dir}/taosws.h || :
 }
 
 function add_newHostname_to_hosts() {
@@ -479,8 +474,8 @@ function add_newHostname_to_hosts() {
   if grep -q "127.0.0.1  $1" /etc/hosts; then
     return
   else
-    ${csudo}chmod 666 /etc/hosts
-    ${csudo}echo "127.0.0.1  $1" >>/etc/hosts
+    chmod 666 /etc/hosts
+    echo "127.0.0.1  $1" >>/etc/hosts
   fi
 }
 
@@ -499,7 +494,7 @@ function set_hostname() {
     fi
   done
 
-  # ${csudo}hostname $newHostname || :
+  # hostname $newHostname || :
   # retval=$(echo $?)
   # if [[ $retval != 0 ]]; then
   #   echo
@@ -509,18 +504,18 @@ function set_hostname() {
 
   # #ubuntu/centos /etc/hostname
   # if [[ -e /etc/hostname ]]; then
-  #   ${csudo}echo $newHostname >/etc/hostname || :
+  #   echo $newHostname >/etc/hostname || :
   # fi
 
   # #debian: #HOSTNAME=yourname
   # if [[ -e /etc/sysconfig/network ]]; then
-  #   ${csudo}sed -i -r "s/#*\s*(HOSTNAME=\s*).*/\1$newHostname/" /etc/sysconfig/network || :
+  #   sed -i -r "s/#*\s*(HOSTNAME=\s*).*/\1$newHostname/" /etc/sysconfig/network || :
   # fi
 
   if [ -f ${configDir}/${configFile} ]; then
-    ${csudo}sed -i -r "s/#*\s*(fqdn\s*).*/\1$newHostname/" ${configDir}/${configFile}
+    sed -i -r "s/#*\s*(fqdn\s*).*/\1$newHostname/" ${configDir}/${configFile}
   else
-    ${csudo}sed -i -r "s/#*\s*(fqdn\s*).*/\1$newHostname/" ${script_dir}/cfg/${configFile}
+    sed -i -r "s/#*\s*(fqdn\s*).*/\1$newHostname/" ${script_dir}/cfg/${configFile}
   fi
   serverFqdn=$newHostname
 
@@ -557,9 +552,9 @@ function set_ipAsFqdn() {
     # Write the local FQDN to configuration file
 
     if [ -f ${configDir}/${configFile} ]; then
-      ${csudo}sed -i -r "s/#*\s*(fqdn\s*).*/\1$localFqdn/" ${configDir}/${configFile}
+      sed -i -r "s/#*\s*(fqdn\s*).*/\1$localFqdn/" ${configDir}/${configFile}
     else
-      ${csudo}sed -i -r "s/#*\s*(fqdn\s*).*/\1$localFqdn/" ${script_dir}/cfg/${configFile}
+      sed -i -r "s/#*\s*(fqdn\s*).*/\1$localFqdn/" ${script_dir}/cfg/${configFile}
     fi
     serverFqdn=$localFqdn
     echo
@@ -583,9 +578,9 @@ function set_ipAsFqdn() {
       else
         # Write the local FQDN to configuration file
         if [ -f ${configDir}/${configFile} ]; then
-          ${csudo}sed -i -r "s/#*\s*(fqdn\s*).*/\1$localFqdn/" ${configDir}/${configFile}
+          sed -i -r "s/#*\s*(fqdn\s*).*/\1$localFqdn/" ${configDir}/${configFile}
         else
-          ${csudo}sed -i -r "s/#*\s*(fqdn\s*).*/\1$localFqdn/" ${script_dir}/cfg/${configFile}
+          sed -i -r "s/#*\s*(fqdn\s*).*/\1$localFqdn/" ${script_dir}/cfg/${configFile}
         fi
         serverFqdn=$localFqdn
         break
@@ -609,12 +604,12 @@ function install_taosx_config() {
 
   file_name="${script_dir}/${xname}/etc/${PREFIX}/${xname}.toml"
   if [ -f ${file_name} ]; then
-    ${csudo}sed -i -r "s/#*\s*(fqdn\s*=\s*).*/\1\"${serverFqdn}\"/" ${file_name}
+    sed -i -r "s/#*\s*(fqdn\s*=\s*).*/\1\"${serverFqdn}\"/" ${file_name}
 
     if [ -f "${configDir}/${xname}.toml" ]; then
-      ${csudo}cp ${file_name} ${configDir}/${xname}.toml.new
+      cp ${file_name} ${configDir}/${xname}.toml.new
     else
-      ${csudo}cp ${file_name} ${configDir}/${xname}.toml
+      cp ${file_name} ${configDir}/${xname}.toml
     fi
   fi
 }
@@ -629,12 +624,12 @@ function install_explorer_config() {
   fi
 
   if [ -f ${file_name} ]; then
-    ${csudo}sed -i "s/localhost/${serverFqdn}/g" ${file_name}
+    sed -i "s/localhost/${serverFqdn}/g" ${file_name}
 
     if [ -f "${configDir}/explorer.toml" ]; then
-      ${csudo}cp ${file_name} ${configDir}/explorer.toml.new
+      cp ${file_name} ${configDir}/explorer.toml.new
     else
-      ${csudo}cp ${file_name} ${configDir}/explorer.toml
+      cp ${file_name} ${configDir}/explorer.toml
     fi
   fi
 }
@@ -644,12 +639,12 @@ function install_adapter_config() {
 
   file_name="${script_dir}/cfg/${adapterName}.toml"
   if [ -f ${file_name} ]; then
-    ${csudo}sed -i -r "s/localhost/${serverFqdn}/g" ${file_name}
+    sed -i -r "s/localhost/${serverFqdn}/g" ${file_name}
 
     if [ -f "${configDir}/${adapterName}.toml" ]; then
-      ${csudo}cp ${file_name} ${configDir}/${adapterName}.toml.new
+      cp ${file_name} ${configDir}/${adapterName}.toml.new
     else
-      ${csudo}cp ${file_name} ${configDir}/${adapterName}.toml
+      cp ${file_name} ${configDir}/${adapterName}.toml
     fi
   fi
 }
@@ -659,12 +654,12 @@ function install_keeper_config() {
 
   file_name="${script_dir}/cfg/${keeperName}.toml"
   if [ -f ${file_name} ]; then
-    ${csudo}sed -i -r "s/127.0.0.1/${serverFqdn}/g" ${file_name}
+    sed -i -r "s/127.0.0.1/${serverFqdn}/g" ${file_name}
 
     if [ -f "${configDir}/${keeperName}.toml" ]; then
-      ${csudo}cp ${file_name} ${configDir}/${keeperName}.toml.new
+      cp ${file_name} ${configDir}/${keeperName}.toml.new
     else
-      ${csudo}cp ${file_name} ${configDir}/${keeperName}.toml
+      cp ${file_name} ${configDir}/${keeperName}.toml
     fi
   fi
 }
@@ -672,34 +667,34 @@ function install_keeper_config() {
 function install_taosd_config() {
   file_name="${script_dir}/cfg/${configFile}"
   if [ -f ${file_name} ]; then
-    ${csudo}sed -i -r "s/#*\s*(fqdn\s*).*/\1$serverFqdn/" ${script_dir}/cfg/${configFile}
-    ${csudo}echo "monitor 1" >>${script_dir}/cfg/${configFile}
-    ${csudo}echo "monitorFQDN ${serverFqdn}" >>${script_dir}/cfg/${configFile}
+    sed -i -r "s/#*\s*(fqdn\s*).*/\1$serverFqdn/" ${script_dir}/cfg/${configFile}
+    echo "monitor 1" >>${script_dir}/cfg/${configFile}
+    echo "monitorFQDN ${serverFqdn}" >>${script_dir}/cfg/${configFile}
     if [ "$verMode" == "cluster" ]; then
-      ${csudo}echo "audit 1" >>${script_dir}/cfg/${configFile}
+      echo "audit 1" >>${script_dir}/cfg/${configFile}
     fi
 
     if [ -f "${configDir}/${configFile}" ]; then
-      ${csudo}cp ${file_name} ${configDir}/${configFile}.new
+      cp ${file_name} ${configDir}/${configFile}.new
     else
-      ${csudo}cp ${file_name} ${configDir}/${configFile}
+      cp ${file_name} ${configDir}/${configFile}
     fi
   fi
 
-  ${csudo}ln -sf ${configDir}/${configFile} ${install_main_dir}/cfg
+  ln -sf ${configDir}/${configFile} ${install_main_dir}/cfg
 }
 
 function install_taosinspect_config() {
   file_name="${script_dir}/cfg/inspect.cfg"
   if [ -f ${file_name} ]; then
     if [ -f "${configDir}/inspect.cfg" ]; then
-      ${csudo}cp ${file_name} ${configDir}/inspect.cfg.new
+      cp ${file_name} ${configDir}/inspect.cfg.new
     else
-      ${csudo}cp ${file_name} ${configDir}/inspect.cfg
+      cp ${file_name} ${configDir}/inspect.cfg
     fi
   fi
 
-  ${csudo}ln -sf ${configDir}/inspect.cfg ${install_main_dir}/cfg
+  ln -sf ${configDir}/inspect.cfg ${install_main_dir}/cfg
 }
 
 function install_config() {
@@ -727,9 +722,9 @@ function install_config() {
   while true; do
     if [ ! -z "$firstEp" ]; then
       if [ -f ${configDir}/${configFile} ]; then
-        ${csudo}sed -i -r "s/#*\s*(firstEp\s*).*/\1$firstEp/" ${configDir}/${configFile}
+        sed -i -r "s/#*\s*(firstEp\s*).*/\1$firstEp/" ${configDir}/${configFile}
       else
-        ${csudo}sed -i -r "s/#*\s*(firstEp\s*).*/\1$firstEp/" ${script_dir}/cfg/${configFile}
+        sed -i -r "s/#*\s*(firstEp\s*).*/\1$firstEp/" ${script_dir}/cfg/${configFile}
       fi
       break
     else
@@ -743,7 +738,7 @@ function install_config() {
   while true; do
     if [ ! -z "$emailAddr" ]; then
       email_file="${install_main_dir}/email"
-      ${csudo}bash -c "echo $emailAddr > ${email_file}"
+      bash -c "echo $emailAddr > ${email_file}"
       break
     else
       break
@@ -752,59 +747,59 @@ function install_config() {
 }
 
 function install_log() {
-  ${csudo}mkdir -p ${logDir} &&  ${csudo}mkdir -p ${logDir}/tcmalloc &&  ${csudo}mkdir -p ${logDir}/jemalloc && ${csudo}chmod 777 ${logDir}
+  mkdir -p ${logDir} &&  mkdir -p ${logDir}/tcmalloc &&  mkdir -p ${logDir}/jemalloc && chmod 777 ${logDir}
 
-  ${csudo}ln -sf ${logDir} ${install_main_dir}/log
+  ln -sf ${logDir} ${install_main_dir}/log
 }
 
 function install_data() {
-  ${csudo}mkdir -p ${dataDir}
+  mkdir -p ${dataDir}
 
-  ${csudo}ln -sf ${dataDir} ${install_main_dir}/data
+  ln -sf ${dataDir} ${install_main_dir}/data
 }
 
 function install_connector() {
   if [ -d "${script_dir}/connector/" ]; then
-    ${csudo}cp -rf ${script_dir}/connector/ ${install_main_dir}/ || echo "failed to copy connector"
-    ${csudo}cp ${script_dir}/README.md ${install_main_dir}/ || echo "failed to copy README.md"
+    cp -rf ${script_dir}/connector/ ${install_main_dir}/ || echo "failed to copy connector"
+    cp ${script_dir}/README.md ${install_main_dir}/ || echo "failed to copy README.md"
   fi
 }
 
 function install_examples() {
   if [ -d ${script_dir}/examples ]; then
-    ${csudo}cp -rf ${script_dir}/examples ${install_main_dir}/ || echo "failed to copy examples"
+    cp -rf ${script_dir}/examples ${install_main_dir}/ || echo "failed to copy examples"
   fi
 }
 
 function install_plugins() {
   if [ -d ${script_dir}/${xname}/plugins ]; then
-    ${csudo}cp -rf ${script_dir}/${xname}/plugins/ ${install_main_dir}/ || echo "failed to copy ${PREFIX}x plugins"
+    cp -rf ${script_dir}/${xname}/plugins/ ${install_main_dir}/ || echo "failed to copy ${PREFIX}x plugins"
   fi
 }
 
 function clean_service_on_sysvinit() {
   if ps aux | grep -v grep | grep $1 &>/dev/null; then
-    ${csudo}service $1 stop || :
+    service $1 stop || :
   fi
 
   if ((${initd_mod} == 1)); then
     if [ -e ${service_config_dir}/$1 ]; then
-      ${csudo}chkconfig --del $1 || :
+      chkconfig --del $1 || :
     fi
   elif ((${initd_mod} == 2)); then
     if [ -e ${service_config_dir}/$1 ]; then
-      ${csudo}insserv -r $1 || :
+      insserv -r $1 || :
     fi
   elif ((${initd_mod} == 3)); then
     if [ -e ${service_config_dir}/$1 ]; then
-      ${csudo}update-rc.d -f $1 remove || :
+      update-rc.d -f $1 remove || :
     fi
   fi
 
-  ${csudo}rm -f ${service_config_dir}/$1 || :
+  rm -f ${service_config_dir}/$1 || :
 
   if $(which init &>/dev/null); then
-    ${csudo}init q || :
+    init q || :
   fi
 }
 
@@ -817,19 +812,19 @@ function install_service_on_sysvinit() {
   sleep 1
 
   if ((${os_type} == 1)); then
-    ${csudo}cp ${script_dir}/init.d/${serverName}.deb ${service_config_dir}/${serverName} && ${csudo}chmod a+x ${service_config_dir}/${serverName}
+    cp ${script_dir}/init.d/${serverName}.deb ${service_config_dir}/${serverName} && chmod a+x ${service_config_dir}/${serverName}
   elif ((${os_type} == 2)); then
-    ${csudo}cp ${script_dir}/init.d/${serverName}.rpm ${service_config_dir}/${serverName} && ${csudo}chmod a+x ${service_config_dir}/${serverName}
+    cp ${script_dir}/init.d/${serverName}.rpm ${service_config_dir}/${serverName} && chmod a+x ${service_config_dir}/${serverName}
   fi
 
   if ((${initd_mod} == 1)); then
-    ${csudo}chkconfig --add $1 || :
-    ${csudo}chkconfig --level 2345 $1 on || :
+    chkconfig --add $1 || :
+    chkconfig --level 2345 $1 on || :
   elif ((${initd_mod} == 2)); then
-    ${csudo}insserv $1} || :
-    ${csudo}insserv -d $1 || :
+    insserv $1} || :
+    insserv -d $1 || :
   elif ((${initd_mod} == 3)); then
-    ${csudo}update-rc.d $1 defaults || :
+    update-rc.d $1 defaults || :
   fi
 }
 
@@ -841,7 +836,7 @@ function clean_service_on_systemd() {
     ${sysctl_cmd} stop $1 &>/dev/null || echo &>/dev/null
   fi
   ${sysctl_cmd} disable $1 &>/dev/null || echo &>/dev/null
-  ${csudo}rm -f ${service_config}
+  rm -f ${service_config}
 }
 
 function install_service_on_systemd() {
@@ -857,14 +852,14 @@ function install_service_on_systemd() {
   fi
 
   if [ -f ${cfg_source_dir}/$1.service ]; then
-    ${csudo}cp ${cfg_source_dir}/$1.service ${service_config_dir}/ || :
+    cp ${cfg_source_dir}/$1.service ${service_config_dir}/ || :
   fi
 
   # # set default malloc config for cluster(enterprise) and edge(community)
   # if [ "$verMode" == "cluster" ] && [ "$ostype" == "Linux" ]; then
   #   if [ "$1" = "taosd" ] || [ "$1" = "taosadapter" ]; then
   #     echo "set $1 malloc config"
-  #     ${csudo} ${install_main_dir}/bin/${set_malloc_bin} -m 0 -q
+  #      ${install_main_dir}/bin/${set_malloc_bin} -m 0 -q
   #   fi
   # fi
 
@@ -942,7 +937,7 @@ deb_erase() {
     echo -e -n "${RED}Existing TDengine deb is detected, do you want to remove it? [yes|no] ${NC}:"
     read confirm
     if [ "yes" == "$confirm" ]; then
-      ${csudo}dpkg --remove tdengine || :
+      dpkg --remove tdengine || :
       break
     elif [ "no" == "$confirm" ]; then
       break
@@ -956,7 +951,7 @@ rpm_erase() {
     echo -e -n "${RED}Existing TDengine rpm is detected, do you want to remove it? [yes|no] ${NC}:"
     read confirm
     if [ "yes" == "$confirm" ]; then
-      ${csudo}rpm -e tdengine || :
+      rpm -e tdengine || :
       break
     elif [ "no" == "$confirm" ]; then
       break
@@ -992,7 +987,7 @@ function updateProduct() {
     if ((${service_mod} == 0)); then
       ${sysctl_cmd} stop ${serverName} || :
     elif ((${service_mod} == 1)); then
-      ${csudo}service ${serverName} stop || :
+      service ${serverName} stop || :
     else
       kill_process ${serverName}
     fi
@@ -1038,30 +1033,30 @@ function updateProduct() {
       echo -e "${GREEN_DARK}To configure ${adapterName} ${NC}\t: edit ${configDir}/${adapterName}.toml"
     echo -e "${GREEN_DARK}To configure ${explorerName} ${NC}\t: edit ${configDir}/explorer.toml"
     if ((${service_mod} == 0)); then
-      echo -e "${GREEN_DARK}To start ${productName} server     ${NC}\t: ${csudo}systemctl start ${serverName}${NC}"
+      echo -e "${GREEN_DARK}To start ${productName} server     ${NC}\t: ${sysctl_cmd} start ${serverName}${NC}"
       [ -f ${service_config_dir}/${clientName}adapter.service ] && [ -f ${installDir}/bin/${clientName}adapter ] &&
-        echo -e "${GREEN_DARK}To start ${clientName}Adapter ${NC}\t\t: ${csudo}systemctl start ${clientName}adapter ${NC}"
+        echo -e "${GREEN_DARK}To start ${clientName}Adapter ${NC}\t\t: ${sysctl_cmd} start ${clientName}adapter ${NC}"
     elif ((${service_mod} == 1)); then
-      echo -e "${GREEN_DARK}To start ${productName} server     ${NC}\t: ${csudo}service ${serverName} start${NC}"
+      echo -e "${GREEN_DARK}To start ${productName} server     ${NC}\t: service ${serverName} start${NC}"
       [ -f ${service_config_dir}/${clientName}adapter.service ] && [ -f ${installDir}/bin/${clientName}adapter ] &&
-        echo -e "${GREEN_DARK}To start ${clientName}Adapter ${NC}\t\t: ${csudo}service ${clientName}adapter start${NC}"
+        echo -e "${GREEN_DARK}To start ${clientName}Adapter ${NC}\t\t: service ${clientName}adapter start${NC}"
     else
       echo -e "${GREEN_DARK}To start ${productName} server     ${NC}\t: ./${serverName}${NC}"
       [ -f ${installDir}/bin/${clientName}adapter ] &&
         echo -e "${GREEN_DARK}To start ${clientName}Adapter ${NC}\t\t: ${clientName}adapter ${NC}"
     fi
 
-    echo -e "${GREEN_DARK}To start ${clientName}keeper ${NC}\t\t: sudo systemctl start ${clientName}keeper ${NC}"
+    echo -e "${GREEN_DARK}To start ${clientName}keeper ${NC}\t\t: ${sysctl_cmd} start ${clientName}keeper ${NC}"
     if [ "$verMode" == "cluster" ] && [ "${entMode}" != "lite" ]; then
-      echo -e "${GREEN_DARK}To start ${clientName}x ${NC}\t\t\t: sudo systemctl start ${clientName}x ${NC}"
+      echo -e "${GREEN_DARK}To start ${clientName}x ${NC}\t\t\t: ${sysctl_cmd} start ${clientName}x ${NC}"
     fi
-    echo -e "${GREEN_DARK}To start ${clientName}-explorer ${NC}\t\t: sudo systemctl start ${clientName}-explorer ${NC}"
+    echo -e "${GREEN_DARK}To start ${clientName}-explorer ${NC}\t\t: ${sysctl_cmd} start ${clientName}-explorer ${NC}"
 
     echo
     echo "${productName} is updated successfully!"
     echo
 
-    echo -e "\033[44;32;1mTo start all the components                 : sudo start-all.sh${NC}"
+    echo -e "\033[44;32;1mTo start all the components                 : start-all.sh${NC}"
     echo -e "\033[44;32;1mTo access ${productName} Command Line Interface    : ${clientName} -h $serverFqdn${NC}"
     echo -e "\033[44;32;1mTo access ${productName} Graphic User Interface   : http://$serverFqdn:6060${NC}"
     if [ "$verMode" == "cluster" ]; then
@@ -1137,31 +1132,31 @@ function installProduct() {
       echo -e "${GREEN_DARK}To configure ${clientName}Adapter ${NC}\t: edit ${configDir}/${clientName}adapter.toml"
     echo -e "${GREEN_DARK}To configure ${clientName}-explorer ${NC}\t: edit ${configDir}/explorer.toml"
     if ((${service_mod} == 0)); then
-      echo -e "${GREEN_DARK}To start ${productName} server    ${NC}\t: ${csudo}systemctl start ${serverName}${NC}"
+      echo -e "${GREEN_DARK}To start ${productName} server    ${NC}\t: ${sysctl_cmd} start ${serverName}${NC}"
       [ -f ${service_config_dir}/${clientName}adapter.service ] && [ -f ${installDir}/bin/${clientName}adapter ] &&
-        echo -e "${GREEN_DARK}To start ${clientName}Adapter ${NC}\t\t: ${csudo}systemctl start ${clientName}adapter ${NC}"
+        echo -e "${GREEN_DARK}To start ${clientName}Adapter ${NC}\t\t: ${sysctl_cmd} start ${clientName}adapter ${NC}"
     elif ((${service_mod} == 1)); then
-      echo -e "${GREEN_DARK}To start ${productName} server     ${NC}\t: ${csudo}service ${serverName} start${NC}"
+      echo -e "${GREEN_DARK}To start ${productName} server     ${NC}\t: service ${serverName} start${NC}"
       [ -f ${service_config_dir}/${clientName}adapter.service ] && [ -f ${installDir}/bin/${clientName}adapter ] &&
-        echo -e "${GREEN_DARK}To start ${clientName}Adapter ${NC}\t\t: ${csudo}service ${clientName}adapter start${NC}"
+        echo -e "${GREEN_DARK}To start ${clientName}Adapter ${NC}\t\t: service ${clientName}adapter start${NC}"
     else
       echo -e "${GREEN_DARK}To start ${productName} server     ${NC}\t: ${serverName}${NC}"
       [ -f ${installDir}/bin/${clientName}adapter ] &&
         echo -e "${GREEN_DARK}To start ${clientName}Adapter ${NC}\t\t: ${clientName}adapter ${NC}"
     fi
 
-    echo -e "${GREEN_DARK}To start ${clientName}keeper ${NC}\t\t: sudo systemctl start ${clientName}keeper ${NC}"
+    echo -e "${GREEN_DARK}To start ${clientName}keeper ${NC}\t\t: ${sysctl_cmd} start ${clientName}keeper ${NC}"
 
     if [ "$verMode" == "cluster" ] && [ "${entMode}" != "lite" ]; then
-      echo -e "${GREEN_DARK}To start ${clientName}x ${NC}\t\t\t: sudo systemctl start ${clientName}x ${NC}"
+      echo -e "${GREEN_DARK}To start ${clientName}x ${NC}\t\t\t: ${sysctl_cmd} start ${clientName}x ${NC}"
     fi
-    echo -e "${GREEN_DARK}To start ${clientName}-explorer ${NC}\t\t: sudo systemctl start ${clientName}-explorer ${NC}"
+    echo -e "${GREEN_DARK}To start ${clientName}-explorer ${NC}\t\t: ${sysctl_cmd} start ${clientName}-explorer ${NC}"
 
     echo
     echo "${productName} is installed successfully!"
     echo
 
-    echo -e "\033[44;32;1mTo start all the components                 : sudo start-all.sh${NC}"
+    echo -e "\033[44;32;1mTo start all the components                 : start-all.sh${NC}"
     echo -e "\033[44;32;1mTo access ${productName} Commnd Line Interface    : ${clientName} -h $serverFqdn${NC}"
     echo -e "\033[44;32;1mTo access ${productName} Graphic User Interface   : http://$serverFqdn:6060${NC}"
     if [ "$verMode" == "cluster" ]; then

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -297,10 +297,9 @@ function install_services() {
 }
 
 function kill_process() {
-  pid=$(ps -ef | grep "$1" | grep -v "grep" | awk '{print $2}')
-  if [ -n "$pid" ]; then
-    kill -9 $pid || :
-  fi
+  pgrep -x "$1" | while read p; do
+    kill -9 "$p" 2>/dev/null || :
+  done || true
 }
 
 function install_main_path() {
@@ -559,6 +558,10 @@ function install_header() {
 }
 
 function add_newHostname_to_hosts() {
+  if [ "$user_mode" -eq 1 ]; then
+    echo "Warning: non-root install, skipping /etc/hosts modification"
+    return
+  fi
   localIp="127.0.0.1"
   OLD_IFS="$IFS"
   IFS=" "

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -211,7 +211,6 @@ function setup_env() {
     lib_link_dir="/usr/lib"
     lib64_link_dir="/usr/lib64"
     inc_link_dir="/usr/include"
-    service_config_dir="/etc/systemd/system"
     sysctl_cmd="systemctl"
   else
     dataDir="${installDir}/data"

--- a/packaging/tools/install_client.sh
+++ b/packaging/tools/install_client.sh
@@ -379,7 +379,6 @@ function install_taosinspect_config() {
 }
 
 function install_log() {
-  rm -rf "${log_dir}" || :
   mkdir -p "${log_dir}"
   chmod 777 "${log_dir}" || :
 

--- a/packaging/tools/install_client.sh
+++ b/packaging/tools/install_client.sh
@@ -155,9 +155,9 @@ function check_conflicting_system_installation() {
 }
 
 function kill_client() {
-  ps -ef | grep "${clientName}" | grep -v "grep" | awk '{print $2}' | while read p; do
+  pgrep -x "${clientName}" | while read p; do
     kill -9 "$p" 2>/dev/null || :
-  done
+  done || true
 }
 
 function install_main_path() {

--- a/packaging/tools/install_client.sh
+++ b/packaging/tools/install_client.sh
@@ -155,10 +155,9 @@ function check_conflicting_system_installation() {
 }
 
 function kill_client() {
-  pid=$(ps -ef | grep "${clientName}" | grep -v "grep" | awk '{print $2}')
-  if [ -n "$pid" ]; then
-    kill -9 "$pid" || :
-  fi
+  ps -ef | grep "${clientName}" | grep -v "grep" | awk '{print $2}' | while read p; do
+    kill -9 "$p" 2>/dev/null || :
+  done
 }
 
 function install_main_path() {

--- a/packaging/tools/install_client.sh
+++ b/packaging/tools/install_client.sh
@@ -19,12 +19,12 @@ uninstallScript="rmtaos"
 configFile="taos.cfg"
 tarName="package.tar.gz"
 
-osType=Linux
+osType=$(uname)
 pagMode=full
 verMode=edge
 
-clientName2="taos"
-serverName2="taosd"
+clientName2="${clientName}"
+serverName2="${serverName}"
 productName2="TDengine"
 emailName2="taosdata.com"
 
@@ -34,40 +34,23 @@ demoName2="${clientName2}demo"
 uninstallScript2="rm${clientName2}"
 inspect_name="${clientName2}inspect"
 
-
 if [ "$osType" != "Darwin" ]; then
-    script_dir=$(dirname $(readlink -f "$0"))
-    # Dynamic directory
-    data_dir=${dataDir}
-    log_dir=${logDir}
+  script_dir=$(dirname "$(readlink -f "$0")")
 else
-    script_dir=`dirname $0`
-    cd ${script_dir}
-    script_dir="$(pwd)"
-    data_dir=${dataDir}
-    log_dir=~/${productName}/log
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
 fi
 
-log_link_dir="${installDir}/log"
-
-cfg_install_dir=${configDir}
-
-if [ "$osType" != "Darwin" ]; then
-    bin_link_dir="/usr/bin"
-    lib_link_dir="/usr/lib"
-    lib64_link_dir="/usr/lib64"
-    inc_link_dir="/usr/include"
-else
-    bin_link_dir="/usr/local/bin"
-    lib_link_dir="/usr/local/lib"
-    inc_link_dir="/usr/local/include"
-fi
-
-#install main path
-install_main_dir="${installDir}"
-
-# old bin dir
-bin_dir="${installDir}/bin"
+log_link_dir=""
+cfg_install_dir=""
+bin_link_dir=""
+lib_link_dir=""
+lib64_link_dir=""
+inc_link_dir=""
+install_main_dir=""
+bin_dir=""
+data_dir=""
+log_dir=""
+user_mode=0
 
 # Color setting
 RED='\033[0;31m'
@@ -76,308 +59,424 @@ GREEN_DARK='\033[0;32m'
 GREEN_UNDERLINE='\033[4;32m'
 NC='\033[0m'
 
-csudo=""
-if command -v sudo > /dev/null; then
-    csudo="sudo "
-fi
-
 update_flag=0
+
+function setup_env() {
+  if [ "$(id -u)" -ne 0 ]; then
+    user_mode=1
+    installDir="$HOME/${clientName2}"
+    dataDir="${installDir}/data"
+    logDir="${installDir}/log"
+    configDir="${installDir}/cfg"
+    bin_link_dir="$HOME/.local/bin"
+    lib_link_dir="$HOME/.local/lib"
+    if [ "$osType" != "Darwin" ]; then
+      lib64_link_dir="$HOME/.local/lib64"
+    else
+      lib64_link_dir="$HOME/.local/lib"
+    fi
+    inc_link_dir="$HOME/.local/include"
+    mkdir -p "$bin_link_dir" "$lib_link_dir" "$lib64_link_dir" "$inc_link_dir"
+  else
+    user_mode=0
+    if [ "$osType" != "Darwin" ]; then
+      bin_link_dir="/usr/bin"
+      lib_link_dir="/usr/lib"
+      lib64_link_dir="/usr/lib64"
+      inc_link_dir="/usr/include"
+    else
+      bin_link_dir="/usr/local/bin"
+      lib_link_dir="/usr/local/lib"
+      lib64_link_dir="/usr/local/lib"
+      inc_link_dir="/usr/local/include"
+    fi
+  fi
+
+  data_dir=${dataDir}
+  log_dir=${logDir}
+  log_link_dir="${installDir}/log"
+  cfg_install_dir=${configDir}
+  install_main_dir="${installDir}"
+  bin_dir="${installDir}/bin"
+}
+
+function check_conflicting_system_installation() {
+  if [ "$user_mode" -ne 1 ]; then
+    return 0
+  fi
+
+  local detected=()
+  local candidate=""
+  local resolved=""
+
+  for candidate in \
+    "/usr/local/taos/bin/${serverName}" \
+    "/usr/local/taos/bin/${clientName}" \
+    "/usr/bin/${serverName}" \
+    "/usr/bin/${clientName}" \
+    "/etc/systemd/system/${serverName}.service" \
+    "/usr/lib/libtaos.so" \
+    "/usr/lib64/libtaos.so" \
+    "/usr/lib/libtaosnative.so" \
+    "/usr/lib64/libtaosnative.so" \
+    "/usr/lib/libtaosws.so" \
+    "/usr/lib64/libtaosws.so"; do
+    [ -e "$candidate" ] && detected+=("$candidate")
+  done
+
+  for candidate in "${serverName}" "${clientName}"; do
+    resolved=$(command -v "$candidate" 2>/dev/null || true)
+    if [ -n "$resolved" ]; then
+      resolved=$(readlink -f "$resolved" 2>/dev/null || echo "$resolved")
+      case "$resolved" in
+        /usr/*|/usr/local/*|/opt/homebrew/*)
+          detected+=("$resolved")
+          ;;
+      esac
+    fi
+  done
+
+  if command -v rpm >/dev/null 2>&1 && rpm -q tdengine >/dev/null 2>&1; then
+    detected+=("rpm:tdengine")
+  fi
+
+  if command -v dpkg >/dev/null 2>&1 && dpkg -l tdengine 2>/dev/null | grep -q '^ii'; then
+    detected+=("dpkg:tdengine")
+  fi
+
+  if [ "${#detected[@]}" -gt 0 ]; then
+    echo -e "${RED}A system-wide TDengine installation was detected.${NC}"
+    echo "Non-root installation is blocked while a system-wide TDengine installation is present."
+    echo "Please uninstall the system-wide TDengine installation as root before continuing."
+    echo "Detected system-wide TDengine paths:"
+    printf '  %s\n' "${detected[@]}"
+    exit 1
+  fi
+}
 
 function kill_client() {
   pid=$(ps -ef | grep "${clientName}" | grep -v "grep" | awk '{print $2}')
   if [ -n "$pid" ]; then
-    ${csudo}kill -9 $pid   || :
+    kill -9 "$pid" || :
   fi
 }
 
 function install_main_path() {
-  #create install main dir and all sub dir
-  ${csudo}rm -rf ${install_main_dir} || :
-  ${csudo}mkdir -p ${install_main_dir}
-  ${csudo}mkdir -p ${install_main_dir}/cfg
-  ${csudo}mkdir -p ${install_main_dir}/bin
-  ${csudo}mkdir -p ${install_main_dir}/driver
-  if [[ "$productName2" == "TDengine"* ]]; then
-    ${csudo}mkdir -p ${install_main_dir}/examples
+  if [ "$user_mode" -eq 0 ]; then
+    rm -rf "${install_main_dir}" || :
+  else
+    rm -rf "${install_main_dir}/bin" "${install_main_dir}/driver" "${install_main_dir}/examples" "${install_main_dir}/include" "${install_main_dir}/connector" || :
   fi
-  ${csudo}mkdir -p ${install_main_dir}/include
+  mkdir -p "${install_main_dir}"
+  mkdir -p "${install_main_dir}/cfg"
+  mkdir -p "${install_main_dir}/bin"
+  mkdir -p "${install_main_dir}/driver"
+  if [[ "$productName2" == "TDengine"* ]]; then
+    mkdir -p "${install_main_dir}/examples"
+  fi
+  mkdir -p "${install_main_dir}/include"
   if [ "$verMode" == "cluster" ]; then
-    ${csudo}mkdir -p ${install_main_dir}/connector
+    mkdir -p "${install_main_dir}/connector"
   fi
 }
 
 function install_bin() {
-  # Remove links
-  ${csudo}rm -f ${bin_link_dir}/${clientName} || :
+  rm -f "${bin_link_dir}/${clientName}" || :
   if [ "$osType" != "Darwin" ]; then
-      ${csudo}rm -f ${bin_link_dir}/taosdemo || :
-      ${csudo}rm -f ${bin_link_dir}/${inspect_name} || :
+    rm -f "${bin_link_dir}/taosdemo" || :
+    rm -f "${bin_link_dir}/${inspect_name}" || :
   fi
-  ${csudo}rm -f ${bin_link_dir}/${uninstallScript} || :
-  ${csudo}rm -f ${bin_link_dir}/set_core || :
-  ${csudo}rm -f ${bin_link_dir}/${benchmarkName2} || :
-  ${csudo}rm -f ${bin_link_dir}/${dumpName2} || :
+  rm -f "${bin_link_dir}/${uninstallScript}" || :
+  rm -f "${bin_link_dir}/set_core" || :
+  rm -f "${bin_link_dir}/${benchmarkName2}" || :
+  rm -f "${bin_link_dir}/${dumpName2}" || :
 
-  ${csudo}cp -r ${script_dir}/bin/* ${install_main_dir}/bin && ${csudo}chmod 0555 ${install_main_dir}/bin/*
+  cp -r "${script_dir}/bin/"* "${install_main_dir}/bin"
+  chmod 0555 "${install_main_dir}/bin/"*
 
-  #Make link
-  [ -x ${install_main_dir}/bin/${clientName2} ] && ${csudo}ln -s ${install_main_dir}/bin/${clientName2} ${bin_link_dir}/${clientName2} || :
+  [ -x "${install_main_dir}/bin/${clientName2}" ] && ln -sf "${install_main_dir}/bin/${clientName2}" "${bin_link_dir}/${clientName2}" || :
   if [ "$osType" != "Darwin" ]; then
-      [ -x ${install_main_dir}/bin/${demoName2} ] && ${csudo}ln -s ${install_main_dir}/bin/${demoName2} ${bin_link_dir}/${demoName2}  || :
-      [ -x ${install_main_dir}/bin/${inspect_name} ] && ${csudo}ln -s ${install_main_dir}/bin/${inspect_name} ${bin_link_dir}/${inspect_name} || :
+    [ -x "${install_main_dir}/bin/${demoName2}" ] && ln -sf "${install_main_dir}/bin/${demoName2}" "${bin_link_dir}/${demoName2}" || :
+    [ -x "${install_main_dir}/bin/${inspect_name}" ] && ln -sf "${install_main_dir}/bin/${inspect_name}" "${bin_link_dir}/${inspect_name}" || :
   fi
-  [ -x ${install_main_dir}/bin/remove_client.sh ] && ${csudo}ln -s ${install_main_dir}/bin/remove_client.sh ${bin_link_dir}/${uninstallScript} || :
-  [ -x ${install_main_dir}/bin/set_core.sh ] && ${csudo}ln -s ${install_main_dir}/bin/set_core.sh ${bin_link_dir}/set_core || :  
-  [ -x ${install_main_dir}/bin/${benchmarkName2} ] && ${csudo}ln -s ${install_main_dir}/bin/${benchmarkName2} ${bin_link_dir}/${benchmarkName2}  || :
-  [ -x ${install_main_dir}/bin/${dumpName2} ] && ${csudo}ln -s ${install_main_dir}/bin/${dumpName2} ${bin_link_dir}/${dumpName2}  || :
+  [ -x "${install_main_dir}/bin/remove_client.sh" ] && ln -sf "${install_main_dir}/bin/remove_client.sh" "${bin_link_dir}/${uninstallScript}" || :
+  [ -x "${install_main_dir}/bin/set_core.sh" ] && ln -sf "${install_main_dir}/bin/set_core.sh" "${bin_link_dir}/set_core" || :
+  [ -x "${install_main_dir}/bin/${benchmarkName2}" ] && ln -sf "${install_main_dir}/bin/${benchmarkName2}" "${bin_link_dir}/${benchmarkName2}" || :
+  [ -x "${install_main_dir}/bin/${dumpName2}" ] && ln -sf "${install_main_dir}/bin/${dumpName2}" "${bin_link_dir}/${dumpName2}" || :
+
+  if [ "$user_mode" -eq 1 ]; then
+    local env_file=""
+    local login_shell="${SHELL##*/}"
+    if [ "$login_shell" = "zsh" ]; then
+      env_file="${HOME}/.zshrc"
+    elif [ "$login_shell" = "bash" ] || [ -z "$login_shell" ]; then
+      env_file="${HOME}/.bashrc"
+    else
+      env_file="${HOME}/.profile"
+    fi
+
+    if ! grep -q "${bin_link_dir}" "$env_file" 2>/dev/null; then
+      echo -e "\n# ${productName2} install path" >>"$env_file"
+      echo "export PATH=\"${bin_link_dir}:\$PATH\"" >>"$env_file"
+    fi
+
+    if ! grep -q "${lib_link_dir}" "$env_file" 2>/dev/null; then
+      echo "export LD_LIBRARY_PATH=\"${lib_link_dir}:\$LD_LIBRARY_PATH\"" >>"$env_file"
+    fi
+  fi
 }
 
 function clean_lib() {
-    sudo rm -f /usr/lib/libtaos.* || :
-    sudo rm -f /usr/lib/libtaosnative.* || :
-    [ -f /usr/lib/libtaosws.so ] && sudo rm -f /usr/lib/libtaosws.so || :
-    [ -f /usr/lib64/libtaosws.so ] && sudo rm -f /usr/lib64/libtaosws.so || :
-    sudo rm -rf ${lib_dir} || :
+  if [ "$user_mode" -ne 0 ]; then
+    return 0
+  fi
+
+  rm -f /usr/lib/libtaos.* || :
+  rm -f /usr/lib/libtaosnative.* || :
+  [ -f /usr/lib/libtaosws.so ] && rm -f /usr/lib/libtaosws.so || :
+  [ -f /usr/lib64/libtaosws.so ] && rm -f /usr/lib64/libtaosws.so || :
 }
 
 function install_lib() {
-    # Remove links
-    ${csudo}rm -f ${lib_link_dir}/libtaos.*         || :
-    ${csudo}rm -f ${lib64_link_dir}/libtaos.*       || :
-    ${csudo}rm -f ${lib_link_dir}/libtaosnative.*   || :
-    ${csudo}rm -f ${lib64_link_dir}/libtaosnative.* || :
+  rm -f "${lib_link_dir}"/libtaos.* || :
+  rm -f "${lib64_link_dir}"/libtaos.* || :
+  rm -f "${lib_link_dir}"/libtaosnative.* || :
+  rm -f "${lib64_link_dir}"/libtaosnative.* || :
 
-    [ -f ${lib_link_dir}/libtaosws.so ] && ${csudo}rm -f ${lib_link_dir}/libtaosws.so         || :
-    [ -f ${lib64_link_dir}/libtaosws.so ] && ${csudo}rm -f ${lib64_link_dir}/libtaosws.so         || :
+  [ -f "${lib_link_dir}/libtaosws.so" ] && rm -f "${lib_link_dir}/libtaosws.so" || :
+  [ -f "${lib64_link_dir}/libtaosws.so" ] && rm -f "${lib64_link_dir}/libtaosws.so" || :
 
-    #${csudo}rm -rf ${v15_java_app_dir}              || :
+  cp -rf "${script_dir}/driver/"* "${install_main_dir}/driver"
+  chmod 777 "${install_main_dir}/driver/"*
 
-    ${csudo}cp -rf ${script_dir}/driver/* ${install_main_dir}/driver && ${csudo}chmod 777 ${install_main_dir}/driver/*
+  if [ "$osType" != "Darwin" ]; then
+    ln -sf "${install_main_dir}/driver/libtaos."* "${lib_link_dir}/libtaos.so.1"
+    ln -sf "${lib_link_dir}/libtaos.so.1" "${lib_link_dir}/libtaos.so"
+    ln -sf "${install_main_dir}/driver/libtaosnative."* "${lib_link_dir}/libtaosnative.so.1"
+    ln -sf "${lib_link_dir}/libtaosnative.so.1" "${lib_link_dir}/libtaosnative.so"
 
-    if [ "$osType" != "Darwin" ]; then
-        ${csudo}ln -s ${install_main_dir}/driver/libtaos.* ${lib_link_dir}/libtaos.so.1
-        ${csudo}ln -s ${lib_link_dir}/libtaos.so.1 ${lib_link_dir}/libtaos.so
-        ${csudo}ln -s ${install_main_dir}/driver/libtaosnative.* ${lib_link_dir}/libtaosnative.so.1
-        ${csudo}ln -s ${lib_link_dir}/libtaosnative.so.1 ${lib_link_dir}/libtaosnative.so
+    [ -f "${install_main_dir}/driver/libtaosws.so" ] && ln -sf "${install_main_dir}/driver/libtaosws.so" "${lib_link_dir}/libtaosws.so" || :
 
-        [ -f ${install_main_dir}/driver/libtaosws.so ] && ${csudo}ln -sf ${install_main_dir}/driver/libtaosws.so ${lib_link_dir}/libtaosws.so ||:
+    if [ -d "${lib64_link_dir}" ] && [ "${lib64_link_dir}" != "${lib_link_dir}" ]; then
+      ln -sf "${install_main_dir}/driver/libtaos."* "${lib64_link_dir}/libtaos.so.1" || :
+      ln -sf "${lib64_link_dir}/libtaos.so.1" "${lib64_link_dir}/libtaos.so" || :
+      ln -sf "${install_main_dir}/driver/libtaosnative."* "${lib64_link_dir}/libtaosnative.so.1" || :
+      ln -sf "${lib64_link_dir}/libtaosnative.so.1" "${lib64_link_dir}/libtaosnative.so" || :
 
-        if [ -d "${lib64_link_dir}" ]; then
-            ${csudo}ln -s ${install_main_dir}/driver/libtaos.* ${lib64_link_dir}/libtaos.so.1       || :
-            ${csudo}ln -s ${lib64_link_dir}/libtaos.so.1 ${lib64_link_dir}/libtaos.so               || :
-            ${csudo}ln -s ${install_main_dir}/driver/libtaosnative.* ${lib64_link_dir}/libtaosnative.so.1       || :
-            ${csudo}ln -s ${lib64_link_dir}/libtaosnative.so.1 ${lib64_link_dir}/libtaosnative.so               || :
-
-            [ -f ${install_main_dir}/driver/libtaosws.so ] && ${csudo}ln -sf ${install_main_dir}/driver/libtaosws.so ${lib64_link_dir}/libtaosws.so       || :
-        fi
-    else
-        ${csudo}ln -s ${install_main_dir}/driver/libtaos.* ${lib_link_dir}/libtaos.1.dylib
-        ${csudo}ln -s ${lib_link_dir}/libtaos.1.dylib ${lib_link_dir}/libtaos.dylib
-        ${csudo}ln -s ${install_main_dir}/driver/libtaosnative.* ${lib_link_dir}/libtaosnative.1.dylib
-        ${csudo}ln -s ${lib_link_dir}/libtaosnative.1.dylib ${lib_link_dir}/libtaosnative.dylib
-
-        [ -f ${install_main_dir}/driver/libtaosws.dylib ] && ${csudo}ln -sf ${install_main_dir}/driver/libtaosws.dylib ${lib_link_dir}/libtaosws.dylib ||:
+      [ -f "${install_main_dir}/driver/libtaosws.so" ] && ln -sf "${install_main_dir}/driver/libtaosws.so" "${lib64_link_dir}/libtaosws.so" || :
     fi
 
-    if [ "$osType" != "Darwin" ]; then
-        ${csudo}ldconfig
-    else
-        ${csudo}update_dyld_shared_cache
+    if [ "$user_mode" -eq 0 ]; then
+      ldconfig
     fi
+  else
+    ln -sf "${install_main_dir}/driver/libtaos."* "${lib_link_dir}/libtaos.1.dylib"
+    ln -sf "${lib_link_dir}/libtaos.1.dylib" "${lib_link_dir}/libtaos.dylib"
+    ln -sf "${install_main_dir}/driver/libtaosnative."* "${lib_link_dir}/libtaosnative.1.dylib"
+    ln -sf "${lib_link_dir}/libtaosnative.1.dylib" "${lib_link_dir}/libtaosnative.dylib"
+
+    [ -f "${install_main_dir}/driver/libtaosws.dylib" ] && ln -sf "${install_main_dir}/driver/libtaosws.dylib" "${lib_link_dir}/libtaosws.dylib" || :
+
+    if [ "$user_mode" -eq 0 ]; then
+      update_dyld_shared_cache
+    fi
+  fi
 }
 
 function install_header() {
-    ${csudo}rm -f ${inc_link_dir}/taos.h ${inc_link_dir}/taosws.h ${inc_link_dir}/taosdef.h ${inc_link_dir}/tdef.h ${inc_link_dir}/taoserror.h  ${inc_link_dir}/taosudf.h  || :
-    ${csudo}cp -f ${script_dir}/inc/* ${install_main_dir}/include && ${csudo}chmod 644 ${install_main_dir}/include/*
-    ${csudo}ln -s ${install_main_dir}/include/taos.h ${inc_link_dir}/taos.h
-    ${csudo}ln -s ${install_main_dir}/include/taosdef.h ${inc_link_dir}/taosdef.h
-    ${csudo}ln -s ${install_main_dir}/include/tdef.h ${inc_link_dir}/tdef.h
-    ${csudo}ln -s ${install_main_dir}/include/taoserror.h ${inc_link_dir}/taoserror.h
-    ${csudo}ln -s ${install_main_dir}/include/taosudf.h ${inc_link_dir}/taosudf.h    
+  rm -f "${inc_link_dir}/taos.h" "${inc_link_dir}/taosws.h" "${inc_link_dir}/taosdef.h" "${inc_link_dir}/tdef.h" "${inc_link_dir}/taoserror.h" "${inc_link_dir}/taosudf.h" || :
+  cp -f "${script_dir}/inc/"* "${install_main_dir}/include"
+  chmod 644 "${install_main_dir}/include/"*
+  ln -sf "${install_main_dir}/include/taos.h" "${inc_link_dir}/taos.h"
+  ln -sf "${install_main_dir}/include/taosdef.h" "${inc_link_dir}/taosdef.h"
+  ln -sf "${install_main_dir}/include/tdef.h" "${inc_link_dir}/tdef.h"
+  ln -sf "${install_main_dir}/include/taoserror.h" "${inc_link_dir}/taoserror.h"
+  ln -sf "${install_main_dir}/include/taosudf.h" "${inc_link_dir}/taosudf.h"
 
-    [ -f ${install_main_dir}/include/taosws.h ] && ${csudo}ln -sf ${install_main_dir}/include/taosws.h ${inc_link_dir}/taosws.h ||:
+  [ -f "${install_main_dir}/include/taosws.h" ] && ln -sf "${install_main_dir}/include/taosws.h" "${inc_link_dir}/taosws.h" || :
 }
 
 function install_jemalloc() {
-    jemalloc_dir=${script_dir}/jemalloc
+  jemalloc_dir=${script_dir}/jemalloc
 
-    if [ -d ${jemalloc_dir} ]; then
-        ${csudo}/usr/bin/install -c -d /usr/local/bin
+  if [ "$user_mode" -ne 0 ]; then
+    return 0
+  fi
 
-        if [ -f ${jemalloc_dir}/bin/jemalloc-config ]; then
-            ${csudo}/usr/bin/install -c -m 755 ${jemalloc_dir}/bin/jemalloc-config /usr/local/bin
-        fi
-        if [ -f ${jemalloc_dir}/bin/jemalloc.sh ]; then
-            ${csudo}/usr/bin/install -c -m 755 ${jemalloc_dir}/bin/jemalloc.sh /usr/local/bin
-        fi
-        if [ -f ${jemalloc_dir}/bin/jeprof ]; then
-            ${csudo}/usr/bin/install -c -m 755 ${jemalloc_dir}/bin/jeprof /usr/local/bin
-        fi
-        if [ -f ${jemalloc_dir}/include/jemalloc/jemalloc.h ]; then
-            ${csudo}/usr/bin/install -c -d /usr/local/include/jemalloc
-            ${csudo}/usr/bin/install -c -m 644 ${jemalloc_dir}/include/jemalloc/jemalloc.h /usr/local/include/jemalloc
-        fi
-        if [ -f ${jemalloc_dir}/lib/libjemalloc.so.2 ]; then
-            ${csudo}/usr/bin/install -c -d /usr/local/lib
-            ${csudo}/usr/bin/install -c -m 755 ${jemalloc_dir}/lib/libjemalloc.so.2 /usr/local/lib
-            ${csudo}ln -sf libjemalloc.so.2 /usr/local/lib/libjemalloc.so
-            ${csudo}/usr/bin/install -c -d /usr/local/lib
-            # if [ -f ${jemalloc_dir}/lib/libjemalloc.a ]; then
-            #     ${csudo}/usr/bin/install -c -m 755 ${jemalloc_dir}/lib/libjemalloc.a /usr/local/lib
-            # fi
-            # if [ -f ${jemalloc_dir}/lib/libjemalloc_pic.a ]; then
-            #     ${csudo}/usr/bin/install -c -m 755 ${jemalloc_dir}/lib/libjemalloc_pic.a /usr/local/lib
-            # fi
-            if [ -f ${jemalloc_dir}/lib/pkgconfig/jemalloc.pc ]; then
-                ${csudo}/usr/bin/install -c -d /usr/local/lib/pkgconfig
-                ${csudo}/usr/bin/install -c -m 644 ${jemalloc_dir}/lib/pkgconfig/jemalloc.pc /usr/local/lib/pkgconfig
-            fi
-        fi
-        if [ -f ${jemalloc_dir}/share/doc/jemalloc/jemalloc.html ]; then
-            ${csudo}/usr/bin/install -c -d /usr/local/share/doc/jemalloc
-            ${csudo}/usr/bin/install -c -m 644 ${jemalloc_dir}/share/doc/jemalloc/jemalloc.html /usr/local/share/doc/jemalloc
-        fi
-        if [ -f ${jemalloc_dir}/share/man/man3/jemalloc.3 ]; then
-            ${csudo}/usr/bin/install -c -d /usr/local/share/man/man3
-            ${csudo}/usr/bin/install -c -m 644 ${jemalloc_dir}/share/man/man3/jemalloc.3 /usr/local/share/man/man3
-        fi
+  if [ -d "${jemalloc_dir}" ]; then
+    /usr/bin/install -c -d /usr/local/bin
 
-        if [ -d /etc/ld.so.conf.d ]; then
-            echo "/usr/local/lib" | ${csudo}tee /etc/ld.so.conf.d/jemalloc.conf > /dev/null || echo -e "failed to write /etc/ld.so.conf.d/jemalloc.conf"
-            ${csudo}ldconfig
-        else
-            echo "/etc/ld.so.conf.d not found!"
-        fi
+    if [ -f "${jemalloc_dir}/bin/jemalloc-config" ]; then
+      /usr/bin/install -c -m 755 "${jemalloc_dir}/bin/jemalloc-config" /usr/local/bin
     fi
+    if [ -f "${jemalloc_dir}/bin/jemalloc.sh" ]; then
+      /usr/bin/install -c -m 755 "${jemalloc_dir}/bin/jemalloc.sh" /usr/local/bin
+    fi
+    if [ -f "${jemalloc_dir}/bin/jeprof" ]; then
+      /usr/bin/install -c -m 755 "${jemalloc_dir}/bin/jeprof" /usr/local/bin
+    fi
+    if [ -f "${jemalloc_dir}/include/jemalloc/jemalloc.h" ]; then
+      /usr/bin/install -c -d /usr/local/include/jemalloc
+      /usr/bin/install -c -m 644 "${jemalloc_dir}/include/jemalloc/jemalloc.h" /usr/local/include/jemalloc
+    fi
+    if [ -f "${jemalloc_dir}/lib/libjemalloc.so.2" ]; then
+      /usr/bin/install -c -d /usr/local/lib
+      /usr/bin/install -c -m 755 "${jemalloc_dir}/lib/libjemalloc.so.2" /usr/local/lib
+      ln -sf libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+      /usr/bin/install -c -d /usr/local/lib
+      if [ -f "${jemalloc_dir}/lib/pkgconfig/jemalloc.pc" ]; then
+        /usr/bin/install -c -d /usr/local/lib/pkgconfig
+        /usr/bin/install -c -m 644 "${jemalloc_dir}/lib/pkgconfig/jemalloc.pc" /usr/local/lib/pkgconfig
+      fi
+    fi
+    if [ -f "${jemalloc_dir}/share/doc/jemalloc/jemalloc.html" ]; then
+      /usr/bin/install -c -d /usr/local/share/doc/jemalloc
+      /usr/bin/install -c -m 644 "${jemalloc_dir}/share/doc/jemalloc/jemalloc.html" /usr/local/share/doc/jemalloc
+    fi
+    if [ -f "${jemalloc_dir}/share/man/man3/jemalloc.3" ]; then
+      /usr/bin/install -c -d /usr/local/share/man/man3
+      /usr/bin/install -c -m 644 "${jemalloc_dir}/share/man/man3/jemalloc.3" /usr/local/share/man/man3
+    fi
+
+    if [ -d /etc/ld.so.conf.d ]; then
+      echo "/usr/local/lib" | tee /etc/ld.so.conf.d/jemalloc.conf >/dev/null || echo -e "failed to write /etc/ld.so.conf.d/jemalloc.conf"
+      ldconfig
+    else
+      echo "/etc/ld.so.conf.d not found!"
+    fi
+  fi
 }
 
 function install_config() {
-    file_name=${cfg_install_dir}/${configFile}
-    if [ -f ${file_name} ]; then
-        echo "The configuration file ${file_name} already exists"
-        ${csudo}cp ${file_name} ${cfg_install_dir}/${configFile}.new
-    else
-        ${csudo}mkdir -p ${cfg_install_dir}
-        [ -f ${script_dir}/cfg/${configFile} ] && ${csudo}cp ${script_dir}/cfg/${configFile} ${cfg_install_dir}
-        ${csudo}chmod 644 ${cfg_install_dir}/*
-     ${csudo}ln -s ${cfg_install_dir}/${configFile} ${install_main_dir}/cfg
-    fi
+  file_name=${cfg_install_dir}/${configFile}
+  if [ -f "${file_name}" ]; then
+    echo "The configuration file ${file_name} already exists"
+    cp "${file_name}" "${cfg_install_dir}/${configFile}.new"
+  else
+    mkdir -p "${cfg_install_dir}"
+    [ -f "${script_dir}/cfg/${configFile}" ] && cp "${script_dir}/cfg/${configFile}" "${cfg_install_dir}"
+    chmod 644 "${cfg_install_dir}/"* || :
+  fi
 
-   
+  if [ "${cfg_install_dir}" != "${install_main_dir}/cfg" ]; then
+    ln -sfn "${cfg_install_dir}/${configFile}" "${install_main_dir}/cfg"
+  fi
 }
 
 function install_taosinspect_config() {
   file_name="${script_dir}/cfg/inspect.cfg"
-  if [ -f ${file_name} ]; then
+  if [ -f "${file_name}" ]; then
     if [ -f "${cfg_install_dir}/inspect.cfg" ]; then
-      ${csudo}cp ${file_name} ${cfg_install_dir}/inspect.cfg.new
+      cp "${file_name}" "${cfg_install_dir}/inspect.cfg.new"
     else
-      ${csudo}mkdir -p ${cfg_install_dir}
-      ${csudo}cp ${file_name} ${cfg_install_dir}/inspect.cfg
+      mkdir -p "${cfg_install_dir}"
+      cp "${file_name}" "${cfg_install_dir}/inspect.cfg"
     fi
-    ${csudo}ln -sf ${cfg_install_dir}/inspect.cfg ${install_main_dir}/cfg
   fi
 
-  
+  if [ "${cfg_install_dir}" != "${install_main_dir}/cfg" ]; then
+    ln -sfn "${cfg_install_dir}/inspect.cfg" "${install_main_dir}/cfg"
+  fi
 }
 
 function install_log() {
-    ${csudo}rm -rf ${log_dir}  || :
+  rm -rf "${log_dir}" || :
+  mkdir -p "${log_dir}"
+  chmod 777 "${log_dir}" || :
 
-    if [ "$osType" != "Darwin" ]; then
-        ${csudo}mkdir -p ${log_dir} && ${csudo}chmod 777 ${log_dir}
-    else
-        mkdir -p ${log_dir} && ${csudo}chmod 777 ${log_dir}
-    fi
-    ${csudo}ln -s ${log_dir} ${install_main_dir}/log
+  if [ "${log_dir}" != "${install_main_dir}/log" ]; then
+    ln -sfn "${log_dir}" "${install_main_dir}/log"
+  fi
 }
 
 function install_connector() {
-    if [ -d ${script_dir}/connector ]; then
-        ${csudo}cp -rf ${script_dir}/connector/ ${install_main_dir}/
-    fi
+  if [ -d "${script_dir}/connector" ]; then
+    cp -rf "${script_dir}/connector/" "${install_main_dir}/"
+  fi
 }
 
 function install_examples() {
-    if [ -d ${script_dir}/examples ]; then
-        ${csudo}cp -rf ${script_dir}/examples/* ${install_main_dir}/examples
-    fi
+  if [ -d "${script_dir}/examples" ]; then
+    cp -rf "${script_dir}/examples/"* "${install_main_dir}/examples"
+  fi
 }
 
 function update_TDengine() {
-    # Start to update
-    if [ ! -e ${tarName} ]; then
-        echo "File ${tarName} does not exist"
-        exit 1
-    fi
-    tar -zxf ${tarName}
-    echo -e "${GREEN}Start to update ${productName2} client...${NC}"
-    # Stop the client shell if running
-    if ps aux | grep -v grep | grep ${clientName2} &> /dev/null; then
-        kill_client
-        sleep 1
-    fi
+  if [ ! -e "${tarName}" ]; then
+    echo "File ${tarName} does not exist"
+    exit 1
+  fi
+  tar -zxf "${tarName}"
+  echo -e "${GREEN}Start to update ${productName2} client...${NC}"
+  if ps aux | grep -v grep | grep "${clientName2}" &> /dev/null; then
+    kill_client
+    sleep 1
+  fi
 
-    install_main_path
+  install_main_path
+  echo "${install_main_dir}" > "${install_main_dir}/.install_path"
 
-    install_log
-    install_header
-    install_lib
-    install_jemalloc
-    if [ "$verMode" == "cluster" ]; then
-        install_connector
-        install_taosinspect_config
-    fi
-    install_examples
-    install_bin
-    install_config
+  install_log
+  install_header
+  install_lib
+  install_jemalloc
+  if [ "$verMode" == "cluster" ]; then
+    install_connector
+    install_taosinspect_config
+  fi
+  install_examples
+  install_bin
+  install_config
 
-    echo
-    echo -e "\033[44;32;1m${productName2} client is updated successfully!${NC}"
+  echo
+  echo -e "\033[44;32;1m${productName2} client is updated successfully!${NC}"
 
-    rm -rf $(tar -tf ${tarName} | grep -Ev "^\./$|^\/")
+  rm -rf $(tar -tf "${tarName}" | grep -Ev "^\./$|^\/")
 }
 
 function install_TDengine() {
-    # Start to install
-    if [ ! -e ${tarName} ]; then
-        echo "File ${tarName} does not exist"
-        exit 1
-    fi
-    tar -zxf ${tarName}
-    echo -e "${GREEN}Start to install ${productName2} client...${NC}"
+  if [ ! -e "${tarName}" ]; then
+    echo "File ${tarName} does not exist"
+    exit 1
+  fi
+  tar -zxf "${tarName}"
+  echo -e "${GREEN}Start to install ${productName2} client...${NC}"
 
-    install_main_path
-    install_log
-    install_header
-    install_lib
-    install_jemalloc
-    if [ "$verMode" == "cluster" ]; then
-        install_connector
-        install_taosinspect_config
-    fi
-    install_examples
-    install_bin
-    install_config
+  install_main_path
+  echo "${install_main_dir}" > "${install_main_dir}/.install_path"
 
-    echo
-    echo -e "\033[44;32;1m${productName2} client is installed successfully!${NC}"
+  install_log
+  install_header
+  install_lib
+  install_jemalloc
+  if [ "$verMode" == "cluster" ]; then
+    install_connector
+    install_taosinspect_config
+  fi
+  install_examples
+  install_bin
+  install_config
 
-    rm -rf $(tar -tf ${tarName} | grep -Ev "^\./$|^\/")
+  echo
+  echo -e "\033[44;32;1m${productName2} client is installed successfully!${NC}"
+
+  rm -rf $(tar -tf "${tarName}" | grep -Ev "^\./$|^\/")
 }
 
+setup_env
+check_conflicting_system_installation
 
 ## ==============================Main program starts from here============================
 # Install or updata client and client
 # if server is already install, don't install client
-if [ -e ${bin_dir}/${serverName} ]; then
-    echo -e "\033[44;32;1mThere are already installed ${productName2} server, so don't need install client!${NC}"
-    exit 0
+if [ -e "${bin_dir}/${serverName}" ]; then
+  echo -e "\033[44;32;1mThere are already installed ${productName2} server, so don't need install client!${NC}"
+  exit 0
 fi
 
-if [ -x ${bin_dir}/${clientName} ]; then
-    update_flag=1
-    update_TDengine
+if [ -x "${bin_dir}/${clientName}" ]; then
+  update_flag=1
+  update_TDengine
 else
-    install_TDengine
+  install_TDengine
 fi

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -45,9 +45,9 @@ elif [ "$osType" != "Darwin" ]; then
   installDir="/usr/local/${PREFIX}"
 else
   if [ -d "/usr/local/Cellar/" ]; then
-    installDir="/usr/local/Cellar/tdengine/${verNumber}"
+    installDir="/usr/local/Cellar/tdengine/"
   elif [ -d "/opt/homebrew/Cellar/" ]; then
-    installDir="/opt/homebrew/Cellar/tdengine/${verNumber}"
+    installDir="/opt/homebrew/Cellar/tdengine/"
   else
     installDir="/usr/local/${PREFIX}"
   fi
@@ -262,9 +262,9 @@ remove_service_of() {
   _service=$1
   clean_service_of ${_service}
   if [[ -e "${bin_link_dir}/${_service}" || -e "${installDir}/bin/${_service}" || -e "${local_bin_link_dir}/${_service}" ]]; then
-    rm -rf ${bin_link_dir}/${_service}
-    rm -rf ${installDir}/bin/${_service}
-    rm -rf ${local_bin_link_dir}/${_service}
+    rm -rf "${bin_link_dir}/${_service}"
+    rm -rf "${installDir}/bin/${_service}"
+    rm -rf "${local_bin_link_dir}/${_service}"
     echo "${_service} is removed successfully!"
   fi
 }
@@ -272,9 +272,9 @@ remove_service_of() {
 remove_tools_of() {
   _tool=$1
   kill_service_of ${_tool}
-  [ -L "${bin_link_dir}/${_tool}" ] && rm -rf ${bin_link_dir}/${_tool} || :
-  [ -e "${installDir}/bin/${_tool}" ] && rm -rf ${installDir}/bin/${_tool} || :
-  [ -L "${local_bin_link_dir}/${_tool}" ] && rm -rf ${local_bin_link_dir}/${_tool} || :
+  [ -L "${bin_link_dir}/${_tool}" ] && rm -rf "${bin_link_dir}/${_tool}" || :
+  [ -e "${installDir}/bin/${_tool}" ] && rm -rf "${installDir}/bin/${_tool}" || :
+  [ -L "${local_bin_link_dir}/${_tool}" ] && rm -rf "${local_bin_link_dir}/${_tool}" || :
 }
 
 remove_bin() {
@@ -323,7 +323,7 @@ function clean_log() {
   if [ "${log_link_dir}" = "${log_dir}" ]; then
     return 0
   fi
-  rm -rf ${log_link_dir} || :
+  rm -rf "${log_link_dir}" || :
 }
 
 function clean_service_on_launchctl() {
@@ -375,7 +375,7 @@ function remove_data_and_config() {
   
   
   if [ -d "${config_dir}" ]; then
-    rm -rf ${config_dir}
+    rm -rf "${config_dir}"
   fi
 
   if [ -d "${data_dir}" ]; then
@@ -410,14 +410,14 @@ function remove_data_and_config() {
 }
 
 function remove_install_main_dir() {
-  rm -f ${install_main_dir}/uninstall_${PREFIX}x.sh ${install_main_dir}/uninstall.sh ${install_main_dir}/.install_path || :
+  rm -f "${install_main_dir}/uninstall_${PREFIX}x.sh" "${install_main_dir}/uninstall.sh" "${install_main_dir}/.install_path" || :
 
   if [ "$user_mode" -eq 1 ] && [ X$remove_flag != X"true" ]; then
     find "${install_main_dir}" -mindepth 1 -maxdepth 1 ! \( -name cfg -o -name log -o -name data \) -exec rm -rf {} + || :
     return 0
   fi
 
-  rm -rf ${install_main_dir} || :
+  rm -rf "${install_main_dir}" || :
 }
 
 function usage() {
@@ -486,7 +486,7 @@ clean_log
 clean_config
 # Remove data link directory
 if [ "${data_link_dir}" != "${data_dir}" ]; then
-  rm -rf ${data_link_dir} || :
+  rm -rf "${data_link_dir}" || :
 fi
 
 if [ X$remove_flag == X"true" ]; then

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -90,7 +90,6 @@ validate_safe_path "$installDir"
 # User mode detection: non-root uses per-user directories and systemd user bus.
 if [ "$(id -u)" -ne 0 ]; then
   user_mode=1
-  csudo=""
   bin_link_dir="$HOME/.local/bin"
   lib_link_dir="$HOME/.local/lib"
   lib64_link_dir="$HOME/.local/lib64"
@@ -116,15 +115,6 @@ else
   services=(${PREFIX}"d" ${PREFIX}"adapter" ${PREFIX}"keeper" ${PREFIX}"-explorer")
 fi
 
-csudo=""
-if command -v sudo >/dev/null; then
-  csudo="sudo "
-fi
-
-# Override: non-root installs must never use sudo for file operations.
-if [ "$user_mode" -eq 1 ]; then
-  csudo=""
-fi
 
 initd_mod=0
 service_mod=2
@@ -150,7 +140,7 @@ kill_service_of() {
   _service=$1
   pid=$(ps aux | grep -w $_service | grep -v grep | grep -v $uninstallScript | awk '{print $2}')
   if [ -n "$pid" ]; then
-    ${csudo}kill -9 $pid || :
+    kill -9 $pid || :
   fi
 }
 
@@ -169,26 +159,26 @@ clean_service_on_sysvinit_of() {
   _service=$1
   if pidof ${_service} &>/dev/null; then
     echo "${_service} is running, stopping it..."
-    ${csudo}service ${_service} stop || :
+    service ${_service} stop || :
   fi
   if ((${initd_mod} == 1)); then
     if [ -e ${service_config_dir}/${_service} ]; then
-      ${csudo}chkconfig --del ${_service} || :
+      chkconfig --del ${_service} || :
     fi
   elif ((${initd_mod} == 2)); then
     if [ -e ${service_config_dir}/${_service} ]; then
-      ${csudo}insserv -r ${_service} || :
+      insserv -r ${_service} || :
     fi
   elif ((${initd_mod} == 3)); then
     if [ -e ${service_config_dir}/${_service} ]; then
-      ${csudo}update-rc.d -f ${_service} remove || :
+      update-rc.d -f ${_service} remove || :
     fi
   fi
 
-  ${csudo}rm -f ${service_config_dir}/${_service} || :
+  rm -f ${service_config_dir}/${_service} || :
 
   if $(which init &>/dev/null); then
-    ${csudo}init q || :
+    init q || :
   fi
 }
 
@@ -206,9 +196,9 @@ remove_service_of() {
   _service=$1
   clean_service_of ${_service}
   if [[ -e "${bin_link_dir}/${_service}" || -e "${installDir}/bin/${_service}" || -e "${local_bin_link_dir}/${_service}" ]]; then
-    ${csudo}rm -rf ${bin_link_dir}/${_service}
-    ${csudo}rm -rf ${installDir}/bin/${_service}
-    ${csudo}rm -rf ${local_bin_link_dir}/${_service}
+    rm -rf ${bin_link_dir}/${_service}
+    rm -rf ${installDir}/bin/${_service}
+    rm -rf ${local_bin_link_dir}/${_service}
     echo "${_service} is removed successfully!"
   fi
 }
@@ -216,9 +206,9 @@ remove_service_of() {
 remove_tools_of() {
   _tool=$1
   kill_service_of ${_tool}
-  [ -L "${bin_link_dir}/${_tool}" ] && ${csudo}rm -rf ${bin_link_dir}/${_tool} || :
-  [ -e "${installDir}/bin/${_tool}" ] && ${csudo}rm -rf ${installDir}/bin/${_tool} || :
-  [ -L "${local_bin_link_dir}/${_tool}" ] && ${csudo}rm -rf ${local_bin_link_dir}/${_tool} || :
+  [ -L "${bin_link_dir}/${_tool}" ] && rm -rf ${bin_link_dir}/${_tool} || :
+  [ -e "${installDir}/bin/${_tool}" ] && rm -rf ${installDir}/bin/${_tool} || :
+  [ -L "${local_bin_link_dir}/${_tool}" ] && rm -rf ${local_bin_link_dir}/${_tool} || :
 }
 
 remove_bin() {
@@ -236,46 +226,46 @@ function clean_lib() {
   for dir in "${lib_link_dir}" "${lib64_link_dir}"; do
     if [ -d "$dir" ]; then
       for pattern in "libtaos.*" "libtaosnative.*" "libtaosws.*"; do
-        ${csudo}find "$dir" -name "$pattern" -exec ${csudo}rm -f {} \; || :
+        find "$dir" -name "$pattern" -exec rm -f {} \; || :
       done
     fi
   done
-  #${csudo}rm -rf ${v15_java_app_dir}           || :
+  #rm -rf ${v15_java_app_dir}           || :
 }
 
 function clean_header() {
   # Remove link
-  ${csudo}rm -f ${inc_link_dir}/taos.h || :
-  ${csudo}rm -f ${inc_link_dir}/taosdef.h || :
-  ${csudo}rm -f ${inc_link_dir}/taoserror.h || :
-  ${csudo}rm -f ${inc_link_dir}/tdef.h || :
-  ${csudo}rm -f ${inc_link_dir}/taosudf.h || :
+  rm -f ${inc_link_dir}/taos.h || :
+  rm -f ${inc_link_dir}/taosdef.h || :
+  rm -f ${inc_link_dir}/taoserror.h || :
+  rm -f ${inc_link_dir}/tdef.h || :
+  rm -f ${inc_link_dir}/taosudf.h || :
 
-  [ -f ${inc_link_dir}/taosws.h ] && ${csudo}rm -f ${inc_link_dir}/taosws.h || :
+  [ -f ${inc_link_dir}/taosws.h ] && rm -f ${inc_link_dir}/taosws.h || :
 }
 
 function clean_config() {
   # Remove link
-  ${csudo}rm -f ${cfg_link_dir}/* || :
+  rm -f ${cfg_link_dir}/* || :
 }
 
 function clean_log() {
   # Remove link
-  ${csudo}rm -rf ${log_link_dir} || :
+  rm -rf ${log_link_dir} || :
 }
 
 function clean_service_on_launchctl() {
-  ${csudo}launchctl unload -w /Library/LaunchDaemons/com.taosdata.taosd.plist || :
-  ${csudo}launchctl unload -w /Library/LaunchDaemons/com.taosdata.${PREFIX}adapter.plist || :
-  ${csudo}launchctl unload -w /Library/LaunchDaemons/com.taosdata.${PREFIX}keeper.plist || :
-  ${csudo}launchctl unload -w /Library/LaunchDaemons/com.taosdata.${PREFIX}-explorer.plist || :
+  launchctl unload -w /Library/LaunchDaemons/com.taosdata.taosd.plist || :
+  launchctl unload -w /Library/LaunchDaemons/com.taosdata.${PREFIX}adapter.plist || :
+  launchctl unload -w /Library/LaunchDaemons/com.taosdata.${PREFIX}keeper.plist || :
+  launchctl unload -w /Library/LaunchDaemons/com.taosdata.${PREFIX}-explorer.plist || :
 
-  ${csudo}launchctl remove com.tdengine.taosd || :
-  ${csudo}launchctl remove com.tdengine.${PREFIX}adapter || :
-  ${csudo}launchctl remove com.tdengine.${PREFIX}keeper || :
-  ${csudo}launchctl remove com.tdengine.${PREFIX}-explorer || :
+  launchctl remove com.tdengine.taosd || :
+  launchctl remove com.tdengine.${PREFIX}adapter || :
+  launchctl remove com.tdengine.${PREFIX}keeper || :
+  launchctl remove com.tdengine.${PREFIX}-explorer || :
 
-  ${csudo}rm /Library/LaunchDaemons/com.taosdata.* >/dev/null 2>&1 || :
+  rm /Library/LaunchDaemons/com.taosdata.* >/dev/null 2>&1 || :
 }
 
 function batch_remove_paths_and_clean_dir() {
@@ -283,11 +273,11 @@ function batch_remove_paths_and_clean_dir() {
   shift
   local paths=("$@")
   for path in "${paths[@]}"; do
-    ${csudo}rm -rf "$path" || :
+    rm -rf "$path" || :
   done
-  ${csudo}find "$dir" -type d -empty -delete || :
+  find "$dir" -type d -empty -delete || :
   if [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
-    ${csudo}rm -rf "$dir" || :
+    rm -rf "$dir" || :
   fi
 }
 
@@ -313,7 +303,7 @@ function remove_data_and_config() {
   
   
   if [ -d "${config_dir}" ]; then
-    ${csudo}rm -rf ${config_dir}
+    rm -rf ${config_dir}
   fi
 
   if [ -d "${data_dir}" ]; then
@@ -403,7 +393,7 @@ fi
 
 if [ "$osType" = "Darwin" ]; then
   clean_service_on_launchctl
-  ${csudo}rm -rf /Applications/TDengine.app
+  rm -rf /Applications/TDengine.app
 fi
 
 remove_bin
@@ -415,13 +405,13 @@ clean_log
 # Remove link configuration file
 clean_config
 # Remove data link directory
-${csudo}rm -rf ${data_link_dir} || :
+rm -rf ${data_link_dir} || :
 
 if [ X$remove_flag == X"true" ]; then
   remove_data_and_config
 fi
 
-${csudo}rm -rf ${install_main_dir} || :
+rm -rf ${install_main_dir} || :
 if [[ -e /etc/os-release ]]; then
   osinfo=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
 else
@@ -430,13 +420,13 @@ fi
 
 if echo $osinfo | grep -qwi "ubuntu"; then
   #  echo "this is ubuntu system"
-  ${csudo}dpkg --force-all -P tdengine >/dev/null 2>&1 || :
+  dpkg --force-all -P tdengine >/dev/null 2>&1 || :
 elif echo $osinfo | grep -qwi "debian"; then
   #  echo "this is debian system"
-  ${csudo}dpkg --force-all -P tdengine >/dev/null 2>&1 || :
+  dpkg --force-all -P tdengine >/dev/null 2>&1 || :
 elif echo $osinfo | grep -qwi "centos"; then
   #  echo "this is centos system"
-  ${csudo}rpm -e --noscripts tdengine >/dev/null 2>&1 || :
+  rpm -e --noscripts tdengine >/dev/null 2>&1 || :
 fi
 
 command -v systemctl >/dev/null 2>&1 && ${sysctl_cmd} daemon-reload >/dev/null 2>&1 || true

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -15,23 +15,42 @@ NC='\033[0m'
 PREFIX="taos"
 
 if [ "$osType" != "Darwin" ]; then
-  installDir="/usr/local/taos"
   bin_link_dir="/usr/bin"
   lib_link_dir="/usr/lib"
   lib64_link_dir="/usr/lib64"
   inc_link_dir="/usr/include"
+else
+  bin_link_dir="/usr/local/bin"
+  lib_link_dir="/usr/local/lib"
+  lib64_link_dir="/usr/local/lib"
+  inc_link_dir="/usr/local/include"
+fi
+
+# Install path discovery: prefer the .install_path sentinel written by install.sh.
+_script_real="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+_script_dir="$(dirname "$_script_real")"
+if [[ "$_script_dir" == */bin ]]; then
+  _guessed_dir="${_script_dir%/bin}"
+else
+  _guessed_dir="$_script_dir"
+fi
+
+if [ -f "${_guessed_dir}/.install_path" ]; then
+  installDir=$(cat "${_guessed_dir}/.install_path")
+elif [ -f "/usr/local/${PREFIX}/.install_path" ]; then
+  installDir=$(cat "/usr/local/${PREFIX}/.install_path")
+elif [ -f "$HOME/${PREFIX}/.install_path" ]; then
+  installDir=$(cat "$HOME/${PREFIX}/.install_path")
+elif [ "$osType" != "Darwin" ]; then
+  installDir="/usr/local/${PREFIX}"
 else
   if [ -d "/usr/local/Cellar/" ]; then
     installDir="/usr/local/Cellar/tdengine/${verNumber}"
   elif [ -d "/opt/homebrew/Cellar/" ]; then
     installDir="/opt/homebrew/Cellar/tdengine/${verNumber}"
   else
-    installDir="/usr/local/taos"
+    installDir="/usr/local/${PREFIX}"
   fi
-  bin_link_dir="/usr/local/bin"
-  lib_link_dir="/usr/local/lib"
-  lib64_link_dir="/usr/local/lib"
-  inc_link_dir="/usr/local/include"
 fi
 
 serverName="${PREFIX}d"
@@ -56,6 +75,32 @@ cfg_link_dir=${installDir}/cfg
 local_bin_link_dir="/usr/local/bin"
 service_config_dir="/etc/systemd/system"
 config_dir="/etc/${PREFIX}"
+
+validate_safe_path() {
+  local path="$1"
+  case "$path" in
+    ""|"/"|"/etc"|"/bin"|"/lib"|"/usr"|"/sbin"|"/boot"|"/root"|"/home"|"/var"|"/tmp"|"/dev"|"/proc"|"/sys"|"/run")
+      echo -e "${RED}Refusing to operate on dangerous system path: $path${NC}"
+      exit 1
+      ;;
+  esac
+}
+validate_safe_path "$installDir"
+
+# User mode detection: non-root uses per-user directories and systemd user bus.
+if [ "$(id -u)" -ne 0 ]; then
+  user_mode=1
+  bin_link_dir="$HOME/.local/bin"
+  lib_link_dir="$HOME/.local/lib"
+  lib64_link_dir="$HOME/.local/lib64"
+  inc_link_dir="$HOME/.local/include"
+  config_dir="${installDir}/cfg"
+  service_config_dir="$HOME/.config/systemd/user"
+  sysctl_cmd="systemctl --user"
+else
+  user_mode=0
+  sysctl_cmd="systemctl"
+fi
 
 if [ "${verMode}" == "cluster" ]; then
   if [ "${entMode}" == "full" ]; then
@@ -106,12 +151,12 @@ kill_service_of() {
 clean_service_on_systemd_of() {
   _service=$1
   _service_config="${service_config_dir}/${_service}.service"
-  if systemctl is-active --quiet ${_service}; then
+  if ${sysctl_cmd} is-active --quiet ${_service}; then
     echo "${_service} is running, stopping it..."
-    ${csudo}systemctl stop ${_service} &>/dev/null || echo &>/dev/null
+    ${sysctl_cmd} stop ${_service} &>/dev/null || echo &>/dev/null
   fi
-  ${csudo}systemctl disable ${_service} &>/dev/null || echo &>/dev/null
-  ${csudo}rm -f ${_service_config}
+  ${sysctl_cmd} disable ${_service} &>/dev/null || echo &>/dev/null
+  rm -f ${_service_config}
 }
 
 clean_service_on_sysvinit_of() {
@@ -241,14 +286,23 @@ function batch_remove_paths_and_clean_dir() {
 }
 
 function remove_data_and_config() {
-  data_dir=$(grep dataDir /etc/${PREFIX}/${PREFIX}.cfg | grep -v '#' | tail -n 1 | awk {'print $2'})
+  local cfg_file="${config_dir}/${PREFIX}.cfg"
+  data_dir=$(grep dataDir "${cfg_file}" 2>/dev/null | grep -v '#' | tail -n 1 | awk {'print $2'})
   if [ -z "$data_dir" ]; then
-    data_dir="/var/lib/${PREFIX}"
+    if [ "$user_mode" -eq 1 ]; then
+      data_dir="${installDir}/data"
+    else
+      data_dir="/var/lib/${PREFIX}"
+    fi
   fi
 
-  log_dir=$(grep logDir /etc/${PREFIX}/${PREFIX}.cfg | grep -v '#' | tail -n 1 | awk {'print $2'})
+  log_dir=$(grep logDir "${cfg_file}" 2>/dev/null | grep -v '#' | tail -n 1 | awk {'print $2'})
   if [ -z "$log_dir" ]; then
-    log_dir="/var/log/${PREFIX}"
+    if [ "$user_mode" -eq 1 ]; then
+      log_dir="${installDir}/log"
+    else
+      log_dir="/var/log/${PREFIX}"
+    fi
   fi
   
   
@@ -379,7 +433,7 @@ elif echo $osinfo | grep -qwi "centos"; then
   ${csudo}rpm -e --noscripts tdengine >/dev/null 2>&1 || :
 fi
 
-command -v systemctl >/dev/null 2>&1 && ${csudo}systemctl daemon-reload >/dev/null 2>&1 || true
+command -v systemctl >/dev/null 2>&1 && ${sysctl_cmd} daemon-reload >/dev/null 2>&1 || true
 echo
 echo "${productName} is removed successfully!"
 echo

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -221,6 +221,32 @@ clean_service_on_systemd_of() {
   rm -f ${_service_config}
 }
 
+function clean_env_file() {
+  if [ "$user_mode" -ne 1 ]; then
+    return 0
+  fi
+
+  local env_file=""
+  local login_shell="${SHELL##*/}"
+  if [ "$login_shell" = "zsh" ]; then
+    env_file="${HOME}/.zshrc"
+  elif [ "$login_shell" = "bash" ] || [ -z "$login_shell" ]; then
+    env_file="${HOME}/.bashrc"
+  else
+    env_file="${HOME}/.profile"
+  fi
+
+  if [ ! -f "$env_file" ]; then
+    return 0
+  fi
+
+  local tmp_file="${env_file}.tmp.$$"
+  sed -e "/^# ${productName} install path$/d" \
+      -e "\|^export PATH=\"${bin_link_dir}:.*\"|d" \
+      -e "\|^export LD_LIBRARY_PATH=\"${lib_link_dir}:.*\"|d" \
+      "$env_file" > "$tmp_file" && mv "$tmp_file" "$env_file" || rm -f "$tmp_file"
+}
+
 clean_service_on_sysvinit_of() {
   _service=$1
   if pidof ${_service} &>/dev/null; then
@@ -511,6 +537,7 @@ elif echo $osinfo | grep -qwi "centos"; then
   rpm -e --noscripts tdengine >/dev/null 2>&1 || :
 fi
 
+clean_env_file
 command -v systemctl >/dev/null 2>&1 && ${sysctl_cmd} daemon-reload >/dev/null 2>&1 || true
 echo
 echo "${productName} is removed successfully!"

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -102,17 +102,34 @@ else
   sysctl_cmd="systemctl"
 fi
 
+if [ "$user_mode" -eq 1 ]; then
+  data_dir="${installDir}/data"
+  log_dir="${installDir}/log"
+else
+  data_dir="/var/lib/${PREFIX}"
+  log_dir="/var/log/${PREFIX}"
+fi
+
 if [ "${verMode}" == "cluster" ]; then
   if [ "${entMode}" == "full" ]; then
-    services=(${PREFIX}"d" ${PREFIX}"adapter" ${PREFIX}"keeper")
+    services=(${PREFIX}"d" ${PREFIX}"adapter" ${PREFIX}"keeper" ${PREFIX}"x" ${PREFIX}"-explorer")
   else
     services=(${PREFIX}"d" ${PREFIX}"adapter" ${PREFIX}"keeper" ${PREFIX}"-explorer")
   fi
-  tools=(${PREFIX} ${PREFIX}"Benchmark" ${PREFIX}"dump" ${PREFIX}"demo" ${PREFIX}"inspect" ${PREFIX}"udf" set_core.sh TDinsight.sh $uninstallScript start-all.sh stop-all.sh)
+  tools=(${PREFIX} ${PREFIX}"Benchmark" ${PREFIX}"dump" ${PREFIX}"demo" ${PREFIX}"inspect" ${PREFIX}"udf" set_core.sh TDinsight.sh $uninstallScript start-all.sh stop-all.sh uninstall_taosx.sh)
 else
-  tools=(${PREFIX} ${PREFIX}"Benchmark" ${PREFIX}"dump" ${PREFIX}"demo" ${PREFIX}"udf" set_core.sh TDinsight.sh $uninstallScript start-all.sh stop-all.sh)
+  tools=(${PREFIX} ${PREFIX}"Benchmark" ${PREFIX}"dump" ${PREFIX}"demo" ${PREFIX}"udf" set_core.sh TDinsight.sh $uninstallScript start-all.sh stop-all.sh uninstall_taosx.sh)
 
   services=(${PREFIX}"d" ${PREFIX}"adapter" ${PREFIX}"keeper" ${PREFIX}"-explorer")
+fi
+
+if [ -x "${install_main_dir}/bin/${xName}" ] || [ -f "${service_config_dir}/${xName}.service" ]; then
+  case " ${services[*]} " in
+  *" ${xName} "*) ;;
+  *)
+    services=(${services[@]} ${xName})
+    ;;
+  esac
 fi
 
 
@@ -138,10 +155,59 @@ fi
 
 kill_service_of() {
   _service=$1
-  pid=$(ps aux | grep -w $_service | grep -v grep | grep -v $uninstallScript | awk '{print $2}')
-  if [ -n "$pid" ]; then
-    kill -9 $pid || :
+  local current_user
+  local pids
+  local config_dir_escaped
+
+  if [ "$user_mode" -eq 1 ]; then
+    current_user=$(id -un)
+    pids=$(ps -eo user=,pid=,comm= | awk -v svc="$_service" -v current_user="$current_user" '$1 == current_user && $3 == svc {print $2}')
+  else
+    config_dir_escaped=${config_dir%/}
+    local allow_default_root_config=0
+    if [ "$config_dir_escaped" = "/etc/${PREFIX}" ]; then
+      allow_default_root_config=1
+    fi
+    pids=$(ps -eo pid=,args= | awk -v svc="$_service" -v config_dir="$config_dir_escaped" -v allow_default_root_config="$allow_default_root_config" '
+      function service_matches(cmd, svc, parts, cmd_name, field_count) {
+        field_count = split(cmd, parts, /[[:space:]]+/)
+        cmd_name = parts[1]
+        sub("^.*/", "", cmd_name)
+        return cmd_name == svc
+      }
+
+      function config_match(cmd, config_dir, parts, i, cfg_arg, field_count) {
+        field_count = split(cmd, parts, /[[:space:]]+/)
+        for (i = 1; i < field_count; i++) {
+          if (parts[i] == "-c") {
+            cfg_arg = parts[i + 1]
+            if (cfg_arg == config_dir || index(cfg_arg, config_dir "/") == 1) {
+              return 1
+            }
+            return 0
+          }
+        }
+        return -1
+      }
+
+      {
+        pid = $1
+        $1 = ""
+        sub(/^[[:space:]]+/, "", $0)
+        cmd = $0
+        if (!service_matches(cmd, svc)) {
+          next
+        }
+        cfg_match = config_match(cmd, config_dir)
+        if (cfg_match == 1 || (cfg_match == -1 && allow_default_root_config == 1)) {
+          print pid
+        }
+      }')
   fi
+
+  while IFS= read -r pid; do
+    [ -n "$pid" ] && kill -9 "$pid" || :
+  done <<< "$pids"
 }
 
 clean_service_on_systemd_of() {
@@ -246,11 +312,17 @@ function clean_header() {
 
 function clean_config() {
   # Remove link
+  if [ "${cfg_link_dir}" = "${config_dir}" ]; then
+    return 0
+  fi
   rm -f ${cfg_link_dir}/* || :
 }
 
 function clean_log() {
   # Remove link
+  if [ "${log_link_dir}" = "${log_dir}" ]; then
+    return 0
+  fi
   rm -rf ${log_link_dir} || :
 }
 
@@ -311,9 +383,14 @@ function remove_data_and_config() {
       "${data_dir}/dnode"
       "${data_dir}/mnode"
       "${data_dir}/vnode"
+      "${data_dir}/snode"
+      "${data_dir}/xnode"
       "${data_dir}/.udf"
       "${data_dir}/.running"*
       "${data_dir}/.taosudf"*
+      "${data_dir}/${PREFIX}x"*
+      "${data_dir}/explorer"*
+      "${data_dir}/backup"
     )
     batch_remove_paths_and_clean_dir "${data_dir}" "${data_remove_list[@]}"
   fi
@@ -330,6 +407,17 @@ function remove_data_and_config() {
     )
     batch_remove_paths_and_clean_dir "${log_dir}" "${log_remove_list[@]}"
   fi
+}
+
+function remove_install_main_dir() {
+  rm -f ${install_main_dir}/uninstall_${PREFIX}x.sh ${install_main_dir}/uninstall.sh ${install_main_dir}/.install_path || :
+
+  if [ "$user_mode" -eq 1 ] && [ X$remove_flag != X"true" ]; then
+    find "${install_main_dir}" -mindepth 1 -maxdepth 1 ! \( -name cfg -o -name log -o -name data \) -exec rm -rf {} + || :
+    return 0
+  fi
+
+  rm -rf ${install_main_dir} || :
 }
 
 function usage() {
@@ -383,14 +471,6 @@ if [ "$interactive_remove" == "yes" ]; then
   echo
 fi
 
-if [ -e ${install_main_dir}/uninstall_${PREFIX}x.sh ]; then
-  if [ X$remove_flag == X"true" ]; then
-    bash ${install_main_dir}/uninstall_${PREFIX}x.sh --clean-all true
-  else
-    bash ${install_main_dir}/uninstall_${PREFIX}x.sh --clean-all false
-  fi
-fi
-
 if [ "$osType" = "Darwin" ]; then
   clean_service_on_launchctl
   rm -rf /Applications/TDengine.app
@@ -405,13 +485,15 @@ clean_log
 # Remove link configuration file
 clean_config
 # Remove data link directory
-rm -rf ${data_link_dir} || :
+if [ "${data_link_dir}" != "${data_dir}" ]; then
+  rm -rf ${data_link_dir} || :
+fi
 
 if [ X$remove_flag == X"true" ]; then
   remove_data_and_config
 fi
 
-rm -rf ${install_main_dir} || :
+remove_install_main_dir
 if [[ -e /etc/os-release ]]; then
   osinfo=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
 else

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -121,6 +121,11 @@ if command -v sudo >/dev/null; then
   csudo="sudo "
 fi
 
+# Override: non-root installs must never use sudo for file operations.
+if [ "$user_mode" -eq 1 ]; then
+  csudo=""
+fi
+
 initd_mod=0
 service_mod=2
 if ps aux | grep -v grep | grep systemd &>/dev/null; then

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -288,9 +288,9 @@ remove_service_of() {
   _service=$1
   clean_service_of ${_service}
   if [[ -e "${bin_link_dir}/${_service}" || -e "${installDir}/bin/${_service}" || -e "${local_bin_link_dir}/${_service}" ]]; then
-    rm -rf "${bin_link_dir}/${_service}"
-    rm -rf "${installDir}/bin/${_service}"
-    rm -rf "${local_bin_link_dir}/${_service}"
+    rm -rf "${bin_link_dir}/${_service}" || :
+    rm -rf "${installDir}/bin/${_service}" || :
+    [ "$user_mode" -eq 0 ] && rm -rf "${local_bin_link_dir}/${_service}" || :
     echo "${_service} is removed successfully!"
   fi
 }
@@ -526,15 +526,14 @@ else
   osinfo=""
 fi
 
-if echo $osinfo | grep -qwi "ubuntu"; then
-  #  echo "this is ubuntu system"
-  dpkg --force-all -P tdengine >/dev/null 2>&1 || :
-elif echo $osinfo | grep -qwi "debian"; then
-  #  echo "this is debian system"
-  dpkg --force-all -P tdengine >/dev/null 2>&1 || :
-elif echo $osinfo | grep -qwi "centos"; then
-  #  echo "this is centos system"
-  rpm -e --noscripts tdengine >/dev/null 2>&1 || :
+if [ "$user_mode" -eq 0 ]; then
+  if echo $osinfo | grep -qwi "ubuntu"; then
+    dpkg --force-all -P tdengine >/dev/null 2>&1 || :
+  elif echo $osinfo | grep -qwi "debian"; then
+    dpkg --force-all -P tdengine >/dev/null 2>&1 || :
+  elif echo $osinfo | grep -qwi "centos"; then
+    rpm -e --noscripts tdengine >/dev/null 2>&1 || :
+  fi
 fi
 
 clean_env_file

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -90,6 +90,7 @@ validate_safe_path "$installDir"
 # User mode detection: non-root uses per-user directories and systemd user bus.
 if [ "$(id -u)" -ne 0 ]; then
   user_mode=1
+  csudo=""
   bin_link_dir="$HOME/.local/bin"
   lib_link_dir="$HOME/.local/lib"
   lib64_link_dir="$HOME/.local/lib64"

--- a/packaging/tools/remove_client.sh
+++ b/packaging/tools/remove_client.sh
@@ -102,7 +102,7 @@ function kill_client() {
     fi
 
     if [ -n "$pids" ]; then
-      echo "$pids" | xargs -r kill -9 2>/dev/null || :
+      echo "$pids" | while read p; do kill -9 "$p" 2>/dev/null || :; done
     fi
   done
 }

--- a/packaging/tools/remove_client.sh
+++ b/packaging/tools/remove_client.sh
@@ -8,11 +8,10 @@ RED='\033[0;31m'
 GREEN='\033[1;32m'
 NC='\033[0m'
 verMode=edge
+osType=$(uname)
 
-installDir="/usr/local/taos"
 clientName="taos"
 uninstallScript="rmtaos"
-
 clientName2="taos"
 productName2="TDengine"
 
@@ -20,119 +19,183 @@ benchmarkName2="${clientName2}Benchmark"
 demoName2="${clientName2}demo"
 dumpName2="${clientName2}dump"
 inspect_name="${clientName2}inspect"
+taosgen_name="${clientName2}gen"
 uninstallScript2="rm${clientName2}"
 
-installDir="/usr/local/${clientName2}"
-
-#install main path
-install_main_dir=${installDir}
-
-log_link_dir=${installDir}/log
-cfg_link_dir=${installDir}/cfg
-bin_link_dir="/usr/bin"
-lib_link_dir="/usr/lib"
-lib64_link_dir="/usr/lib64"
-inc_link_dir="/usr/include"
-log_dir="/var/log/${clientName2}"
-cfg_dir="/etc/${clientName2}"
-
-csudo=""
-if command -v sudo >/dev/null; then
-    csudo="sudo "
+_script_real="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+_script_dir="$(dirname "$_script_real")"
+if [[ "$_script_dir" == */bin ]]; then
+  _guessed_dir="${_script_dir%/bin}"
+else
+  _guessed_dir="$_script_dir"
 fi
 
+if [ -f "${_guessed_dir}/.install_path" ]; then
+  installDir=$(cat "${_guessed_dir}/.install_path")
+elif [ -f "/usr/local/${clientName2}/.install_path" ]; then
+  installDir=$(cat "/usr/local/${clientName2}/.install_path")
+elif [ -f "$HOME/${clientName2}/.install_path" ]; then
+  installDir=$(cat "$HOME/${clientName2}/.install_path")
+elif [ "$osType" != "Darwin" ]; then
+  installDir="/usr/local/${clientName2}"
+else
+  installDir="/usr/local/${clientName2}"
+fi
+
+validate_safe_path() {
+  local path="$1"
+  case "$path" in
+    ""|"/"|"/etc"|"/bin"|"/lib"|"/usr"|"/sbin"|"/boot"|"/root"|"/home"|"/var"|"/tmp"|"/dev"|"/proc"|"/sys"|"/run")
+      echo -e "${RED}Refusing to operate on dangerous system path: $path${NC}"
+      exit 1
+      ;;
+  esac
+}
+validate_safe_path "$installDir"
+
+install_main_dir=${installDir}
+log_link_dir=${installDir}/log
+cfg_link_dir=${installDir}/cfg
+
+if [ "$(id -u)" -ne 0 ]; then
+  user_mode=1
+  bin_link_dir="$HOME/.local/bin"
+  lib_link_dir="$HOME/.local/lib"
+  if [ "$osType" != "Darwin" ]; then
+    lib64_link_dir="$HOME/.local/lib64"
+  else
+    lib64_link_dir="$HOME/.local/lib"
+  fi
+  inc_link_dir="$HOME/.local/include"
+  log_dir="${installDir}/log"
+  cfg_dir="${installDir}/cfg"
+else
+  user_mode=0
+  if [ "$osType" != "Darwin" ]; then
+    bin_link_dir="/usr/bin"
+    lib_link_dir="/usr/lib"
+    lib64_link_dir="/usr/lib64"
+    inc_link_dir="/usr/include"
+    log_dir="/var/log/${clientName2}"
+    cfg_dir="/etc/${clientName2}"
+  else
+    bin_link_dir="/usr/local/bin"
+    lib_link_dir="/usr/local/lib"
+    lib64_link_dir="/usr/local/lib"
+    inc_link_dir="/usr/local/include"
+    log_dir="${installDir}/log"
+    cfg_dir="${installDir}/cfg"
+  fi
+fi
+
+remove_config_and_log="false"
+
 function kill_client() {
-    pid=$(ps -C ${clientName2} | grep -w ${clientName2} | grep -v $uninstallScript2 | awk '{print $1}')
-    if [ -n "$pid" ]; then
-        ${csudo}kill -9 $pid || :
+  current_user=$(id -un)
+  client_processes=("${clientName2}" "${benchmarkName2}" "${dumpName2}" "${demoName2}" "${inspect_name}" "${taosgen_name}")
+
+  for process_name in "${client_processes[@]}"; do
+    if [ "$user_mode" -eq 1 ]; then
+      pids=$(ps -eo pid=,user=,comm= | awk -v current_user="$current_user" -v process_name="$process_name" '$2 == current_user && $3 == process_name {print $1}' || true)
+    else
+      pids=$(ps -eo pid=,user=,comm= | awk -v process_name="$process_name" '$3 == process_name {print $1}' || true)
     fi
+
+    if [ -n "$pids" ]; then
+      echo "$pids" | xargs -r kill -9 2>/dev/null || :
+    fi
+  done
 }
 
 function clean_bin() {
-    # Remove link
-    ${csudo}rm -f ${bin_link_dir}/${clientName2} || :
-    ${csudo}rm -f ${bin_link_dir}/${demoName2} || :
-    ${csudo}rm -f ${bin_link_dir}/${benchmarkName2} || :
-    ${csudo}rm -f ${bin_link_dir}/${dumpName2} || :
-    ${csudo}rm -f ${bin_link_dir}/${uninstallScript2} || :
-    ${csudo}rm -f ${bin_link_dir}/set_core || :
-    [ -L ${bin_link_dir}/${inspect_name} ] && ${csudo}rm -f ${bin_link_dir}/${inspect_name} || :
+  rm -f "${bin_link_dir}/${clientName2}" || :
+  rm -f "${bin_link_dir}/${demoName2}" || :
+  rm -f "${bin_link_dir}/${benchmarkName2}" || :
+  rm -f "${bin_link_dir}/${dumpName2}" || :
+  rm -f "${bin_link_dir}/${uninstallScript2}" || :
+  rm -f "${bin_link_dir}/set_core" || :
+  rm -f "${bin_link_dir}/${taosgen_name}" || :
+  [ -L "${bin_link_dir}/${inspect_name}" ] && rm -f "${bin_link_dir}/${inspect_name}" || :
 
-    if [ "$verMode" == "cluster" ] && [ "$clientName" != "$clientName2" ]; then
-        ${csudo}rm -f ${bin_link_dir}/${clientName2} || :
-        ${csudo}rm -f ${bin_link_dir}/${demoName2} || :
-        ${csudo}rm -f ${bin_link_dir}/${benchmarkName2} || :
-        ${csudo}rm -f ${bin_link_dir}/${dumpName2} || :
-        ${csudo}rm -f ${bin_link_dir}/${uninstallScript2} || :
-        [ -L ${bin_link_dir}/${inspect_name} ] && ${csudo}rm -f ${bin_link_dir}/${inspect_name} || :
-    fi
+  if [ "$verMode" == "cluster" ] && [ "$clientName" != "$clientName2" ]; then
+    rm -f "${bin_link_dir}/${clientName2}" || :
+    rm -f "${bin_link_dir}/${demoName2}" || :
+    rm -f "${bin_link_dir}/${benchmarkName2}" || :
+    rm -f "${bin_link_dir}/${dumpName2}" || :
+    rm -f "${bin_link_dir}/${uninstallScript2}" || :
+    rm -f "${bin_link_dir}/${taosgen_name}" || :
+    [ -L "${bin_link_dir}/${inspect_name}" ] && rm -f "${bin_link_dir}/${inspect_name}" || :
+  fi
 }
 
 function clean_lib() {
-    # Remove links in lib and lib64 directories
-    for dir in "${lib_link_dir}" "${lib64_link_dir}"; do
-        if [ -d "$dir" ]; then
-            for pattern in "libtaos.*" "libtaosnative.*" "libtaosws.*"; do
-                ${csudo}find "$dir" -name "$pattern" -exec ${csudo}rm -f {} \; || :
-            done
-        fi
-    done
+  for dir in "${lib_link_dir}" "${lib64_link_dir}"; do
+    if [ -d "$dir" ]; then
+      for pattern in "libtaos.*" "libtaosnative.*" "libtaosws.*"; do
+        find "$dir" -name "$pattern" -exec rm -f {} \; || :
+      done
+    fi
+  done
 }
 
 function clean_header() {
-    # Remove link
-    ${csudo}rm -f ${inc_link_dir}/taos.h || :
-    ${csudo}rm -f ${inc_link_dir}/taosdef.h || :
-    ${csudo}rm -f ${inc_link_dir}/taoserror.h || :
-    ${csudo}rm -f ${inc_link_dir}/tdef.h || :
-    ${csudo}rm -f ${inc_link_dir}/taosudf.h || :
-    ${csudo}rm -f ${inc_link_dir}/taosws.h || :
+  rm -f "${inc_link_dir}/taos.h" || :
+  rm -f "${inc_link_dir}/taosdef.h" || :
+  rm -f "${inc_link_dir}/taoserror.h" || :
+  rm -f "${inc_link_dir}/tdef.h" || :
+  rm -f "${inc_link_dir}/taosudf.h" || :
+  rm -f "${inc_link_dir}/taosws.h" || :
 }
 
 function clean_config() {
-    # Remove link
-    ${csudo}rm -f ${cfg_link_dir}/* || :
+  if [ "${cfg_link_dir}" = "${cfg_dir}" ]; then
+    return 0
+  fi
+  rm -f "${cfg_link_dir}"/* || :
 }
 
 function clean_log() {
-    # Remove link
-    ${csudo}rm -rf ${log_link_dir} || :
+  if [ "${log_link_dir}" = "${log_dir}" ]; then
+    return 0
+  fi
+  rm -rf "${log_link_dir}" || :
 }
 
 function clean_config_and_log_dir() {
-    # Remove link
-    echo "Do you want to remove all the log and configuration files? [y/n]"
+  echo "Do you want to remove all the log and configuration files? [y/n]"
+  read answer
+  if [ X$answer == X"y" ] || [ X$answer == X"Y" ]; then
+    confirmMsg="I confirm that I would like to delete all log and configuration files"
+    echo "Please enter '${confirmMsg}' to continue"
     read answer
-    if [ X$answer == X"y" ] || [ X$answer == X"Y" ]; then
-        confirmMsg="I confirm that I would like to delete all log and configuration files"
-        echo "Please enter '${confirmMsg}' to continue"
-        read answer
-        if [ X"$answer" == X"${confirmMsg}" ]; then
-            # Remove dir
-            rm -rf ${cfg_dir} || :
-            rm -rf ${log_dir} || :
-        else
-            echo "answer doesn't match, skip this step"
-        fi
+    if [ X"$answer" == X"${confirmMsg}" ]; then
+      rm -rf "${cfg_dir}" || :
+      rm -rf "${log_dir}" || :
+      remove_config_and_log="true"
+    else
+      echo "answer doesn't match, skip this step"
     fi
+  fi
 }
 
-# Stop client.
+function remove_install_main_dir() {
+  if { [ "${cfg_link_dir}" = "${cfg_dir}" ] || [ "${log_link_dir}" = "${log_dir}" ]; } && [ "$remove_config_and_log" != "true" ]; then
+    find "${install_main_dir}" -mindepth 1 -maxdepth 1 ! \( -name cfg -o -name log \) -exec rm -rf {} + || :
+    return 0
+  fi
+
+  rm -rf "${install_main_dir}"
+}
+
 kill_client
-# Remove binary file and links
 clean_bin
-# Remove header file.
 clean_header
-# Remove lib file
 clean_lib
-# Remove link log directory
 clean_log
-# Remove link configuration file
 clean_config
-# Remove dir
 clean_config_and_log_dir
 
-${csudo}rm -rf ${install_main_dir}
+remove_install_main_dir
 
 echo -e "${GREEN}${productName2} client is removed successfully!${NC}"
 echo

--- a/packaging/tools/remove_client.sh
+++ b/packaging/tools/remove_client.sh
@@ -102,7 +102,7 @@ function kill_client() {
     fi
 
     if [ -n "$pids" ]; then
-      echo "$pids" | while read p; do kill -9 "$p" 2>/dev/null || :; done
+      echo "$pids" | while read p; do kill -9 "$p" 2>/dev/null || :; done || :
     fi
   done
 }

--- a/packaging/tools/remove_client.sh
+++ b/packaging/tools/remove_client.sh
@@ -197,5 +197,33 @@ clean_config_and_log_dir
 
 remove_install_main_dir
 
+# Clean env variables from shell rc file for non-root uninstall
+function clean_env_file() {
+  if [ "${user_mode:-0}" -ne 1 ]; then
+    return 0
+  fi
+
+  local env_file=""
+  local login_shell="${SHELL##*/}"
+  if [ "$login_shell" = "zsh" ]; then
+    env_file="${HOME}/.zshrc"
+  elif [ "$login_shell" = "bash" ] || [ -z "$login_shell" ]; then
+    env_file="${HOME}/.bashrc"
+  else
+    env_file="${HOME}/.profile"
+  fi
+
+  if [ ! -f "$env_file" ]; then
+    return 0
+  fi
+
+  local tmp_file="${env_file}.tmp.$$"
+  sed -e "/^# ${productName2} install path$/d" \
+      -e "\|^export PATH=\"${bin_link_dir}:.*\"|d" \
+      -e "\|^export LD_LIBRARY_PATH=\"${lib_link_dir}:.*\"|d" \
+      "$env_file" > "$tmp_file" && mv "$tmp_file" "$env_file" || rm -f "$tmp_file"
+}
+clean_env_file
+
 echo -e "${GREEN}${productName2} client is removed successfully!${NC}"
 echo

--- a/packaging/tools/startPre.sh
+++ b/packaging/tools/startPre.sh
@@ -6,8 +6,16 @@
 
 serverName="taosd"
 logDir="/var/log/taos"
+serviceDir="/etc/systemd/system"
+sysctl_cmd="systemctl"
 
-taosd=/etc/systemd/system/${serverName}.service
+if [ "$(id -u)" -ne 0 ]; then
+  logDir="$HOME/taos/log"
+  serviceDir="$HOME/.config/systemd/user"
+  sysctl_cmd="systemctl --user"
+fi
+
+taosd=${serviceDir}/${serverName}.service
 line=$(grep StartLimitBurst ${taosd})
 num=${line##*=}
 #echo "burst num: ${num}"
@@ -36,7 +44,7 @@ if [ ${coreFlag} = "0" ]; then
   #echo "core is 0"
   if [ ${num} != "20" ]; then
     sed -i "s/^.*StartLimitBurst.*$/StartLimitBurst=20/" ${taosd}
-    systemctl daemon-reload
+    ${sysctl_cmd} daemon-reload
     echo "modify burst count from ${num} to 20" >>${recordFile}
   fi
 fi
@@ -45,7 +53,7 @@ if [ ${coreFlag} = "unlimited" ]; then
   #echo "core is unlimited"
   if [ ${num} != "3" ]; then
     sed -i "s/^.*StartLimitBurst.*$/StartLimitBurst=3/" ${taosd}
-    systemctl daemon-reload
+    ${sysctl_cmd} daemon-reload
     echo "modify burst count from ${num} to 3" >>${recordFile}
   fi
 fi

--- a/packaging/tools/startPre.sh
+++ b/packaging/tools/startPre.sh
@@ -16,7 +16,10 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 taosd=${serviceDir}/${serverName}.service
-line=$(grep StartLimitBurst ${taosd})
+line=$(grep StartLimitBurst ${taosd} 2>/dev/null || true)
+if [ -z "$line" ]; then
+  exit 0
+fi
 num=${line##*=}
 #echo "burst num: ${num}"
 


### PR DESCRIPTION
## Summary
- backport main-branch non-root Linux packaging behavior into the 3.3.6 community install/remove scripts
- block non-root install when a system-wide TDengine install already exists and align root/non-root process cleanup safety
- add server and client packaging smoke coverage for the 3.3.6 backport regressions

## Test Plan
- [x] bash packaging/smokeTest/test_non_root_server_packaging_backport.sh
- [x] bash packaging/smokeTest/test_non_root_client_packaging_backport.sh
- [x] bash -n packaging/tools/install.sh
- [x] bash -n packaging/tools/install_client.sh
- [x] bash -n packaging/tools/remove.sh
- [x] bash -n packaging/tools/remove_client.sh
- [x] Remote verification on 192.168.0.22 for root uninstall safety and non-root lifecycle

https://project.feishu.cn/taosdata_td/job/detail/6961071591