### PR TITLE
fix: replace \s with [[:space:]] in shell regex for macOS BSD compat

### DIFF
--- a/tools/shell/src/shellCommand.c
+++ b/tools/shell/src/shellCommand.c
@@ -325,8 +325,8 @@ bool shellIsReadyGo(SShellCmd *cmd) {
   sprintf(total, "%s%s", cmd->buffer, cmd->command);
 
   char *reg_str =
-      "(^.*;\\s*$)|(^\\s*$)|(^\\s*exit\\s*$)|(^\\s*q\\s*$)|(^\\s*quit\\s*$)|(^"
-      "\\s*clear\\s*$)";
+      "(^.*;[[:space:]]*$)|(^[[:space:]]*$)|(^[[:space:]]*exit[[:space:]]*$)|(^[[:space:]]*q[[:space:]]*$)|(^[[:space:]]*quit[[:space:]]*$)|(^"
+      "[[:space:]]*clear[[:space:]]*$)";
   if (shellRegexMatch(total, reg_str, REG_EXTENDED | REG_ICASE)) {
     taosMemoryFree(total);
     return true;

--- a/tools/shell/src/shellCommand.c
+++ b/tools/shell/src/shellCommand.c
@@ -287,7 +287,7 @@ void shellUpdateBuffer(SShellCmd *cmd) {
 
   /* If regex condition is met, try to append one space to cmd->command safely.
      This mirrors the original intent but avoids buffer overflow. */
-  if (shellRegexMatch(cmd->buffer, "(\\s+$)|(^$)", REG_EXTENDED)) {
+  if (shellRegexMatch(cmd->buffer, "([[:space:]]+$)|(^$)", REG_EXTENDED)) {
     if (cmd_len + 1 < cap) {
       cmd->command[cmd_len] = ' ';
       cmd->command[cmd_len + 1] = '\0';

--- a/tools/shell/src/shellEngine.c
+++ b/tools/shell/src/shellEngine.c
@@ -255,7 +255,7 @@ void shellRunSingleCommandImp(char *command) {
     return;
   }
 
-  if (shellRegexMatch(command, "^[[:space:]]*use[[:space:]]+[a-zA-Z0-9_]+[[:space:]]*;[[:space:]]*$", REG_EXTENDED | REG_ICASE)) {
+  if (shellRegexMatch(command, "^[[:space:]]*use[[:space:]]+[a-zA-Z0-9_]+[[:space:]]*;?[[:space:]]*$", REG_EXTENDED | REG_ICASE)) {
     (void)printf("Database changed.\r\n\r\n");
 
     // call back auto tab module
@@ -268,9 +268,9 @@ void shellRunSingleCommandImp(char *command) {
 
   // pre string
   char *pre = "Query OK";
-  if (shellRegexMatch(command, "^[[:space:]]*delete[[:space:]]*from[[:space:]]*.*", REG_EXTENDED | REG_ICASE)) {
+  if (shellRegexMatch(command, "^[[:space:]]*delete[[:space:]]+from[[:space:]]*.*", REG_EXTENDED | REG_ICASE)) {
     pre = "Delete OK";
-  } else if (shellRegexMatch(command, "^[[:space:]]*insert[[:space:]]*into[[:space:]]*.*", REG_EXTENDED | REG_ICASE)) {
+  } else if (shellRegexMatch(command, "^[[:space:]]*insert[[:space:]]+into[[:space:]]*.*", REG_EXTENDED | REG_ICASE)) {
     pre = "Insert OK";
   } else if (shellRegexMatch(command, "^[[:space:]]*create[[:space:]]*.*", REG_EXTENDED | REG_ICASE)) {
     pre = "Create OK";

--- a/tools/shell/src/shellEngine.c
+++ b/tools/shell/src/shellEngine.c
@@ -255,7 +255,7 @@ void shellRunSingleCommandImp(char *command) {
     return;
   }
 
-  if (shellRegexMatch(command, "^\\s*use\\s+[a-zA-Z0-9_]+\\s*;\\s*$", REG_EXTENDED | REG_ICASE)) {
+  if (shellRegexMatch(command, "^[[:space:]]*use[[:space:]]+[a-zA-Z0-9_]+[[:space:]]*;[[:space:]]*$", REG_EXTENDED | REG_ICASE)) {
     (void)printf("Database changed.\r\n\r\n");
 
     // call back auto tab module
@@ -268,13 +268,13 @@ void shellRunSingleCommandImp(char *command) {
 
   // pre string
   char *pre = "Query OK";
-  if (shellRegexMatch(command, "^\\s*delete\\s*from\\s*.*", REG_EXTENDED | REG_ICASE)) {
+  if (shellRegexMatch(command, "^[[:space:]]*delete[[:space:]]*from[[:space:]]*.*", REG_EXTENDED | REG_ICASE)) {
     pre = "Delete OK";
-  } else if (shellRegexMatch(command, "^\\s*insert\\s*into\\s*.*", REG_EXTENDED | REG_ICASE)) {
+  } else if (shellRegexMatch(command, "^[[:space:]]*insert[[:space:]]*into[[:space:]]*.*", REG_EXTENDED | REG_ICASE)) {
     pre = "Insert OK";
-  } else if (shellRegexMatch(command, "^\\s*create\\s*.*", REG_EXTENDED | REG_ICASE)) {
+  } else if (shellRegexMatch(command, "^[[:space:]]*create[[:space:]]*.*", REG_EXTENDED | REG_ICASE)) {
     pre = "Create OK";
-  } else if (shellRegexMatch(command, "^\\s*drop\\s*.*", REG_EXTENDED | REG_ICASE)) {
+  } else if (shellRegexMatch(command, "^[[:space:]]*drop[[:space:]]*.*", REG_EXTENDED | REG_ICASE)) {
     pre = "Drop OK";
   }
 
@@ -1244,7 +1244,7 @@ void shellPrintError(TAOS_RES *tres, int64_t st) {
 
 bool shellIsCommentLine(char *line) {
   if (line == NULL) return true;
-  return shellRegexMatch(line, "^\\s*#.*", REG_EXTENDED);
+  return shellRegexMatch(line, "^[[:space:]]*#.*", REG_EXTENDED);
 }
 
 void shellSourceFile(const char *file) {


### PR DESCRIPTION
# Description

<!-- Please briefly describe the code changes in this pull request. -->

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
