### PR TITLE
fix(stream): handle notify output for nested diff external window

### DIFF
--- a/cmake/in/lzma2.Makefile
+++ b/cmake/in/lzma2.Makefile
@@ -7,7 +7,7 @@ CC:=gcc
 AR:=ar -rcs
 RM:=rm -rf
 
-ASFLAGS :=
+ASFLAGS := -Wa,--noexecstack
 
 SONAME:=libfast-lzma2.so.1
 REAL_NAME:=libfast-lzma2.so.1.0

--- a/conan/fast-lzma2/conanfile.py
+++ b/conan/fast-lzma2/conanfile.py
@@ -50,6 +50,7 @@ class FastLzma2Conan(ConanFile):
 
         # Build make command
         cflags = "-Wall -O2 -pthread"
+        asflags = "-Wa,--noexecstack"
         if self.options.get_safe("fPIC"):
             cflags += " -fPIC"
 
@@ -59,7 +60,7 @@ class FastLzma2Conan(ConanFile):
 
         # Execute make compilation
         self.run(
-            f'make CFLAGS="{cflags}" CC={self.settings.get_safe("compiler", default="gcc")} libfast-lzma2',
+            f'make CFLAGS="{cflags}" ASFLAGS="{asflags}" CC={self.settings.get_safe("compiler", default="gcc")} libfast-lzma2',
             cwd=source_folder,
         )
 

--- a/source/libs/executor/src/projectoperator.c
+++ b/source/libs/executor/src/projectoperator.c
@@ -89,6 +89,191 @@ static void destroyIndefinitOperatorInfo(void* param) {
   taosMemoryFreeClear(param);
 }
 
+static void cleanupProcessByRowIter(SqlFunctionCtx* pCtx) {
+  SFuncInputRowIter* pIter = &pCtx->rowIter;
+
+  if (pIter->pPrevRowBlock != NULL) {
+    blockDataDestroy(pIter->pPrevRowBlock);
+  }
+  taosMemoryFreeClear(pIter->pPrevData);
+  taosMemoryFreeClear(pIter->pPrevPk);
+  memset(pIter, 0, sizeof(*pIter));
+}
+
+static int32_t resetProcessByRowCtx(SqlFunctionCtx* pCtx) {
+  SResultRowEntryInfo* pResInfo = GET_RES_INFO(pCtx);
+  char*                pOutput = pCtx->pOutput;
+
+  if (pResInfo->initialized && pCtx->fpSet.cleanup != NULL) {
+    pCtx->fpSet.cleanup(pCtx);
+  }
+
+  cleanupProcessByRowIter(pCtx);
+  pResInfo->initialized = false;
+  pResInfo->numOfRes = 0;
+  pCtx->bInputFinished = false;
+
+  pCtx->pOutput = NULL;
+  int32_t code = pCtx->fpSet.init(pCtx, pResInfo);
+  pCtx->pOutput = pOutput;
+  return code;
+}
+
+static bool allProcessByRowCtxSameFuncId(SArray* pProcessByRowFunctionCtx) {
+  if (pProcessByRowFunctionCtx == NULL || taosArrayGetSize(pProcessByRowFunctionCtx) <= 1) {
+    return true;
+  }
+
+  SqlFunctionCtx** ppFirstCtx = taosArrayGet(pProcessByRowFunctionCtx, 0);
+  if (ppFirstCtx == NULL || *ppFirstCtx == NULL) {
+    return false;
+  }
+
+  int32_t funcId = (*ppFirstCtx)->functionId;
+  for (int32_t i = 1; i < taosArrayGetSize(pProcessByRowFunctionCtx); ++i) {
+    SqlFunctionCtx** ppCtx = taosArrayGet(pProcessByRowFunctionCtx, i);
+    if (ppCtx == NULL || *ppCtx == NULL || (*ppCtx)->functionId != funcId) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static int32_t processByRowInExternalWindows(SArray* pGroupedCtxArray, SSDataBlock* pSrcBlock,
+                                             SStreamRuntimeFuncInfo* pStreamInfo) {
+  int32_t code = TSDB_CODE_SUCCESS;
+  int32_t lino = 0;
+
+  int32_t  ctxNum = taosArrayGetSize(pGroupedCtxArray);
+  int32_t  idxNum = taosArrayGetSize(pStreamInfo->pStreamBlkWinIdx);
+  int32_t  totalRows = 0;
+  SArray*  pInputWinIdx = NULL;
+  int32_t* pStartRows = NULL;
+  int64_t* pNumRows = NULL;
+  int32_t* pOffsets = NULL;
+
+  pInputWinIdx = taosArrayInit(idxNum, sizeof(int64_t));
+  TSDB_CHECK_NULL(pInputWinIdx, code, lino, _exit, terrno);
+  TSDB_CHECK_NULL(taosArrayAddBatch(pInputWinIdx, TARRAY_DATA(pStreamInfo->pStreamBlkWinIdx), idxNum), code, lino,
+                  _exit, terrno);
+
+  pStartRows = taosMemoryCalloc(ctxNum, sizeof(int32_t));
+  TSDB_CHECK_NULL(pStartRows, code, lino, _exit, terrno);
+  pNumRows = taosMemoryCalloc(ctxNum, sizeof(int64_t));
+  TSDB_CHECK_NULL(pNumRows, code, lino, _exit, terrno);
+  pOffsets = taosMemoryCalloc(ctxNum, sizeof(int32_t));
+  TSDB_CHECK_NULL(pOffsets, code, lino, _exit, terrno);
+
+  for (int32_t i = 0; i < ctxNum; ++i) {
+    SqlFunctionCtx** ppCtx = taosArrayGet(pGroupedCtxArray, i);
+    TSDB_CHECK_NULL(ppCtx, code, lino, _exit, terrno);
+    TSDB_CHECK_NULL(*ppCtx, code, lino, _exit, terrno);
+    pStartRows[i] = (*ppCtx)->input.startRowIndex;
+    pNumRows[i] = (*ppCtx)->input.numOfRows;
+    pOffsets[i] = (*ppCtx)->offset;
+  }
+
+  taosArrayClear(pStreamInfo->pStreamBlkWinIdx);
+
+  for (int32_t i = 0; i < idxNum; ++i) {
+    int64_t* pCurr = taosArrayGet(pInputWinIdx, i);
+    int32_t* pCurrPair = (int32_t*)pCurr;
+    int32_t  winIdx = pCurrPair[0];
+    int32_t  rowStart = pCurrPair[1];
+    int32_t  rowEnd = pSrcBlock->info.rows;
+
+    if (i + 1 < idxNum) {
+      int64_t* pNext = taosArrayGet(pInputWinIdx, i + 1);
+      rowEnd = ((int32_t*)pNext)[1];
+    }
+
+    if (rowEnd <= rowStart) {
+      continue;
+    }
+
+    for (int32_t j = 0; j < ctxNum; ++j) {
+      SqlFunctionCtx** ppCtx = taosArrayGet(pGroupedCtxArray, j);
+      SqlFunctionCtx*  pCtx = *ppCtx;
+
+      pCtx->input.startRowIndex = rowStart;
+      pCtx->input.numOfRows = rowEnd - rowStart;
+      pCtx->offset = pOffsets[j] + totalRows;
+      TAOS_CHECK_EXIT(resetProcessByRowCtx(pCtx));
+    }
+
+    SqlFunctionCtx** ppFirstCtx = taosArrayGet(pGroupedCtxArray, 0);
+    TAOS_CHECK_EXIT((*ppFirstCtx)->fpSet.processFuncByRow(pGroupedCtxArray));
+
+    int32_t winRows = (*ppFirstCtx)->resultInfo->numOfRes;
+    if (winRows > 0) {
+      int64_t  val = 0;
+      int32_t* pOutPair = (int32_t*)&val;
+      pOutPair[0] = winIdx;
+      pOutPair[1] = totalRows;
+      TSDB_CHECK_NULL(taosArrayPush(pStreamInfo->pStreamBlkWinIdx, &val), code, lino, _exit, terrno);
+      totalRows += winRows;
+    }
+  }
+
+  for (int32_t i = 0; i < ctxNum; ++i) {
+    SqlFunctionCtx** ppCtx = taosArrayGet(pGroupedCtxArray, i);
+    SqlFunctionCtx*  pCtx = *ppCtx;
+    pCtx->input.startRowIndex = pStartRows[i];
+    pCtx->input.numOfRows = pNumRows[i];
+    pCtx->offset = pOffsets[i];
+    pCtx->resultInfo->numOfRes = totalRows;
+  }
+
+_exit:
+  if (pInputWinIdx != NULL) {
+    taosArrayDestroy(pInputWinIdx);
+  }
+  taosMemoryFreeClear(pStartRows);
+  taosMemoryFreeClear(pNumRows);
+  taosMemoryFreeClear(pOffsets);
+  return code;
+}
+
+static int32_t assignPlaceHolderInExternalWindows(SColumnInfoData* pResColData, int64_t offset, int64_t rows,
+                                                  int16_t funcId, SStreamRuntimeFuncInfo* pInfo, SNode* pParamNode) {
+  int32_t code = TSDB_CODE_SUCCESS;
+  int32_t lino = 0;
+
+  int32_t originIdx = pInfo->curIdx;
+  int32_t idxNum = taosArrayGetSize(pInfo->pStreamBlkWinIdx);
+  SArray* pInputWinIdx = taosArrayInit(idxNum, sizeof(int64_t));
+  TSDB_CHECK_NULL(pInputWinIdx, code, lino, _exit, terrno);
+  TSDB_CHECK_NULL(taosArrayAddBatch(pInputWinIdx, TARRAY_DATA(pInfo->pStreamBlkWinIdx), idxNum), code, lino, _exit,
+                  terrno);
+
+  for (int32_t i = 0; i < idxNum; ++i) {
+    int64_t* pCurr = taosArrayGet(pInputWinIdx, i);
+    int32_t* pCurrPair = (int32_t*)pCurr;
+    int32_t  winIdx = pCurrPair[0];
+    int32_t  rowStart = pCurrPair[1];
+    int32_t  rowEnd = rows;
+
+    if (i + 1 < idxNum) {
+      int64_t* pNext = taosArrayGet(pInputWinIdx, i + 1);
+      rowEnd = ((int32_t*)pNext)[1];
+    }
+
+    if (rowEnd <= rowStart) {
+      continue;
+    }
+
+    pInfo->curIdx = winIdx;
+    TAOS_CHECK_EXIT(scalarAssignPlaceHolderRes(pResColData, offset + rowStart, rowEnd - rowStart, funcId, pInfo,
+                                               pParamNode));
+  }
+
+_exit:
+  pInfo->curIdx = originIdx;
+  taosArrayDestroy(pInputWinIdx);
+  return code;
+}
+
 void streamOperatorReleaseState(SOperatorInfo* pOperator) {
   SOperatorInfo* downstream = pOperator->pDownstream[0];
   if (downstream->fpSet.releaseStreamStateFn) {
@@ -314,6 +499,8 @@ int32_t doProjectOperation(SOperatorInfo* pOperator, SSDataBlock** pResBlock) {
 
   blockDataCleanup(pFinalRes);
   SExecTaskInfo* pTaskInfo = pOperator->pTaskInfo;
+  bool           withExternalWindow = pTaskInfo->pStreamRuntimeInfo != NULL &&
+                                      pTaskInfo->pStreamRuntimeInfo->funcInfo.withExternalWindow;
 
   if (pOperator->status == OP_EXEC_DONE) {
     return code;
@@ -388,17 +575,18 @@ int32_t doProjectOperation(SOperatorInfo* pOperator, SSDataBlock** pResBlock) {
       break;
     }
 
-      if (pProjectInfo->mergeDataBlocks) {
-        if (pRes->info.rows > 0) {
-          pFinalRes->info.id.groupId = 0;  // clear groupId
-          pFinalRes->info.version = pRes->info.version;
-          // keep baseGId from current upstream block; already set above for this merge round
+    if (pProjectInfo->mergeDataBlocks) {
+      if (pRes->info.rows > 0) {
+        pFinalRes->info.id.groupId = 0;  // clear groupId
+        pFinalRes->info.version = pRes->info.version;
+        // keep baseGId from current upstream block; already set above for this merge round
 
-          // continue merge data, ignore the group id
-          code = blockDataMerge(pFinalRes, pRes);
-          QUERY_CHECK_CODE(code, lino, _end);
+        // continue merge data, ignore the group id
+        code = blockDataMerge(pFinalRes, pRes);
+        QUERY_CHECK_CODE(code, lino, _end);
 
-        if (pFinalRes->info.rows + pRes->info.rows <= pOperator->resultInfo.threshold && (pOperator->status != OP_EXEC_DONE)) {
+        if (!withExternalWindow && pFinalRes->info.rows + pRes->info.rows <= pOperator->resultInfo.threshold &&
+            (pOperator->status != OP_EXEC_DONE)) {
           continue;
         }
       }
@@ -662,6 +850,13 @@ int32_t doApplyIndefinitFunction(SOperatorInfo* pOperator, SSDataBlock** pResBlo
         }
 
         doHandleDataBlock(pOperator, pBlock, downstream, pTaskInfo);
+        // External-window outputs carry per-window row ranges in stream runtime state.
+        // Return as soon as this operator has a result block so the downstream state
+        // still matches the block we are about to hand back to the runner.
+        if (pTaskInfo->pStreamRuntimeInfo != NULL && pTaskInfo->pStreamRuntimeInfo->funcInfo.withExternalWindow &&
+            pInfo->pRes->info.rows > 0) {
+          break;
+        }
         if (!noSplitOutput && pInfo->pRes->info.rows >= pOperator->resultInfo.threshold) {
           break;
         }
@@ -1008,7 +1203,15 @@ int32_t projectApplyFunction(SqlFunctionCtx* pCtx, SqlFunctionCtx* pfCtx, SExprI
 
   if (fmIsPlaceHolderFunc(pfCtx->functionId) && pExtraParams && pfCtx->pExpr->base.pParamList && 1 == pfCtx->pExpr->base.pParamList->length) {
     SNode* pParamNode = nodesListGetNode(pfCtx->pExpr->base.pParamList, 0);
-    TAOS_CHECK_EXIT(scalarAssignPlaceHolderRes(pResColData, pResult->info.rows, pSrcBlock->info.rows, pfCtx->functionId, pExtraParams, pParamNode));
+    SStreamRuntimeFuncInfo* pStreamInfo = (SStreamRuntimeFuncInfo*)pExtraParams;
+    if (pStreamInfo != NULL && pStreamInfo->withExternalWindow && pStreamInfo->pStreamBlkWinIdx != NULL &&
+        taosArrayGetSize(pStreamInfo->pStreamBlkWinIdx) > 1) {
+      TAOS_CHECK_EXIT(assignPlaceHolderInExternalWindows(pResColData, pResult->info.rows, pSrcBlock->info.rows,
+                                                         pfCtx->functionId, pStreamInfo, pParamNode));
+    } else {
+      TAOS_CHECK_EXIT(scalarAssignPlaceHolderRes(pResColData, pResult->info.rows, pSrcBlock->info.rows,
+                                                 pfCtx->functionId, pExtraParams, pParamNode));
+    }
     *numOfRows = pSrcBlock->info.rows;
 
     return code;
@@ -1222,6 +1425,11 @@ int32_t projectApplyFunctionsWithSelect(SExprInfo* pExpr, SSDataBlock* pResult, 
 
   if (processByRowFunctionCtx && taosArrayGetSize(processByRowFunctionCtx) > 0) {
     int32_t processByRowSize = taosArrayGetSize(processByRowFunctionCtx);
+    SStreamRuntimeFuncInfo* pStreamInfo = (SStreamRuntimeFuncInfo*)pExtraParams;
+    bool splitByExternalWindow = pSrcBlock != NULL && pStreamInfo != NULL && pStreamInfo->withExternalWindow &&
+                                 pStreamInfo->pStreamBlkWinIdx != NULL &&
+                                 taosArrayGetSize(pStreamInfo->pStreamBlkWinIdx) > 1 &&
+                                 allProcessByRowCtxSameFuncId(processByRowFunctionCtx);
     pProcessedFuncIds = taosArrayInit(4, sizeof(int32_t));
     TSDB_CHECK_NULL(pProcessedFuncIds, code, lino, _exit, terrno);
 
@@ -1259,7 +1467,11 @@ int32_t projectApplyFunctionsWithSelect(SExprInfo* pExpr, SSDataBlock* pResult, 
         }
       }
 
-      TAOS_CHECK_EXIT((*ppCurrCtx)->fpSet.processFuncByRow(pGroupedCtxArray));
+      if (splitByExternalWindow) {
+        TAOS_CHECK_EXIT(processByRowInExternalWindows(pGroupedCtxArray, pSrcBlock, pStreamInfo));
+      } else {
+        TAOS_CHECK_EXIT((*ppCurrCtx)->fpSet.processFuncByRow(pGroupedCtxArray));
+      }
       taosArrayDestroy(pGroupedCtxArray);
       pGroupedCtxArray = NULL;
 

--- a/source/libs/executor/src/streamexternalwindowoperator.c
+++ b/source/libs/executor/src/streamexternalwindowoperator.c
@@ -1676,9 +1676,11 @@ static int32_t extWinIndefRowsDo(SOperatorInfo* pOperator, SSDataBlock* pInputBl
   SExternalWindowOperator* pExtW = pOperator->info;
   SSDataBlock*             pResBlock = NULL;
   SArray*                  pIdx = NULL;
+  int64_t                  rowsBefore = 0;
   int32_t                  code = TSDB_CODE_SUCCESS, lino = 0;
   
   TAOS_CHECK_EXIT(extWinGetSetWinResBlockBuf(pOperator, rows, pWin, &pResBlock, &pIdx));
+  rowsBefore = pResBlock->info.rows;
   
   if (!pExtW->pTmpBlock) {
     TAOS_CHECK_EXIT(createOneDataBlock(pInputBlock, false, &pExtW->pTmpBlock));
@@ -1691,7 +1693,9 @@ static int32_t extWinIndefRowsDo(SOperatorInfo* pOperator, SSDataBlock* pInputBl
   TAOS_CHECK_EXIT(blockDataMergeNRows(pExtW->pTmpBlock, pInputBlock, startPos, rows));
   TAOS_CHECK_EXIT(extWinIndefRowsDoImpl(pOperator, pResBlock, pExtW->pTmpBlock));
 
-  TAOS_CHECK_EXIT(extWinAppendWinIdx(pOperator->pTaskInfo, pIdx, pResBlock, extWinGetCurWinIdx(pOperator->pTaskInfo), rows));
+  TAOS_CHECK_EXIT(extWinAppendWinIdx(pOperator->pTaskInfo, pIdx, pResBlock,
+                                     extWinGetCurWinIdx(pOperator->pTaskInfo),
+                                     (int32_t)(pResBlock->info.rows - rowsBefore)));
 
 _exit:
 

--- a/source/libs/new-stream/src/streamRunner.c
+++ b/source/libs/new-stream/src/streamRunner.c
@@ -789,6 +789,20 @@ static void printOutputProjBlock(SStreamRunnerTask* pTask, const SSDataBlock* pB
   }
 }
 
+static int32_t stRunnerAdvanceExternalWinOutput(SStreamRunnerTask* pTask, SStreamRunnerTaskExecution* pExec,
+                                                SSDataBlock** ppForceOutBlock, bool finished, bool* createTable,
+                                                int32_t* pNextOutIdx) {
+  if (finished || ((*ppForceOutBlock) && (*ppForceOutBlock)->info.rows > 0)) {
+    int32_t code = stRunnerMergeOutputBlock(pTask, pExec, *ppForceOutBlock, false, createTable);
+    if (code != TSDB_CODE_SUCCESS) {
+      return code;
+    }
+  }
+
+  (*pNextOutIdx)++;
+  return TSDB_CODE_SUCCESS;
+}
+
 static int32_t stRunnerTopTaskHandleExternalWinOutputBlock(SStreamRunnerTask* pTask, SStreamRunnerTaskExecution* pExec,
                                                     SSDataBlock* pBlock, SSDataBlock** ppForceOutBlock,
                                                     int32_t* pNextOutIdx, bool finished, bool* createTable) {
@@ -817,41 +831,55 @@ static int32_t stRunnerTopTaskHandleExternalWinOutputBlock(SStreamRunnerTask* pT
     }
 
     // printOutputProjBlock(pTask, pBlock, pExec->runtimeInfo.funcInfo.pStreamBlkWinIdx);
+    SArray* pBlkWinIdx = pExec->runtimeInfo.funcInfo.pStreamBlkWinIdx;
+    if (pBlkWinIdx == NULL || taosArrayGetSize(pBlkWinIdx) == 0) {
+      int32_t totalWins = (int32_t)taosArrayGetSize(pExec->runtimeInfo.funcInfo.pStreamPesudoFuncVals);
+      int32_t remainingWins = totalWins - *pNextOutIdx;
+      if (remainingWins != 1) {
+        code = TSDB_CODE_QRY_EXECUTOR_INTERNAL_ERROR;
+        lino = __LINE__;
+        ST_TASK_ELOG("missing external-window row index for output block, remainingWins:%d, rows:%" PRId64,
+                     remainingWins, pBlock->info.rows);
+        goto _exit;
+      }
 
-    int64_t idx = *(int64_t*)taosArrayGet(pExec->runtimeInfo.funcInfo.pStreamBlkWinIdx, 0);
-    int32_t winOutIdx = idx & 0xFFFFFFFF;
-    int32_t lastStartIdx = idx >> 32;
-    while (*pNextOutIdx < winOutIdx) {
-      TAOS_CHECK_GOTO(streamForceOutput(pExec->pExecutor, ppForceOutBlock, *pNextOutIdx), &lino, _exit);
-      TAOS_CHECK_GOTO(streamPrepareNotification(pTask, pExec, *ppForceOutBlock, *pNextOutIdx, 0, 0), &lino, _exit);
-      (*pNextOutIdx)++;
-    }
-
-    for (int i = 1; i < taosArrayGetSize(pExec->runtimeInfo.funcInfo.pStreamBlkWinIdx); ++i) {
-      int64_t idx = *(int64_t*)taosArrayGet(pExec->runtimeInfo.funcInfo.pStreamBlkWinIdx, i);
-      winOutIdx = idx & 0xFFFFFFFF;
-      int32_t rowStartIdx = idx >> 32;
-
-      TAOS_CHECK_GOTO(streamPrepareNotification(pTask, pExec, pBlock, *pNextOutIdx, lastStartIdx, rowStartIdx - 1),
+      TAOS_CHECK_GOTO(streamPrepareNotification(pTask, pExec, pBlock, *pNextOutIdx, 0, pBlock->info.rows - 1),
                       &lino, _exit);
-      (*pNextOutIdx)++;
-
+      TAOS_CHECK_GOTO(stRunnerAdvanceExternalWinOutput(pTask, pExec, ppForceOutBlock, finished, createTable,
+                                                       pNextOutIdx), &lino, _exit);
+    } else {
+      int64_t idx = *(int64_t*)taosArrayGet(pBlkWinIdx, 0);
+      int32_t winOutIdx = idx & 0xFFFFFFFF;
+      int32_t lastStartIdx = idx >> 32;
       while (*pNextOutIdx < winOutIdx) {
         TAOS_CHECK_GOTO(streamForceOutput(pExec->pExecutor, ppForceOutBlock, *pNextOutIdx), &lino, _exit);
         TAOS_CHECK_GOTO(streamPrepareNotification(pTask, pExec, *ppForceOutBlock, *pNextOutIdx, 0, 0), &lino, _exit);
         (*pNextOutIdx)++;
       }
 
-      lastStartIdx = rowStartIdx;
-    }
+      for (int i = 1; i < taosArrayGetSize(pBlkWinIdx); ++i) {
+        int64_t idx = *(int64_t*)taosArrayGet(pBlkWinIdx, i);
+        winOutIdx = idx & 0xFFFFFFFF;
+        int32_t rowStartIdx = idx >> 32;
 
-    TAOS_CHECK_GOTO(streamPrepareNotification(pTask, pExec, pBlock, *pNextOutIdx, lastStartIdx, pBlock->info.rows - 1),
-                    &lino, _exit);
+        TAOS_CHECK_GOTO(streamPrepareNotification(pTask, pExec, pBlock, *pNextOutIdx, lastStartIdx, rowStartIdx - 1),
+                        &lino, _exit);
+        (*pNextOutIdx)++;
 
-    if (finished || (*ppForceOutBlock) && (*ppForceOutBlock)->info.rows > 0) {
-      TAOS_CHECK_GOTO(stRunnerMergeOutputBlock(pTask, pExec, *ppForceOutBlock, false, createTable), &lino, _exit);
+        while (*pNextOutIdx < winOutIdx) {
+          TAOS_CHECK_GOTO(streamForceOutput(pExec->pExecutor, ppForceOutBlock, *pNextOutIdx), &lino, _exit);
+          TAOS_CHECK_GOTO(streamPrepareNotification(pTask, pExec, *ppForceOutBlock, *pNextOutIdx, 0, 0), &lino, _exit);
+          (*pNextOutIdx)++;
+        }
+
+        lastStartIdx = rowStartIdx;
+      }
+
+      TAOS_CHECK_GOTO(streamPrepareNotification(pTask, pExec, pBlock, *pNextOutIdx, lastStartIdx, pBlock->info.rows - 1),
+                      &lino, _exit);
+      TAOS_CHECK_GOTO(stRunnerAdvanceExternalWinOutput(pTask, pExec, ppForceOutBlock, finished, createTable,
+                                                       pNextOutIdx), &lino, _exit);
     }
-    (*pNextOutIdx)++;
   }
 
   if (pBlock) {  // && *pNextOutIdx < taosArrayGetSize(pExec->runtimeInfo.funcInfo.pStreamPesudoFuncVals)

--- a/test/cases/18-StreamProcessing/05-Notify/test_notify.py
+++ b/test/cases/18-StreamProcessing/05-Notify/test_notify.py
@@ -83,6 +83,7 @@ class TestStreamNotifyTrigger:
         streams.append(self.Basic14())
         streams.append(self.Basic15())
         streams.append(self.Basic16())
+        streams.append(self.Basic17())
 
         tdStream.checkAll(streams)      
         stop_notify_server_background()
@@ -2166,3 +2167,60 @@ class TestStreamNotifyTrigger:
                 expectCount=5,
             )
 
+    class Basic17(StreamCheckItem):
+        def __init__(self):
+            self.db = "sdb17"
+            self.stb = "stb"
+            self.stream = "nproc_detection"
+            self.result_table = "nproc_detect_res"
+
+        def create(self):
+            tdLog.info("=============== create database")
+            tdSql.execute(f"create database {self.db} vgroups 1;")
+            tdSql.execute(f"use {self.db}")
+
+            tdSql.execute(
+                f"create stable {self.stb} (ts timestamp, nproc int) tags (ip varchar(32));"
+            )
+            tdSql.query("show stables")
+            tdSql.checkRows(1)
+
+            tdLog.info("=============== create sub table")
+            tdSql.execute(f"create table ct1 using {self.stb} tags ('127.0.0.1');")
+            tdSql.query("show tables")
+            tdSql.checkRows(1)
+
+            tdLog.info("=============== create stream")
+            tdSql.execute(
+                f"create stream if not exists {self.stream} "
+                f"count_window(3, 1) from {self.stb} partition by tbname "
+                f"notify('ws://localhost:12345/basic17_s0') on(window_close) "
+                f"into {self.result_table} "
+                f"as select _twend ts, diff(dif) as derived_diff "
+                f"from (select ts, diff(nproc) as dif from %%tbname where _c0 >= _twstart and _c0 <= _twend);"
+            )
+
+        def insert1(self):
+            tdLog.info("=============== insert crash repro rows")
+            tdSql.execute(
+                "insert into ct1 values ('2026-01-01 00:00:00.000', 1000), ('2026-01-01 00:00:10.000', 950), ('2026-01-01 00:00:20.000', 100), ('2026-01-01 00:00:30.000', 50);"
+            )
+
+        def check1(self):
+            tdLog.info("check the stream crash repro result")
+            tdSql.checkResultsByFunc(
+                sql=f"select * from {self.db}.{self.result_table} order by ts",
+                func=lambda: tdSql.getRows() == 2
+                and tdSql.compareData(0, 0, "2026-01-01 00:00:20.000")
+                and tdSql.compareData(0, 1, -800)
+                and tdSql.compareData(0, 2, "ct1")
+                and tdSql.compareData(1, 0, "2026-01-01 00:00:30.000")
+                and tdSql.compareData(1, 1, 800)
+                and tdSql.compareData(1, 2, "ct1"),
+            )
+            expect_event(
+                os.path.join(NOTIFY_RESULT_DIR, "basic17_s0.log"),
+                streamName=f"{self.db}.{self.stream}",
+                eventType="WINDOW_CLOSE",
+                result_pred=lambda data: len(data) > 0,
+            )


### PR DESCRIPTION
# Description

Keep the stream runner from crashing when external-window output row indexes are cleared before nested diff returns its final block.

# Issue(s)

- Fix: https://project.feishu.cn/taosdata_td/defect/detail/6930096221

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
