### PR TITLE
fix: unify client uninstall entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,5 +79,6 @@ tools/tdgpt/packaging/bin/WinSW.exe
 tools/tdgpt/packaging/bin/uv.exe
 
 .agents/
+.worktrees/
 skills-lock.json
 debug_coverage/

--- a/packaging/smokeTest/test_install_sh_client_uninstall_entrypoint.sh
+++ b/packaging/smokeTest/test_install_sh_client_uninstall_entrypoint.sh
@@ -13,25 +13,38 @@ NC='\033[0m'
 pass=0
 fail=0
 
-check_client_branch_contains() {
-  local description="$1"
-  local pattern="$2"
+extract_install_bin_client_branch() {
+  awk '
+    /^[[:space:]]*function install_bin\(\)/ { in_function = 1 }
+    in_function { print }
+    in_function && /^[[:space:]]*}/ { exit }
+  ' "$INSTALL_SH" | awk '
+    /^[[:space:]]*if \[ "\$\{verType\}" == "client" \]; then$/ { in_branch = 1; next }
+    in_branch && /^[[:space:]]*else$/ { exit }
+    in_branch { print }
+  '
+}
 
-  if awk '/if \[ "\$verType" == "client" \]; then/,/^[[:space:]]*else$/' "$INSTALL_SH" | grep -qF "$pattern"; then
-    echo -e "  ${GREEN}PASS${NC}: $description"
-    ((pass++)) || true
-  else
-    echo -e "  ${RED}FAIL${NC}: $description"
-    echo "       Expected client branch in $INSTALL_SH to contain: '$pattern'"
-    ((fail++)) || true
-  fi
+extract_client_remove_name_branch() {
+  awk '
+    !in_branch && /^[[:space:]]*if \[ "\$verType" == "client" \]; then$/ { in_branch = 1 }
+    in_branch { print }
+    in_branch && /^[[:space:]]*else$/ { exit }
+  ' "$INSTALL_SH"
 }
 
 check_client_branch_absent() {
   local description="$1"
   local pattern="$2"
+  local client_branch
 
-  if awk '/if \[ "\$verType" == "client" \]; then/,/^[[:space:]]*else$/' "$INSTALL_SH" | grep -qF "$pattern"; then
+  client_branch="$(extract_install_bin_client_branch)"
+
+  if [[ -z "${client_branch}" ]]; then
+    echo -e "  ${RED}FAIL${NC}: ${description}"
+    echo "       Failed to locate install_bin() client branch in $INSTALL_SH"
+    ((fail++)) || true
+  elif grep -qF "$pattern" <<<"$client_branch"; then
     echo -e "  ${RED}FAIL${NC}: $description"
     echo "       Found forbidden pattern '$pattern' in client branch of $INSTALL_SH"
     ((fail++)) || true
@@ -43,15 +56,26 @@ check_client_branch_absent() {
 
 check_client_uninstall_backend() {
   local client_branch
+  local remove_name_branch
 
-  client_branch="$(awk '/if \[ "\$verType" == "client" \]; then/,/^[[:space:]]*else$/' "$INSTALL_SH")"
+  client_branch="$(extract_install_bin_client_branch)"
+  remove_name_branch="$(extract_client_remove_name_branch)"
 
-  if grep -qF 'remove_name="remove.sh"' <<<"$client_branch" || grep -qF 'cp -r ${script_dir}/bin/remove.sh ${install_main_dir}/bin' "$INSTALL_SH"; then
+  if [[ -z "${client_branch}" ]]; then
+    echo -e "  ${RED}FAIL${NC}: client mode uses remove.sh as uninstall backend"
+    echo "       Failed to locate install_bin() client branch in $INSTALL_SH"
+    ((fail++)) || true
+  elif grep -qF 'cp -r ${script_dir}/bin/remove.sh ${install_main_dir}/bin' <<<"$client_branch"; then
+    echo -e "  ${GREEN}PASS${NC}: client mode uses remove.sh as uninstall backend"
+    ((pass++)) || true
+  elif grep -qF 'cp -r ${script_dir}/bin/${remove_name} ${install_main_dir}/bin' <<<"$client_branch" \
+    && grep -qF 'remove_name="remove.sh"' <<<"$remove_name_branch" \
+    && ! grep -qF 'remove_name="remove_client.sh"' <<<"$remove_name_branch"; then
     echo -e "  ${GREEN}PASS${NC}: client mode uses remove.sh as uninstall backend"
     ((pass++)) || true
   else
     echo -e "  ${RED}FAIL${NC}: client mode uses remove.sh as uninstall backend"
-    echo "       Expected install.sh client flow to select or copy remove.sh"
+    echo "       Expected install.sh client flow to copy remove.sh directly or via remove_name=remove.sh"
     ((fail++)) || true
   fi
 }

--- a/packaging/smokeTest/test_install_sh_client_uninstall_entrypoint.sh
+++ b/packaging/smokeTest/test_install_sh_client_uninstall_entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGING_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+INSTALL_SH="${PACKAGING_DIR}/tools/install.sh"
+
+RED='\033[0;31m'
+GREEN='\033[1;32m'
+NC='\033[0m'
+
+pass=0
+fail=0
+
+check_client_branch_contains() {
+  local description="$1"
+  local pattern="$2"
+
+  if awk '/if \[ "\$verType" == "client" \]; then/,/^[[:space:]]*else$/' "$INSTALL_SH" | grep -qF "$pattern"; then
+    echo -e "  ${GREEN}PASS${NC}: $description"
+    ((pass++)) || true
+  else
+    echo -e "  ${RED}FAIL${NC}: $description"
+    echo "       Expected client branch in $INSTALL_SH to contain: '$pattern'"
+    ((fail++)) || true
+  fi
+}
+
+check_client_branch_absent() {
+  local description="$1"
+  local pattern="$2"
+
+  if awk '/if \[ "\$verType" == "client" \]; then/,/^[[:space:]]*else$/' "$INSTALL_SH" | grep -qF "$pattern"; then
+    echo -e "  ${RED}FAIL${NC}: $description"
+    echo "       Found forbidden pattern '$pattern' in client branch of $INSTALL_SH"
+    ((fail++)) || true
+  else
+    echo -e "  ${GREEN}PASS${NC}: $description"
+    ((pass++)) || true
+  fi
+}
+
+check_client_uninstall_backend() {
+  local client_branch
+
+  client_branch="$(awk '/if \[ "\$verType" == "client" \]; then/,/^[[:space:]]*else$/' "$INSTALL_SH")"
+
+  if grep -qF 'remove_name="remove.sh"' <<<"$client_branch" || grep -qF 'cp -r ${script_dir}/bin/remove.sh ${install_main_dir}/bin' "$INSTALL_SH"; then
+    echo -e "  ${GREEN}PASS${NC}: client mode uses remove.sh as uninstall backend"
+    ((pass++)) || true
+  else
+    echo -e "  ${RED}FAIL${NC}: client mode uses remove.sh as uninstall backend"
+    echo "       Expected install.sh client flow to select or copy remove.sh"
+    ((fail++)) || true
+  fi
+}
+
+echo "=== install.sh client uninstall entrypoint guard ==="
+echo
+
+check_client_uninstall_backend
+check_client_branch_absent "client mode does not select remove_client.sh" 'remove_name="remove_client.sh"'
+
+echo
+if [[ $fail -gt 0 ]]; then
+  echo -e "${RED}FAILED${NC}: $fail check(s) failed, $pass passed"
+  exit 1
+else
+  echo -e "${GREEN}install.sh client uninstall entrypoint guard passed${NC} ($pass/$((pass+fail)))"
+  exit 0
+fi

--- a/packaging/smokeTest/test_install_sh_client_uninstall_entrypoint_guard_selftest.sh
+++ b/packaging/smokeTest/test_install_sh_client_uninstall_entrypoint_guard_selftest.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD_SCRIPT="${SCRIPT_DIR}/test_install_sh_client_uninstall_entrypoint.sh"
+
+RED='\033[0;31m'
+GREEN='\033[1;32m'
+NC='\033[0m'
+
+pass=0
+fail=0
+
+create_fixture() {
+  local fixture_dir="$1"
+  local prelude_block="$2"
+  local client_block="$3"
+  local server_block="$4"
+
+  mkdir -p "${fixture_dir}/smokeTest" "${fixture_dir}/tools"
+  cp "${GUARD_SCRIPT}" "${fixture_dir}/smokeTest/test_install_sh_client_uninstall_entrypoint.sh"
+
+  cat > "${fixture_dir}/tools/install.sh" <<EOF
+#!/bin/bash
+
+${prelude_block}
+
+function install_bin() {
+  if [ "\${verType}" == "client" ]; then
+${client_block}
+  else
+${server_block}
+  fi
+}
+
+elif [ "\$verType" == "client" ]; then
+  interactiveFqdn=no
+  if [ -x \${bin_dir}/\${clientName} ]; then
+    update_flag=1
+    updateProduct client
+  else
+    installProduct client
+  fi
+else
+  echo "please input correct verType"
+fi
+EOF
+}
+
+run_case() {
+  local description="$1"
+  local expected_status="$2"
+  local fixture_dir="$3"
+
+  local status=0
+  set +e
+  bash "${fixture_dir}/smokeTest/test_install_sh_client_uninstall_entrypoint.sh" >/tmp/guard-selftest.log 2>&1
+  status=$?
+  set -e
+
+  if [[ "${expected_status}" == "pass" && ${status} -eq 0 ]] || [[ "${expected_status}" == "fail" && ${status} -ne 0 ]]; then
+    echo -e "  ${GREEN}PASS${NC}: ${description}"
+    ((pass++)) || true
+  else
+    echo -e "  ${RED}FAIL${NC}: ${description}"
+    cat /tmp/guard-selftest.log | sed 's/^/       /'
+    ((fail++)) || true
+  fi
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}" /tmp/guard-selftest.log' EXIT
+
+create_fixture "${tmp_dir}/good-direct" \
+"" \
+"    cp -r \${script_dir}/bin/remove.sh \${install_main_dir}/bin" \
+"    cp -r \${script_dir}/bin/remove.sh \${install_main_dir}/bin"
+
+create_fixture "${tmp_dir}/good-variable" \
+"if [ \"\$verType\" == \"client\" ]; then
+  remove_name=\"remove.sh\"
+else
+  remove_name=\"remove.sh\"
+fi" \
+"    remove_name=\"remove.sh\"
+    cp -r \${script_dir}/bin/\${remove_name} \${install_main_dir}/bin" \
+"    remove_name=\"remove.sh\"
+    cp -r \${script_dir}/bin/\${remove_name} \${install_main_dir}/bin"
+
+create_fixture "${tmp_dir}/bad-direct" \
+"" \
+"    cp -r \${script_dir}/bin/remove_client.sh \${install_main_dir}/bin" \
+"    cp -r \${script_dir}/bin/remove.sh \${install_main_dir}/bin"
+
+create_fixture "${tmp_dir}/bad-variable" \
+"if [ \"\$verType\" == \"client\" ]; then
+  remove_name=\"remove_client.sh\"
+else
+  remove_name=\"remove.sh\"
+fi" \
+"    remove_name=\"remove_client.sh\"
+    cp -r \${script_dir}/bin/\${remove_name} \${install_main_dir}/bin" \
+"    remove_name=\"remove.sh\"
+    cp -r \${script_dir}/bin/\${remove_name} \${install_main_dir}/bin"
+
+echo "=== install.sh client uninstall entrypoint guard self-test ==="
+echo
+
+run_case "accepts direct-copy remove.sh client branch" pass "${tmp_dir}/good-direct"
+run_case "accepts variable-based remove.sh client branch" pass "${tmp_dir}/good-variable"
+run_case "rejects direct-copy remove_client.sh client branch" fail "${tmp_dir}/bad-direct"
+run_case "rejects variable-based remove_client.sh client branch" fail "${tmp_dir}/bad-variable"
+
+echo
+if [[ $fail -gt 0 ]]; then
+  echo -e "${RED}FAILED${NC}: $fail check(s) failed, $pass passed"
+  exit 1
+else
+  echo -e "${GREEN}guard self-test passed${NC} ($pass/$((pass+fail)))"
+fi

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -381,7 +381,7 @@ function setup_env() {
   #  tools/services/config_files files setting
   if [ "$verType" == "client" ]; then
     # Only client tools, no services included
-    remove_name="remove_client.sh"
+    remove_name="remove.sh"
     tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${inspect_name}" "${taosgen_name}" "${remove_name}")
     services=()
     


### PR DESCRIPTION
## Summary
- switch install.sh client mode to use remove.sh as the uninstall backend
- add a smoke test to lock in the install.sh client uninstall entrypoint

## Validation
- bash packaging/smokeTest/test_install_sh_client_uninstall_entrypoint.sh
- bash -n packaging/tools/install.sh packaging/tools/remove.sh packaging/tools/install_client.sh packaging/tools/remove_client.sh
- remote root/non-root validation with current 3.3.6 scripts injected into the server package: install.sh -v client install + uninstall via uninstall.sh/rmtaos