### PR TITLE
docs(dotnet): dotnet connector supports blob data type

### DIFF
--- a/docs/en/14-reference/05-connector/40-csharp.md
+++ b/docs/en/14-reference/05-connector/40-csharp.md
@@ -72,11 +72,13 @@ For error code information please refer to [Error Codes](../09-error-code.md)
 | JSON              | byte[]   |
 | VARBINARY         | byte[]   |
 | GEOMETRY          | byte[]   |
+| BLOB              | byte[]   |
 | DECIMAL           | decimal  |
 
 **Note**:
 
 - JSON type is only supported in tags.
+- Blob type is not supported as a tag column and does not support stmt parameterized query binding.
 - The GEOMETRY type is binary data in little endian byte order, conforming to the WKB standard. For more details, please refer to [Data Types](../03-taos-sql/01-datatype.md)
 For WKB standard, please refer to [Well-Known Binary (WKB)](https://libgeos.org/specifications/wkb/)
 - The DECIMAL type in C# is represented using the `decimal` type, which supports high-precision decimal numbers.

--- a/docs/en/14-reference/05-connector/40-csharp.md
+++ b/docs/en/14-reference/05-connector/40-csharp.md
@@ -78,7 +78,7 @@ For error code information please refer to [Error Codes](../09-error-code.md)
 **Note**:
 
 - JSON type is only supported in tags.
-- Blob type is not supported as a tag column and does not support stmt parameterized query binding.
+- BLOB type is not supported as a tag column and does not support stmt parameterized query binding.
 - The GEOMETRY type is binary data in little endian byte order, conforming to the WKB standard. For more details, please refer to [Data Types](../03-taos-sql/01-datatype.md)
 For WKB standard, please refer to [Well-Known Binary (WKB)](https://libgeos.org/specifications/wkb/)
 - The DECIMAL type in C# is represented using the `decimal` type, which supports high-precision decimal numbers.

--- a/docs/zh/14-reference/05-connector/40-csharp.mdx
+++ b/docs/zh/14-reference/05-connector/40-csharp.mdx
@@ -71,11 +71,13 @@ TDengine TSDB 其他功能模块的报错，请参考 [错误码](../../../refer
 | JSON                   | byte[]   |
 | VARBINARY              | byte[]   |
 | GEOMETRY               | byte[]   |
+| BLOB                   | byte[]   |
 | DECIMAL                | decimal  |
 
 **注意**：
 
 - JSON 类型仅在 tag 中支持。
+- BLOB 类型不支持作为 tag 列，不支持 stmt 参数化查询绑定。
 - GEOMETRY 类型是 little endian 字节序的二进制数据，符合 WKB 规范。详细信息请参考 [数据类型](../../taos-sql/datatype)。
 WKB 规范请参考 [Well-Known Binary (WKB)](https://libgeos.org/specifications/wkb/)。
 - DECIMAL 类型在 C# 中使用 `decimal` 类型表示，支持高精度的十进制数值。因为 C# 的 `decimal` 类型与 TDengine TSDB 的 DECIMAL 类型在精度和范围上有所不同，


### PR DESCRIPTION
# Description

dotnet connector supports blob data type.

# Issue(s)

- Close https://project.feishu.cn/taosdata_td/feature/detail/6663148353

# Checklist

Please check the items in the checklist if applicable.

- [x] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
