### PR TITLE
fix: install script bugs (chmod 666, insserv typo, process handling)

### DIFF
--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -432,7 +432,7 @@ function kill_process() {
     if command -v pkill >/dev/null 2>&1; then
         pkill -x -9 "$1" 2>/dev/null || true
     else
-        pgrep -x "$1" | while read p; do kill -9 "$p" 2>/dev/null || :; done
+        pgrep -x "$1" | while read p; do kill -9 "$p" 2>/dev/null || :; done || :
     fi
 }
 

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -428,11 +428,11 @@ function install_services() {
 }
 
 function kill_process() {
-    # use pkill if available, otherwise fallback to pgrep + xargs
+    # use pkill if available, otherwise fallback to pgrep + while-read
     if command -v pkill >/dev/null 2>&1; then
         pkill -x -9 "$1" 2>/dev/null || true
     else
-        pgrep -x "$1" | xargs -r kill -9 2>/dev/null || true
+        pgrep -x "$1" | while read p; do kill -9 "$p" 2>/dev/null || :; done
     fi
 }
 
@@ -718,6 +718,10 @@ function install_header() {
 }
 
 function add_newHostname_to_hosts() {
+  if [ "$user_mode" -eq 1 ]; then
+    echo "Warning: non-root install, skipping /etc/hosts modification"
+    return
+  fi
   localIp="127.0.0.1"
   OLD_IFS="$IFS"
   IFS=" "
@@ -732,9 +736,10 @@ function add_newHostname_to_hosts() {
 
   if grep -q "127.0.0.1  $1" /etc/hosts; then
     return
-  else
-    chmod 666 /etc/hosts
+  elif [ -w /etc/hosts ]; then
     echo "127.0.0.1  $1" >>/etc/hosts
+  else
+    echo "Warning: /etc/hosts is not writable, skipping hostname addition"
   fi
 }
 
@@ -1126,7 +1131,7 @@ function install_service_on_sysvinit() {
     chkconfig --add $1 || :
     chkconfig --level 2345 $1 on || :
   elif ((${initd_mod} == 2)); then
-    insserv $1} || :
+    insserv $1 || :
     insserv -d $1 || :
   elif ((${initd_mod} == 3)); then
     update-rc.d $1 defaults || :

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -464,11 +464,10 @@ function kill_process() {
 
 function install_main_path() {
   #create install main dir and all sub dir
-  if [[ $user_mode -eq 0 ]]; then
-    rm -rf "${data_link_dir}" || :
-    rm -rf "${log_link_dir}" || :
-    rm -rf "${cfg_link_dir}" || :
-  fi
+  # Note: do NOT rm data/log/cfg link dirs here.
+  # - Real directories from old versions must be preserved (data loss risk)
+  # - Symlinks are safely overwritten by ln -sf in install_log/install_config
+  # - data_link_dir is not recreated during upgrade (install_data not called)
   rm -rf "${bin_dir}" || :
   rm -rf "${driver_dir}" || :
   rm -rf "${install_main_dir}/examples" || :

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -237,11 +237,20 @@ function setup_env() {
 
   # 2. User mode detection
   if [[ "$(id -u)" -ne 0 ]]; then
+    # Check systemd version >= 232 for user service support
+    local sd_ver
+    sd_ver=$(systemctl --version 2>/dev/null | head -1 | awk '{print $2}')
+    if [ -z "$sd_ver" ] || [ "$sd_ver" -lt 232 ] 2>/dev/null; then
+      echo -e "${RED}Non-root install requires systemd >= 232, current version: ${sd_ver:-unknown}${NC}"
+      echo -e "Supported: CentOS/RHEL 8+, Ubuntu 18.04+, Debian 9+, SUSE 15+"
+      echo -e "CentOS/RHEL 7 (systemd 219) does not support non-root installation."
+      exit 1
+    fi
     if ! systemctl --user show-environment &>/dev/null; then
       echo -e "${RED}Current user is not root and no systemd user session (user bus) is available.${NC}"
-      echo -e "A systemd user session is required so the installer can manage per-user systemd services."
       echo -e "Please use ssh to log in as this user and then run the installer, for example:"
       echo -e "${BOLD}ssh <username>@<host>${NC}"
+      echo -e "If the problem persists, ask root to run: loginctl enable-linger $(whoami)"
       exit 1
     fi
     user_mode=1
@@ -1304,6 +1313,15 @@ function finished_install_info(){
     # header
     echo
     log info_color "${productName} has been installed successfully!"
+
+    if [ "$user_mode" -eq 1 ]; then
+      if ! loginctl show-user "$(whoami)" 2>/dev/null | grep -q "Linger=yes"; then
+        echo
+        echo -e "${RED}IMPORTANT: To ensure services auto-start after reboot, ask root to run:${NC}"
+        echo -e "  loginctl enable-linger $(whoami)"
+      fi
+    fi
+
     echo
 
     # collect pairs "label|value"

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -302,7 +302,9 @@ function setup_env() {
       candidate_path=$(cat "$HOME/${PREFIX}/.install_path")
     fi
 
-    if [ -n "$candidate_path" ] && [ -d "$candidate_path" ]; then
+    if [ -n "$candidate_path" ] && [ "$candidate_path" != "/" ] && \
+       [[ "$candidate_path" != /bin && "$candidate_path" != /usr && "$candidate_path" != /etc && "$candidate_path" != /var ]] && \
+       [ -d "$candidate_path" ]; then
       taos_dir="$candidate_path"
       taos_dir_set=1
       log info "Detected previous installation path: ${taos_dir}"

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -302,9 +302,8 @@ function setup_env() {
       candidate_path=$(cat "$HOME/${PREFIX}/.install_path")
     fi
 
-    if [ -n "$candidate_path" ] && [ "$candidate_path" != "/" ] && \
-       [[ "$candidate_path" != /bin && "$candidate_path" != /usr && "$candidate_path" != /etc && "$candidate_path" != /var ]] && \
-       [ -d "$candidate_path" ]; then
+    if [ -n "$candidate_path" ] && [ -d "$candidate_path" ] && \
+       [[ "$candidate_path" == */"${PREFIX}" ]]; then
       taos_dir="$candidate_path"
       taos_dir_set=1
       log info "Detected previous installation path: ${taos_dir}"

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -291,6 +291,23 @@ function setup_env() {
       echo
   fi
   
+  # 3.5 Read previous install path from .install_path if not explicitly set via -d
+  if [[ $taos_dir_set -eq 0 ]]; then
+    local candidate_path=""
+    if [ -n "${taosd_parent_dir:-}" ] && [ -f "${taosd_parent_dir}/.install_path" ]; then
+      candidate_path=$(cat "${taosd_parent_dir}/.install_path")
+    elif [ -f "/usr/local/${PREFIX}/.install_path" ]; then
+      candidate_path=$(cat "/usr/local/${PREFIX}/.install_path")
+    elif [ -f "$HOME/${PREFIX}/.install_path" ]; then
+      candidate_path=$(cat "$HOME/${PREFIX}/.install_path")
+    fi
+
+    if [ -n "$candidate_path" ] && [ -d "$candidate_path" ]; then
+      taos_dir="$candidate_path"
+      taos_dir_set=1
+      log info "Detected previous installation path: ${taos_dir}"
+    fi
+  fi
 
   # 4. Install directory setting
   log info "Detected install mode: $mode_desc"

--- a/packaging/tools/install_client.sh
+++ b/packaging/tools/install_client.sh
@@ -84,10 +84,9 @@ fi
 update_flag=0
 
 function kill_client() {
-  pid=$(ps -ef | grep "${clientName}" | grep -v "grep" | awk '{print $2}')
-  if [ -n "$pid" ]; then
-    ${csudo}kill -9 $pid   || :
-  fi
+  ps -ef | grep "${clientName}" | grep -v "grep" | awk '{print $2}' | while read p; do
+    ${csudo}kill -9 "$p" 2>/dev/null || :
+  done
 }
 
 function install_main_path() {

--- a/packaging/tools/install_client.sh
+++ b/packaging/tools/install_client.sh
@@ -84,9 +84,9 @@ fi
 update_flag=0
 
 function kill_client() {
-  ps -ef | grep "${clientName}" | grep -v "grep" | awk '{print $2}' | while read p; do
+  pgrep -x "${clientName}" | while read p; do
     ${csudo}kill -9 "$p" 2>/dev/null || :
-  done
+  done || true
 }
 
 function install_main_path() {

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -547,9 +547,12 @@ function clean_env_file() {
   fi
 
   local tmp_file="${env_file}.tmp.$$"
+  local escaped_bin escaped_lib
+  escaped_bin=$(printf '%s' "${bin_link_dir}" | sed 's/[.[\\/^$*]/\\&/g')
+  escaped_lib=$(printf '%s' "${lib_link_dir}" | sed 's/[.[\\/^$*]/\\&/g')
   sed -e "/^# ${productName} install path$/d" \
-      -e "\|^export PATH=\"${bin_link_dir}:.*\"|d" \
-      -e "\|^export LD_LIBRARY_PATH=\"${lib_link_dir}:.*\"|d" \
+      -e "\|^export PATH=\"${escaped_bin}:.*\"|d" \
+      -e "\|^export LD_LIBRARY_PATH=\"${escaped_lib}:.*\"|d" \
       "$env_file" > "$tmp_file" && mv "$tmp_file" "$env_file" || rm -f "$tmp_file"
 }
 clean_env_file

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -525,6 +525,35 @@ elif echo $osinfo | grep -qwi "centos"; then
 fi
 
 command -v systemctl >/dev/null 2>&1 && ${sysctl_cmd} daemon-reload >/dev/null 2>&1 || true
+
+# Clean env variables from shell rc file for non-root uninstall
+function clean_env_file() {
+  if [ "$user_mode" -ne 1 ]; then
+    return 0
+  fi
+
+  local env_file=""
+  local login_shell="${SHELL##*/}"
+  if [ "$login_shell" = "zsh" ]; then
+    env_file="${HOME}/.zshrc"
+  elif [ "$login_shell" = "bash" ] || [ -z "$login_shell" ]; then
+    env_file="${HOME}/.bashrc"
+  else
+    env_file="${HOME}/.profile"
+  fi
+
+  if [ ! -f "$env_file" ]; then
+    return 0
+  fi
+
+  local tmp_file="${env_file}.tmp.$$"
+  sed -e "/^# ${productName} install path$/d" \
+      -e "\|^export PATH=\"${bin_link_dir}:.*\"|d" \
+      -e "\|^export LD_LIBRARY_PATH=\"${lib_link_dir}:.*\"|d" \
+      "$env_file" > "$tmp_file" && mv "$tmp_file" "$env_file" || rm -f "$tmp_file"
+}
+clean_env_file
+
 echo
 echo "${productName} is removed successfully!"
 echo

--- a/packaging/tools/remove_client.sh
+++ b/packaging/tools/remove_client.sh
@@ -21,7 +21,7 @@ benchmarkName2="${clientName2}Benchmark"
 demoName2="${clientName2}demo"
 dumpName2="${clientName2}dump"
 inspect_name="${clientName2}inspect"
-taosgen_name="${PREFIX}gen"
+taosgen_name="${clientName2}taosgen"
 uninstallScript2="rm${clientName2}"
 
 # User mode detection and path setup
@@ -188,9 +188,12 @@ function clean_env_file() {
   fi
 
   local tmp_file="${env_file}.tmp.$$"
+  local escaped_bin escaped_lib
+  escaped_bin=$(printf '%s' "${bin_link_dir}" | sed 's/[.[\\/^$*]/\\&/g')
+  escaped_lib=$(printf '%s' "${lib_link_dir}" | sed 's/[.[\\/^$*]/\\&/g')
   sed -e "/^# ${productName} install path$/d" \
-      -e "\|^export PATH=\"${bin_link_dir}:.*\"|d" \
-      -e "\|^export LD_LIBRARY_PATH=\"${lib_link_dir}:.*\"|d" \
+      -e "\|^export PATH=\"${escaped_bin}:.*\"|d" \
+      -e "\|^export LD_LIBRARY_PATH=\"${escaped_lib}:.*\"|d" \
       "$env_file" > "$tmp_file" && mv "$tmp_file" "$env_file" || rm -f "$tmp_file"
 }
 clean_env_file

--- a/packaging/tools/remove_client.sh
+++ b/packaging/tools/remove_client.sh
@@ -8,13 +8,14 @@ RED='\033[0;31m'
 GREEN='\033[1;32m'
 NC='\033[0m'
 verMode=edge
+PREFIX="taos"
 
-installDir="/usr/local/taos"
 clientName="taos"
 uninstallScript="rmtaos"
 
 clientName2="taos"
 productName2="TDengine"
+productName="TDengine TSDB"
 
 benchmarkName2="${clientName2}Benchmark"
 demoName2="${clientName2}demo"
@@ -23,24 +24,53 @@ inspect_name="${clientName2}inspect"
 taosgen_name="${PREFIX}gen"
 uninstallScript2="rm${clientName2}"
 
-installDir="/usr/local/${clientName2}"
+# User mode detection and path setup
+if [ "$(id -u)" -ne 0 ]; then
+  user_mode=1
+  installDir="$HOME/${clientName2}"
+  bin_link_dir="$HOME/.local/bin"
+  lib_link_dir="$HOME/.local/lib"
+  lib64_link_dir="$HOME/.local/lib64"
+  inc_link_dir="$HOME/.local/include"
+  log_dir="$HOME/${clientName2}/log"
+  cfg_dir="$HOME/${clientName2}/cfg"
+  csudo=""
+else
+  user_mode=0
+  installDir="/usr/local/${clientName2}"
+  bin_link_dir="/usr/bin"
+  lib_link_dir="/usr/lib"
+  lib64_link_dir="/usr/lib64"
+  inc_link_dir="/usr/include"
+  log_dir="/var/log/${clientName2}"
+  cfg_dir="/etc/${clientName2}"
+  csudo=""
+  if command -v sudo >/dev/null; then
+    csudo="sudo "
+  fi
+fi
 
-#install main path
+# Install path discovery from .install_path
+_script_real="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+_script_dir="$(dirname "$_script_real")"
+_guessed_dir=""
+if [[ "$_script_dir" == */bin ]]; then
+  _guessed_dir="${_script_dir%/bin}"
+elif [[ "$_script_dir" == */${clientName2} ]]; then
+  _guessed_dir="$_script_dir"
+fi
+
+if [ -n "${_guessed_dir:-}" ] && [ -f "${_guessed_dir}/.install_path" ]; then
+  installDir=$(cat "${_guessed_dir}/.install_path")
+elif [ -f "/usr/local/${clientName2}/.install_path" ] && [ "$user_mode" -eq 0 ]; then
+  installDir=$(cat "/usr/local/${clientName2}/.install_path")
+elif [ -f "$HOME/${clientName2}/.install_path" ] && [ "$user_mode" -eq 1 ]; then
+  installDir=$(cat "$HOME/${clientName2}/.install_path")
+fi
+
 install_main_dir=${installDir}
-
 log_link_dir=${installDir}/log
 cfg_link_dir=${installDir}/cfg
-bin_link_dir="/usr/bin"
-lib_link_dir="/usr/lib"
-lib64_link_dir="/usr/lib64"
-inc_link_dir="/usr/include"
-log_dir="/var/log/${clientName2}"
-cfg_dir="/etc/${clientName2}"
-
-csudo=""
-if command -v sudo >/dev/null; then
-    csudo="sudo "
-fi
 
 function kill_client() {
     pid=$(ps -C ${clientName2} | grep -w ${clientName2} | grep -v $uninstallScript2 | awk '{print $1}')
@@ -136,6 +166,34 @@ clean_config
 clean_config_and_log_dir
 
 ${csudo}rm -rf ${install_main_dir}
+
+# Clean env variables from shell rc file for non-root uninstall
+function clean_env_file() {
+  if [ "$user_mode" -ne 1 ]; then
+    return 0
+  fi
+
+  local env_file=""
+  local login_shell="${SHELL##*/}"
+  if [ "$login_shell" = "zsh" ]; then
+    env_file="${HOME}/.zshrc"
+  elif [ "$login_shell" = "bash" ] || [ -z "$login_shell" ]; then
+    env_file="${HOME}/.bashrc"
+  else
+    env_file="${HOME}/.profile"
+  fi
+
+  if [ ! -f "$env_file" ]; then
+    return 0
+  fi
+
+  local tmp_file="${env_file}.tmp.$$"
+  sed -e "/^# ${productName} install path$/d" \
+      -e "\|^export PATH=\"${bin_link_dir}:.*\"|d" \
+      -e "\|^export LD_LIBRARY_PATH=\"${lib_link_dir}:.*\"|d" \
+      "$env_file" > "$tmp_file" && mv "$tmp_file" "$env_file" || rm -f "$tmp_file"
+}
+clean_env_file
 
 echo -e "${GREEN}${productName2} client is removed successfully!${NC}"
 echo


### PR DESCRIPTION
## 问题背景
在 3.3.6 非 root 打包 backport 的 review 中，发现 main 分支安装/卸载脚本存在同类问题，可能影响安全性、跨平台兼容性和升级/卸载稳定性。本 PR 将相关修复同步到 main。

## 主要修复
1. 安装脚本安全与兼容性修复  
- 修复 /etc/hosts 处理：非 root 模式跳过修改，root 模式仅在可写时追加，避免不安全权限操作。  
- 修复 SysV 注册拼写问题：insserv 参数多余字符导致注册失败。  
- 修复进程清理兼容性：去除 GNU 专有依赖，改为更稳妥的逐行处理。  
- 增强 non-root 运行提示：增加 systemd 版本检查与 linger 提示。

2. 升级路径与安装目录保护  
- 升级场景支持读取 .install_path，尽量保持历史安装目录。  
- 新增危险路径校验，防止异常路径导致安装过程误操作系统目录。  
- 移除 install_main_path 中对 data/log/cfg 链接目录的危险删除逻辑，降低数据误删风险。

3. 卸载脚本修复  
- 非 root 卸载补齐路径与模式识别逻辑。  
- 卸载时增加环境变量清理（PATH/LD_LIBRARY_PATH）。  
- 修复 taosgen 命名不一致问题。  
- 修复 sed 正则转义，避免误删无关环境变量行。

## 影响范围
- packaging/tools/install.sh  
- packaging/tools/install_client.sh  
- packaging/tools/remove.sh  
- packaging/tools/remove_client.sh

## 验证建议
- root / non-root 安装、升级、卸载全流程回归。  
- 覆盖 systemd 低版本与高版本场景。  
- 覆盖 bash 与 zsh 不同登录 shell 组合。  
- 覆盖自定义安装目录与历史 .install_path 升级场景。  
- 重点验证数据目录与日志目录在升级中不被误删。

## 关联 PR
- TDengine PR #35145 (3.3.6 backport，已修复相同问题)
- TDinternal PR [#2573](https://github.com/taosdata/TDinternal/pull/2573) (企业版脚本)
