### PR TITLE
fix: avoid use-after-free of pQuery->pCmdMsg in asyncExecDdlQuery

### DIFF
--- a/source/client/src/clientImpl.c
+++ b/source/client/src/clientImpl.c
@@ -505,6 +505,9 @@ int32_t asyncExecDdlQuery(SRequestObj* pRequest, SQuery* pQuery) {
   }
 
   SCmdMsgInfo* pMsgInfo = pQuery->pCmdMsg;
+  // Clear pQuery->pCmdMsg before the async call so that nodesDestroyNode (which may be
+  // triggered by the async response callback on another thread) will not double-free pCmdMsg.
+  pQuery->pCmdMsg = NULL;
   pRequest->type = pMsgInfo->msgType;
   pRequest->body.requestMsg = (SDataBuf){.pData = pMsgInfo->pMsg, .len = pMsgInfo->msgLen, .handle = NULL};
   pMsgInfo->pMsg = NULL;  // pMsg transferred to SMsgSendInfo management
@@ -515,9 +518,9 @@ int32_t asyncExecDdlQuery(SRequestObj* pRequest, SQuery* pQuery) {
   int32_t code = asyncSendMsgToServer(pAppInfo->pTransporter, &pMsgInfo->epSet, NULL, pSendMsg);
   // pMsgInfo->pMsg has been transferred to pRequest->body.requestMsg and pMsgInfo->epSet has
   // been consumed by asyncSendMsgToServer; the SCmdMsgInfo struct itself is no longer needed.
-  // Free it now so that nodesDestroyAllocatorSet() during atexit does not orphan it when the
-  // chunk containing pQuery is released before doDestroyRequest() can be called.
-  taosMemoryFreeClear(pQuery->pCmdMsg);
+  // Use the local pMsgInfo variable (not pQuery->pCmdMsg) to avoid a use-after-free: the async
+  // response callback may have run on another thread and destroyed pQuery by this point.
+  taosMemoryFree(pMsgInfo);
   if (code) {
     doRequestCallback(pRequest, code);
   }


### PR DESCRIPTION
asyncSendMsgToServer() is non-blocking. Once it returns, the async response callback on another thread may already have called doDestroyRequest() -> nodesDestroyAllocator(), freeing the chunk that contains SQuery. Any subsequent access to pQuery (including reading pQuery->pCmdMsg for the taosMemoryFreeClear call) is a use-after-free.

Fix: save pQuery->pCmdMsg into a local variable (pMsgInfo), then set pQuery->pCmdMsg = NULL before the async call so that nodesDestroyNode() — if triggered by the callback — sees NULL and skips the free. After asyncSendMsgToServer() returns, free via the local pMsgInfo to avoid touching the potentially-freed pQuery.

Reproducer: loop test_scalar_sub4a2.py triggers the race via the DDL path; ASAN reports heap-use-after-free at clientImpl.c:520.

# Description

<!-- Please briefly describe the code changes in this pull request. -->

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
