### PR TITLE
feat(planner): push outer time range down through UNION ALL subqueries

### DIFF
--- a/source/libs/executor/src/externalwindowoperator.c
+++ b/source/libs/executor/src/externalwindowoperator.c
@@ -2475,8 +2475,8 @@ static int32_t extWinApplyAggPostProjection(SOperatorInfo* pOperator, SExternalW
     return TSDB_CODE_SUCCESS;
   }
 
-  int32_t      code = TSDB_CODE_SUCCESS;
-  int32_t      lino = 0;
+  int32_t code = TSDB_CODE_SUCCESS;
+  int32_t lino = 0;
 
   if (startRow < 0 || startRow + numOfRows > pBlock->info.rows) {
     return TSDB_CODE_INVALID_PARA;
@@ -2493,8 +2493,8 @@ static int32_t extWinApplyAggPostProjection(SOperatorInfo* pOperator, SExternalW
 
   SSDataBlock* pSlice = pExtW->pProjTmpBlock;
   TAOS_CHECK_EXIT(projectApplyFunctions(pExtW->projSupp.pExprInfo, pSlice, pSlice, pExtW->projSupp.pCtx,
-                                        pExtW->projSupp.numOfExprs, NULL,
-                                        GET_STM_RTINFO(pOperator->pTaskInfo)));
+                                        pExtW->projSupp.numOfExprs, NULL, GET_STM_RTINFO(pOperator->pTaskInfo),
+                                        pOperator->pTaskInfo));
 
   int32_t numOfCols = taosArrayGetSize(pBlock->pDataBlock);
   // TODO(perf): only copy back the slots actually written by projSupp, not all columns.

--- a/source/libs/planner/src/planOptimizer.c
+++ b/source/libs/planner/src/planOptimizer.c
@@ -2653,22 +2653,37 @@ static int32_t pdcExtractPrimKeyPushCond(SNode* pCond, SNode** ppOut, bool* pIsP
  *   a LIMIT boundary); if any child is skipped the setop project retains
  *   the condition for those children.
  */
-/* Returns true when the first projected expression of a UNION ALL branch project
- * node is an arithmetic operator (e.g. _rowts + 3600000).  In that case the
- * outer ts condition must NOT be pushed to the scan: pushing ts >= X to the scan
- * as _rowts >= X is wrong because the actual scan boundary should be
- * _rowts >= X - offset.  The condition must stay on the setop project to be
- * applied correctly after the arithmetic is evaluated. */
-static bool pdcSetOpBranchFirstProjIsArithExpr(SLogicNode* pBranch) {
-  if (QUERY_NODE_LOGIC_PLAN_PROJECT != nodeType(pBranch)) {
+/* Returns the 0-based index of the primary-key column in the setop output
+ * projection list, or -1 if not found. */
+static int32_t pdcSetOpFindPkProjIdx(SProjectLogicNode* pSetOpProj) {
+  int32_t idx  = 0;
+  SNode*  pCol = NULL;
+  FOREACH(pCol, pSetOpProj->pProjections) {
+    if (QUERY_NODE_COLUMN == nodeType(pCol) &&
+        PRIMARYKEY_TIMESTAMP_COL_ID == ((SColumnNode*)pCol)->colId) {
+      return idx;
+    }
+    idx++;
+  }
+  return -1;
+}
+
+/* Returns true when the projected expression at position pkIdx of a UNION ALL
+ * branch project node is an arithmetic operator (e.g. _rowts + 3600000).
+ * In that case the outer ts condition must NOT be pushed to the scan: pushing
+ * ts >= X to the scan as _rowts >= X is wrong because the actual scan boundary
+ * should be _rowts >= X - offset.  The condition must stay on the setop project
+ * to be applied correctly after the arithmetic is evaluated. */
+static bool pdcSetOpBranchProjAtIdxIsArithExpr(SLogicNode* pBranch, int32_t pkIdx) {
+  if (QUERY_NODE_LOGIC_PLAN_PROJECT != nodeType(pBranch) || pkIdx < 0) {
     return false;
   }
   SProjectLogicNode* pProj = (SProjectLogicNode*)pBranch;
-  if (NULL == pProj->pProjections || LIST_LENGTH(pProj->pProjections) == 0) {
+  if (NULL == pProj->pProjections || LIST_LENGTH(pProj->pProjections) <= pkIdx) {
     return false;
   }
-  SNode* pFirst = nodesListGetNode(pProj->pProjections, 0);
-  return QUERY_NODE_OPERATOR == nodeType(pFirst);
+  SNode* pPkExpr = nodesListGetNode(pProj->pProjections, pkIdx);
+  return QUERY_NODE_OPERATOR == nodeType(pPkExpr);
 }
 
 static int32_t pdcDealSetOpProject(SOptimizeContext* pCxt, SProjectLogicNode* pSetOpProj) {
@@ -2695,10 +2710,11 @@ static int32_t pdcDealSetOpProject(SOptimizeContext* pCxt, SProjectLogicNode* pS
   }
 
   /* Clone-push the ts condition into each child that has no LIMIT/SLIMIT and
-   * whose first projected column is not an arithmetic expression on _rowts.
+   * whose primary-key projected column is not an arithmetic expression on _rowts.
    * Arithmetic expressions (e.g. _rowts + offset) require the outer condition
    * to be applied after evaluation; pushing ts >= X to the scan would
    * incorrectly interpret it as _rowts >= X, ignoring the offset. */
+  int32_t pkIdx          = pdcSetOpFindPkProjIdx(pSetOpProj);
   bool   anyChildSkipped = false;
   bool   pushedAny       = false;
   SNode* pChildNode      = NULL;
@@ -2708,7 +2724,7 @@ static int32_t pdcDealSetOpProject(SOptimizeContext* pCxt, SProjectLogicNode* pS
       anyChildSkipped = true;
       continue;
     }
-    if (pdcSetOpBranchFirstProjIsArithExpr(pChild)) {
+    if (pdcSetOpBranchProjAtIdxIsArithExpr(pChild, pkIdx)) {
       anyChildSkipped = true;
       continue;
     }

--- a/source/libs/planner/src/planOptimizer.c
+++ b/source/libs/planner/src/planOptimizer.c
@@ -2588,12 +2588,20 @@ static int32_t pdcExtractPrimKeyPushCond(SNode* pCond, SNode** ppOut, bool* pIsP
   *ppOut         = NULL;
   *pIsPureTsCond = false;
 
-  if (pdcSetOpCondOnlyRefsPrimaryKey(pCond)) {
+  /* A top-level AND or simple comparison that references only the primary key
+   * can be cloned and pushed as an I/O hint to branch scans.
+   * OR conditions (e.g. ts < X OR ts > Y) cannot be expressed as a single
+   * contiguous scan time range and must stay as a Filter on the setop project;
+   * pushing them would cause a slot-key resolution failure in the physical
+   * planner because the column reference context changes at the branch boundary. */
+  bool isOrCond = (QUERY_NODE_LOGIC_CONDITION == nodeType(pCond) &&
+                   LOGIC_COND_TYPE_OR == ((SLogicConditionNode*)pCond)->condType);
+  if (!isOrCond && pdcSetOpCondOnlyRefsPrimaryKey(pCond)) {
     *pIsPureTsCond = true;
     return nodesCloneNode(pCond, ppOut);
   }
 
-  /* Non-AND top-level condition with non-ts refs: nothing pushable. */
+  /* Non-AND top-level condition with non-ts refs or OR: nothing pushable. */
   if (QUERY_NODE_LOGIC_CONDITION != nodeType(pCond) ||
       LOGIC_COND_TYPE_AND != ((SLogicConditionNode*)pCond)->condType) {
     return TSDB_CODE_SUCCESS;
@@ -2645,6 +2653,24 @@ static int32_t pdcExtractPrimKeyPushCond(SNode* pCond, SNode** ppOut, bool* pIsP
  *   a LIMIT boundary); if any child is skipped the setop project retains
  *   the condition for those children.
  */
+/* Returns true when the first projected expression of a UNION ALL branch project
+ * node is an arithmetic operator (e.g. _rowts + 3600000).  In that case the
+ * outer ts condition must NOT be pushed to the scan: pushing ts >= X to the scan
+ * as _rowts >= X is wrong because the actual scan boundary should be
+ * _rowts >= X - offset.  The condition must stay on the setop project to be
+ * applied correctly after the arithmetic is evaluated. */
+static bool pdcSetOpBranchFirstProjIsArithExpr(SLogicNode* pBranch) {
+  if (QUERY_NODE_LOGIC_PLAN_PROJECT != nodeType(pBranch)) {
+    return false;
+  }
+  SProjectLogicNode* pProj = (SProjectLogicNode*)pBranch;
+  if (NULL == pProj->pProjections || LIST_LENGTH(pProj->pProjections) == 0) {
+    return false;
+  }
+  SNode* pFirst = nodesListGetNode(pProj->pProjections, 0);
+  return QUERY_NODE_OPERATOR == nodeType(pFirst);
+}
+
 static int32_t pdcDealSetOpProject(SOptimizeContext* pCxt, SProjectLogicNode* pSetOpProj) {
   int32_t code = TSDB_CODE_SUCCESS;
 
@@ -2668,14 +2694,22 @@ static int32_t pdcDealSetOpProject(SOptimizeContext* pCxt, SProjectLogicNode* pS
     return code;
   }
 
-  /* Clone-push the ts condition into each child that has no LIMIT/SLIMIT. */
-  bool   anyChildHasLimit = false;
-  bool   pushedAny        = false;
-  SNode* pChildNode       = NULL;
+  /* Clone-push the ts condition into each child that has no LIMIT/SLIMIT and
+   * whose first projected column is not an arithmetic expression on _rowts.
+   * Arithmetic expressions (e.g. _rowts + offset) require the outer condition
+   * to be applied after evaluation; pushing ts >= X to the scan would
+   * incorrectly interpret it as _rowts >= X, ignoring the offset. */
+  bool   anyChildSkipped = false;
+  bool   pushedAny       = false;
+  SNode* pChildNode      = NULL;
   FOREACH(pChildNode, pSetOpProj->node.pChildren) {
     SLogicNode* pChild = (SLogicNode*)pChildNode;
     if (NULL != pChild->pLimit || NULL != pChild->pSlimit) {
-      anyChildHasLimit = true;
+      anyChildSkipped = true;
+      continue;
+    }
+    if (pdcSetOpBranchFirstProjIsArithExpr(pChild)) {
+      anyChildSkipped = true;
       continue;
     }
     SNode* pPushCond = NULL;
@@ -2698,9 +2732,10 @@ static int32_t pdcDealSetOpProject(SOptimizeContext* pCxt, SProjectLogicNode* pS
   if (pushedAny) {
     /* For a pure-ts condition fully delivered to all children, remove it
      * from the setop project (redundant re-filter).  For mixed conditions
-     * or when some children had LIMIT, the original full condition must
-     * stay on the setop project for final filtering. */
-    if (isPureTsCond && !anyChildHasLimit) {
+     * or when some children had LIMIT or arithmetic-expression aliases, the
+     * original full condition must stay on the setop project for final
+     * filtering. */
+    if (isPureTsCond && !anyChildSkipped) {
       nodesDestroyNode(pSetOpProj->node.pConditions);
       pSetOpProj->node.pConditions = NULL;
     }

--- a/source/libs/planner/src/planOptimizer.c
+++ b/source/libs/planner/src/planOptimizer.c
@@ -2552,21 +2552,182 @@ static int32_t rewriteProjectCondForPushDown(SOptimizeContext* pCxt, SProjectLog
   return cxt.errCode;
 }
 
+static EDealRes pdcSetOpCondHasNonPrimKeyImpl(SNode* pNode, void* pCtx) {
+  if (QUERY_NODE_COLUMN == nodeType(pNode)) {
+    if (!isPrimaryKeyImpl(pNode)) {
+      *(bool*)pCtx = true;
+      return DEAL_RES_END;
+    }
+  }
+  return DEAL_RES_CONTINUE;
+}
+
+/* Returns true only when every column reference in pCond is the primary
+ * timestamp column.  Conditions that reference other columns (e.g. tbname,
+ * tag columns) cannot be safely rewritten through a branch project's column
+ * mapping because of tableAlias mismatches, so they must stay on the setop
+ * project node and must not be pushed to children. */
+static bool pdcSetOpCondOnlyRefsPrimaryKey(SNode* pCond) {
+  bool hasNonPrimKey = false;
+  nodesWalkExpr(pCond, pdcSetOpCondHasNonPrimKeyImpl, &hasNonPrimKey);
+  return !hasNonPrimKey;
+}
+
+/* Extract the primary-timestamp-only sub-conditions from pCond and return
+ * them as a new node (owned by caller) suitable for pushing to branch scans.
+ * Sets *pIsPureTsCond = true when the entire condition is primary-ts-only.
+ *
+ * - Pure-ts condition:  returns a clone of the entire condition.
+ * - Top-level AND with some pure-ts sub-terms: returns AND of those clones.
+ * - Non-AND mixed condition (OR, single non-ts term): returns NULL.
+ *
+ * The returned node is used only as an I/O hint pushed to branch scans;
+ * the original pCond stays on the setop project for definitive filtering.
+ */
+static int32_t pdcExtractPrimKeyPushCond(SNode* pCond, SNode** ppOut, bool* pIsPureTsCond) {
+  *ppOut         = NULL;
+  *pIsPureTsCond = false;
+
+  if (pdcSetOpCondOnlyRefsPrimaryKey(pCond)) {
+    *pIsPureTsCond = true;
+    return nodesCloneNode(pCond, ppOut);
+  }
+
+  /* Non-AND top-level condition with non-ts refs: nothing pushable. */
+  if (QUERY_NODE_LOGIC_CONDITION != nodeType(pCond) ||
+      LOGIC_COND_TYPE_AND != ((SLogicConditionNode*)pCond)->condType) {
+    return TSDB_CODE_SUCCESS;
+  }
+
+  /* AND: collect clones of pure-ts sub-terms. */
+  SNodeList* pTsList = NULL;
+  int32_t    code    = TSDB_CODE_SUCCESS;
+  SNode*     pItem   = NULL;
+  FOREACH(pItem, ((SLogicConditionNode*)pCond)->pParameterList) {
+    if (!pdcSetOpCondOnlyRefsPrimaryKey(pItem)) continue;
+    SNode* pClone = NULL;
+    code = nodesCloneNode(pItem, &pClone);
+    if (TSDB_CODE_SUCCESS != code) {
+      nodesDestroyList(pTsList);
+      return code;
+    }
+    code = nodesListMakeAppend(&pTsList, pClone);
+    if (TSDB_CODE_SUCCESS != code) {
+      nodesDestroyNode(pClone);
+      nodesDestroyList(pTsList);
+      return code;
+    }
+  }
+
+  if (NULL == pTsList) return TSDB_CODE_SUCCESS;
+
+  /* nodesMergeConds: single item → unwrap; multiple → AND wrapper. */
+  return nodesMergeConds(ppOut, &pTsList);
+}
+
+/*
+ * Distribute the primary-timestamp part of the condition from a set-operator
+ * project (UNION ALL) to child nodes for I/O pruning.
+ *
+ * - If the setop project itself has LIMIT/SLIMIT, do not distribute at all.
+ * - For pure-ts conditions with no LIMIT on any child: clear the condition
+ *   from the setop project (it is now fully handled by branch scans).
+ * - For mixed AND conditions (ts + non-ts): push only the ts sub-conditions
+ *   as I/O hints; keep the full original condition on the setop project for
+ *   final filtering of non-ts predicates.
+ * - Children that have their own LIMIT/SLIMIT are skipped (cannot push past
+ *   a LIMIT boundary); if any child is skipped the setop project retains
+ *   the condition for those children.
+ */
+static int32_t pdcDealSetOpProject(SOptimizeContext* pCxt, SProjectLogicNode* pSetOpProj) {
+  int32_t code = TSDB_CODE_SUCCESS;
+
+  /* Do not push through the setop project's own LIMIT/SLIMIT boundary. */
+  if (NULL != pSetOpProj->node.pLimit || NULL != pSetOpProj->node.pSlimit) {
+    OPTIMIZE_FLAG_SET_MASK(pSetOpProj->node.optimizedFlag, OPTIMIZE_FLAG_PUSH_DOWN_CONDE);
+    return code;
+  }
+
+  /* Extract the pushable (primary-timestamp-only) part of the condition in a
+   * single pass.  pdcExtractPrimKeyPushCond also tells us whether the entire
+   * condition is pure-ts (isPureTsCond) so we do not need a second traversal. */
+  bool   isPureTsCond = false;
+  SNode* pTsPushCond  = NULL;
+  code = pdcExtractPrimKeyPushCond(pSetOpProj->node.pConditions, &pTsPushCond, &isPureTsCond);
+  if (TSDB_CODE_SUCCESS != code) return code;
+
+  if (NULL == pTsPushCond) {
+    /* No pushable ts sub-condition (non-ts predicate or OR with non-ts). */
+    OPTIMIZE_FLAG_SET_MASK(pSetOpProj->node.optimizedFlag, OPTIMIZE_FLAG_PUSH_DOWN_CONDE);
+    return code;
+  }
+
+  /* Clone-push the ts condition into each child that has no LIMIT/SLIMIT. */
+  bool   anyChildHasLimit = false;
+  bool   pushedAny        = false;
+  SNode* pChildNode       = NULL;
+  FOREACH(pChildNode, pSetOpProj->node.pChildren) {
+    SLogicNode* pChild = (SLogicNode*)pChildNode;
+    if (NULL != pChild->pLimit || NULL != pChild->pSlimit) {
+      anyChildHasLimit = true;
+      continue;
+    }
+    SNode* pPushCond = NULL;
+    code = nodesCloneNode(pTsPushCond, &pPushCond);
+    if (TSDB_CODE_SUCCESS != code) {
+      nodesDestroyNode(pTsPushCond);
+      return code;
+    }
+    code = nodesMergeNode(&pChild->pConditions, &pPushCond);
+    if (TSDB_CODE_SUCCESS != code) {
+      nodesDestroyNode(pPushCond);
+      nodesDestroyNode(pTsPushCond);
+      return code;
+    }
+    pushedAny = true;
+  }
+
+  nodesDestroyNode(pTsPushCond);
+
+  if (pushedAny) {
+    /* For a pure-ts condition fully delivered to all children, remove it
+     * from the setop project (redundant re-filter).  For mixed conditions
+     * or when some children had LIMIT, the original full condition must
+     * stay on the setop project for final filtering. */
+    if (isPureTsCond && !anyChildHasLimit) {
+      nodesDestroyNode(pSetOpProj->node.pConditions);
+      pSetOpProj->node.pConditions = NULL;
+    }
+    pCxt->optimized = true;
+  }
+
+  OPTIMIZE_FLAG_SET_MASK(pSetOpProj->node.optimizedFlag, OPTIMIZE_FLAG_PUSH_DOWN_CONDE);
+  return code;
+}
+
 static int32_t pdcDealProject(SOptimizeContext* pCxt, SProjectLogicNode* pProject) {
   if (NULL == pProject->node.pConditions ||
       OPTIMIZE_FLAG_TEST_MASK(pProject->node.optimizedFlag, OPTIMIZE_FLAG_PUSH_DOWN_CONDE)) {
     return TSDB_CODE_SUCCESS;
   }
+
+  /* UNION ALL merge-point: distribute ts conditions to branch children. */
+  if (pProject->isSetOpProj) {
+    return pdcDealSetOpProject(pCxt, pProject);
+  }
+
   // TODO: remove it after full implementation of pushing down to child
   if (1 != LIST_LENGTH(pProject->node.pChildren)) {
     return TSDB_CODE_SUCCESS;
   }
 
+  SLogicNode* pChild = (SLogicNode*)nodesListGetNode(pProject->node.pChildren, 0);
+
   if (NULL != pProject->node.pLimit || NULL != pProject->node.pSlimit) {
     return TSDB_CODE_SUCCESS;
   }
-  SLogicNode* pChild = (SLogicNode*)nodesListGetNode(pProject->node.pChildren, 0);
-  if(pChild->pLimit != NULL) {
+
+  if (NULL != pChild->pLimit || NULL != pChild->pSlimit) {
     return TSDB_CODE_SUCCESS;
   }
 
@@ -2589,6 +2750,14 @@ static int32_t pdcDealProject(SOptimizeContext* pCxt, SProjectLogicNode* pProjec
 static int32_t pdcTrivialPushDown(SOptimizeContext* pCxt, SLogicNode* pLogicNode) {
   if (NULL == pLogicNode->pConditions ||
       OPTIMIZE_FLAG_TEST_MASK(pLogicNode->optimizedFlag, OPTIMIZE_FLAG_PUSH_DOWN_CONDE)) {
+    return TSDB_CODE_SUCCESS;
+  }
+  /* Do not push a condition past a LIMIT/SLIMIT boundary on the current node.
+   * The condition must be evaluated on this node's output (after LIMIT is
+   * applied), so pushing it to a child would change how many rows the LIMIT
+   * sees and alter query semantics. */
+  if (NULL != pLogicNode->pLimit || NULL != pLogicNode->pSlimit) {
+    OPTIMIZE_FLAG_SET_MASK(pLogicNode->optimizedFlag, OPTIMIZE_FLAG_PUSH_DOWN_CONDE);
     return TSDB_CODE_SUCCESS;
   }
   SLogicNode* pChild = (SLogicNode*)nodesListGetNode(pLogicNode->pChildren, 0);
@@ -3160,6 +3329,17 @@ static int32_t sortPriKeyOptApply(SOptimizeContext* pCxt, SLogicSubplan* pLogicS
 }
 
 static int32_t sortPrimaryKeyOptimizeImpl(SOptimizeContext* pCxt, SLogicSubplan* pLogicSubplan, SSortLogicNode* pSort) {
+  /* Do not eliminate a SORT that carries WHERE conditions or a LIMIT/SLIMIT.
+   * Both must be evaluated on the sort's output; removing the SORT would
+   * destroy them and silently change query semantics. */
+  if (NULL != pSort->node.pConditions ||
+      NULL != pSort->node.pLimit || NULL != pSort->node.pSlimit) {
+    pSort->skipPKSortOpt = true;
+    optSetParentOrder(pSort->node.pParent, sortPriKeyOptGetPriKeyOrder(pSort), NULL);
+    pCxt->optimized = true;
+    return TSDB_CODE_SUCCESS;
+  }
+
   SNodeList* pSequencingNodes = NULL;
   bool       keepSort = true;
   int32_t    code = sortPriKeyOptGetSequencingNodes(pSort, pSort->groupSort, &pSequencingNodes, &keepSort);
@@ -3179,7 +3359,7 @@ static int32_t sortPrimaryKeyOptimizeImpl(SOptimizeContext* pCxt, SLogicSubplan*
       pCxt->optimized = true;
     } else {
       // if we decided not to push down sort info to children, we should propagate output ts order to parents of pSort
-      optSetParentOrder(pSort->node.pParent, sortPriKeyOptGetPriKeyOrder(pSort), 0);
+      optSetParentOrder(pSort->node.pParent, sortPriKeyOptGetPriKeyOrder(pSort), NULL);
       // we need to prevent this pSort from being chosen to do optimization again
       pSort->skipPKSortOpt = true;
       pCxt->optimized = true;

--- a/source/libs/planner/src/planOptimizer.c
+++ b/source/libs/planner/src/planOptimizer.c
@@ -2621,8 +2621,14 @@ static int32_t pdcExtractPrimKeyPushCond(SNode* pCond, SNode** ppOut, bool* pIsP
 
   if (NULL == pTsList) return TSDB_CODE_SUCCESS;
 
-  /* nodesMergeConds: single item → unwrap; multiple → AND wrapper. */
-  return nodesMergeConds(ppOut, &pTsList);
+  /* nodesMergeConds: single item → unwrap; multiple → AND wrapper.
+   * On failure it does not free *pSrc, so destroy pTsList explicitly. */
+  code = nodesMergeConds(ppOut, &pTsList);
+  if (TSDB_CODE_SUCCESS != code) {
+    *ppOut = NULL;
+    nodesDestroyList(pTsList);
+  }
+  return code;
 }
 
 /*

--- a/test/cases/09-DataQuerying/02-Filter/ans/test_union_all_ts_pushdown.ans
+++ b/test/cases/09-DataQuerying/02-Filter/ans/test_union_all_ts_pushdown.ans
@@ -1,5 +1,3 @@
-Welcome to the TDengine TSDB Command Line Interface, Native Client Version:3.4.1.0.alpha.enterprise 
-Copyright (c) 2025 by TDengine TSDB, all rights reserved.
 
 taos> use uts_adv_db;
 Database changed.
@@ -1616,13 +1614,59 @@ QUERY_PLAN:                Output: columns=2 width=12
 *************************** 18.row ***************************
 QUERY_PLAN:                Time Range: [9223372036854775807, -9223372036854775808]
 
-taos> select ts, v from (select _rowts+3600000 ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc;
+taos> select ts, v from (select _rowts+3600000 ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc, v asc;
            ts            |      v      |
 ========================================
- 2024-03-15 01:00:00.000 |         203 |
  2024-03-15 01:00:00.000 |         102 |
+ 2024-03-15 01:00:00.000 |         203 |
 
-taos> explain verbose true select ts, v from (select _rowts+3600000 ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc\G;
+taos> explain verbose true select ts, v from (select _rowts+3600000 ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc, v asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:          Filter: conditions=((`u`.`ts` >= 1710433800000) AND (`u`.`ts` <= 1718382600000))
+*************************** 6.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 8.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 9.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 10.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 11.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 12.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 13.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 15.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 16.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 17.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 18.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 19.row ***************************
+QUERY_PLAN:                Time Range: [1710433800000, 1718382600000]
+
+taos> select ts, v from (select v, _rowts+3600000 ts from dev_a union all select v, _rowts ts from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc, v asc;
+           ts            |      v      |
+========================================
+ 2024-03-15 01:00:00.000 |         102 |
+ 2024-03-15 01:00:00.000 |         203 |
+
+taos> explain verbose true select ts, v from (select v, _rowts+3600000 ts from dev_a union all select v, _rowts ts from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc, v asc\G;
 *************************** 1.row ***************************
 QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
 *************************** 2.row ***************************

--- a/test/cases/09-DataQuerying/02-Filter/ans/test_union_all_ts_pushdown.ans
+++ b/test/cases/09-DataQuerying/02-Filter/ans/test_union_all_ts_pushdown.ans
@@ -1,0 +1,1664 @@
+Welcome to the TDengine TSDB Command Line Interface, Native Client Version:3.4.1.0.alpha.enterprise 
+Copyright (c) 2025 by TDengine TSDB, all rights reserved.
+
+taos> use uts_adv_db;
+Database changed.
+
+taos> select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts < '2024-02-01 00:00:00' or u.ts > '2024-09-01 00:00:00' order by ts asc;
+           ts            |      v      |
+========================================
+ 2023-07-15 01:00:00.000 |         201 |
+ 2023-12-15 01:00:00.000 |         202 |
+ 2024-01-15 00:00:00.000 |         101 |
+ 2024-09-15 00:00:00.000 |         104 |
+ 2024-12-15 00:00:00.000 |         105 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts < '2024-02-01 00:00:00' or u.ts > '2024-09-01 00:00:00' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:          Filter: conditions=((`u`.`ts` < 1706716800000) OR (`u`.`ts` > 1725120000000))
+*************************** 6.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 8.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 9.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 10.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 11.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 12.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 13.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 15.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 16.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 17.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 18.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 19.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 9223372036854775807]
+
+taos> select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59') u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-07-31 23:59:59' order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-06-15 01:00:00.000 |         204 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59') u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-07-31 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [1714492800000, 1722441599000]
+*************************** 12.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 13.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 15.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Time Range: [1714492800000, 1719763199000]
+
+taos> select ts, v from (select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) inner_u union all select _rowts ts, v from dev_c) outer_u where outer_u.ts >= '2024-03-01 00:00:00' and outer_u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-03-15 00:00:00.000 |         102 |
+ 2024-03-15 01:00:00.000 |         203 |
+ 2024-06-01 02:00:00.000 |         301 |
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-06-15 01:00:00.000 |         204 |
+ 2024-08-15 02:00:00.000 |         302 |
+ 2024-09-15 00:00:00.000 |         104 |
+
+taos> explain verbose true select ts, v from (select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) inner_u union all select _rowts ts, v from dev_c) outer_u where outer_u.ts >= '2024-03-01 00:00:00' and outer_u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=unknown)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Data Exchange 2:1 (width=12)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:             -> Projection (columns=2 width=12 input_order=asc)
+*************************** 12.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 13.row ***************************
+QUERY_PLAN:                   Output: Ignore Group Id: true
+*************************** 14.row ***************************
+QUERY_PLAN:                   Merge ResBlocks: False
+*************************** 15.row ***************************
+QUERY_PLAN:                -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 16.row ***************************
+QUERY_PLAN:                      Output: columns=2 width=12
+*************************** 17.row ***************************
+QUERY_PLAN:                      Time Range: [1709222400000, 1727711999000]
+*************************** 18.row ***************************
+QUERY_PLAN:             -> Projection (columns=2 width=12 input_order=asc)
+*************************** 19.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 20.row ***************************
+QUERY_PLAN:                   Output: Ignore Group Id: true
+*************************** 21.row ***************************
+QUERY_PLAN:                   Merge ResBlocks: False
+*************************** 22.row ***************************
+QUERY_PLAN:                -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 23.row ***************************
+QUERY_PLAN:                      Output: columns=2 width=12
+*************************** 24.row ***************************
+QUERY_PLAN:                      Time Range: [1709222400000, 1727711999000]
+*************************** 25.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 26.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 27.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 28.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 29.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_c (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 30.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 31.row ***************************
+QUERY_PLAN:                Time Range: [1709222400000, 1727711999000]
+
+taos> select ts, total from (select _wstart ts, sum(v) total from dev_a interval(1s) union all select _wstart ts, sum(v) total from dev_b interval(1s)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |         total         |
+==================================================
+ 2024-03-15 00:00:00.000 |                   102 |
+ 2024-03-15 01:00:00.000 |                   203 |
+ 2024-06-15 00:00:00.000 |                   103 |
+ 2024-06-15 01:00:00.000 |                   204 |
+ 2024-09-15 00:00:00.000 |                   104 |
+
+taos> explain verbose true select ts, total from (select _wstart ts, sum(v) total from dev_a interval(1s) union all select _wstart ts, sum(v) total from dev_b interval(1s)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=16)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=16
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=16)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=16
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Interval on Column ts (functions=2 width=16 input_order=asc output_order=asc)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 12.row ***************************
+QUERY_PLAN:                Time Window: interval=1s offset=0a sliding=1s
+*************************** 13.row ***************************
+QUERY_PLAN:                Filter: conditions=((`u`.`ts` >= 1709222400000) AND (`u`.`ts` <= 1727711999000))
+*************************** 14.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 15.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=sma)
+*************************** 16.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 17.row ***************************
+QUERY_PLAN:                   Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 18.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 19.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 20.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 21.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 22.row ***************************
+QUERY_PLAN:          -> Interval on Column ts (functions=2 width=16 input_order=asc output_order=asc)
+*************************** 23.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16
+*************************** 24.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 25.row ***************************
+QUERY_PLAN:                Time Window: interval=1s offset=0a sliding=1s
+*************************** 26.row ***************************
+QUERY_PLAN:                Filter: conditions=((`u`.`ts` >= 1709222400000) AND (`u`.`ts` <= 1727711999000))
+*************************** 27.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 28.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=sma)
+*************************** 29.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 30.row ***************************
+QUERY_PLAN:                   Time Range: [-9223372036854775808, 9223372036854775807]
+
+taos> select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' and u.v > 102 order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-03-15 01:00:00.000 |         203 |
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-06-15 01:00:00.000 |         204 |
+ 2024-09-15 00:00:00.000 |         104 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' and u.v > 102 order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:          Filter: conditions=((`u`.`ts` >= 1709222400000) AND (`u`.`ts` <= 1727711999000) AND (`u`.`v` > 102))
+*************************** 6.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 8.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 9.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 10.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 11.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 12.row ***************************
+QUERY_PLAN:                Time Range: [1709222400000, 1727711999000]
+*************************** 13.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 15.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 16.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 17.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 18.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 19.row ***************************
+QUERY_PLAN:                Time Range: [1709222400000, 1727711999000]
+
+taos> select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-01 00:00:00' order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-03-15 00:00:00.000 |         102 |
+ 2024-03-15 01:00:00.000 |         203 |
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-06-15 01:00:00.000 |         204 |
+ 2024-09-15 00:00:00.000 |         104 |
+ 2024-12-15 00:00:00.000 |         105 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-01 00:00:00' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [1709222400000, 9223372036854775807]
+*************************** 12.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 13.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 15.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Time Range: [1709222400000, 9223372036854775807]
+
+taos> select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b union all select _rowts ts, v from dev_c) u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-06-01 02:00:00.000 |         301 |
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-06-15 01:00:00.000 |         204 |
+ 2024-08-15 02:00:00.000 |         302 |
+ 2024-09-15 00:00:00.000 |         104 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b union all select _rowts ts, v from dev_c) u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 3:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [1714492800000, 1727711999000]
+*************************** 12.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 13.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 15.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Time Range: [1714492800000, 1727711999000]
+*************************** 19.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 20.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 21.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 22.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 23.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_c (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 24.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 25.row ***************************
+QUERY_PLAN:                Time Range: [1714492800000, 1727711999000]
+
+taos> select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_c where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-03-15 00:00:00.000 |         102 |
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-06-15 01:00:00.000 |         204 |
+ 2024-08-15 02:00:00.000 |         302 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_c where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 3:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [1709222400000, 1719763199000]
+*************************** 12.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 13.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 15.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Time Range: [1711900800000, 1727711999000]
+*************************** 19.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 20.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 21.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 22.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 23.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_c (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 24.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 25.row ***************************
+QUERY_PLAN:                Time Range: [1719763200000, 1727711999000]
+
+taos> select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_c where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-03-15 00:00:00.000 |         102 |
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-08-15 02:00:00.000 |         302 |
+ 2024-09-15 00:00:00.000 |         104 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_c where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [1709222400000, 1727711999000]
+*************************** 12.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 13.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 15.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_c (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Time Range: [1719763200000, 1727711999000]
+
+taos> select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-05-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_b union all select _rowts ts, v from dev_c where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-08-31 23:59:59') u where u.ts >= '2024-06-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-06-01 02:00:00.000 |         301 |
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-06-15 01:00:00.000 |         204 |
+ 2024-08-15 02:00:00.000 |         302 |
+ 2024-09-15 00:00:00.000 |         104 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-05-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_b union all select _rowts ts, v from dev_c where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-08-31 23:59:59') u where u.ts >= '2024-06-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 3:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [1717171200000, 1727711999000]
+*************************** 12.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 13.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 15.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Time Range: [1717171200000, 1727711999000]
+*************************** 19.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 20.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 21.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 22.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 23.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_c (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 24.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 25.row ***************************
+QUERY_PLAN:                Time Range: [1717171200000, 1725119999000]
+
+taos> select ts, total from (select _wstart ts, sum(v) total from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' interval(1s) union all select _wstart ts, sum(v) total from dev_e where _rowts >= '2024-05-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' interval(1s)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |         total         |
+==================================================
+ 2024-03-15 00:00:00.000 |                    13 |
+ 2024-04-15 00:00:00.000 |                    14 |
+ 2024-05-15 00:00:00.000 |                    15 |
+ 2024-05-15 03:00:00.000 |                   150 |
+ 2024-06-15 00:00:00.000 |                    16 |
+ 2024-06-15 03:00:00.000 |                   160 |
+ 2024-07-15 03:00:00.000 |                   170 |
+ 2024-08-15 03:00:00.000 |                   180 |
+ 2024-09-15 03:00:00.000 |                   190 |
+
+taos> explain verbose true select ts, total from (select _wstart ts, sum(v) total from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' interval(1s) union all select _wstart ts, sum(v) total from dev_e where _rowts >= '2024-05-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' interval(1s)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=16)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=16
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=16)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=16
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Interval on Column ts (functions=2 width=16 input_order=asc output_order=asc)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [1704038400000, 1719763199000]
+*************************** 12.row ***************************
+QUERY_PLAN:                Time Window: interval=1s offset=0a sliding=1s
+*************************** 13.row ***************************
+QUERY_PLAN:                Filter: conditions=((`u`.`ts` >= 1709222400000) AND (`u`.`ts` <= 1727711999000))
+*************************** 14.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 15.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_d (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=sma)
+*************************** 16.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 17.row ***************************
+QUERY_PLAN:                   Time Range: [1704038400000, 1719763199000]
+*************************** 18.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 19.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 20.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 21.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 22.row ***************************
+QUERY_PLAN:          -> Interval on Column ts (functions=2 width=16 input_order=asc output_order=asc)
+*************************** 23.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16
+*************************** 24.row ***************************
+QUERY_PLAN:                Time Range: [1714492800000, 1735660799000]
+*************************** 25.row ***************************
+QUERY_PLAN:                Time Window: interval=1s offset=0a sliding=1s
+*************************** 26.row ***************************
+QUERY_PLAN:                Filter: conditions=((`u`.`ts` >= 1709222400000) AND (`u`.`ts` <= 1727711999000))
+*************************** 27.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 28.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_e (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=sma)
+*************************** 29.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 30.row ***************************
+QUERY_PLAN:                   Time Range: [1714492800000, 1735660799000]
+
+taos> select ts, total from (select _wstart ts, sum(v) total from dev_d session(ts, 10d) union all select _wstart ts, sum(v) total from dev_e session(ts, 10d)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |         total         |
+==================================================
+ 2024-03-15 00:00:00.000 |                    13 |
+ 2024-03-15 03:00:00.000 |                   130 |
+ 2024-04-15 00:00:00.000 |                    14 |
+ 2024-04-15 03:00:00.000 |                   140 |
+ 2024-05-15 00:00:00.000 |                    15 |
+ 2024-05-15 03:00:00.000 |                   150 |
+ 2024-06-15 00:00:00.000 |                    16 |
+ 2024-06-15 03:00:00.000 |                   160 |
+ 2024-07-15 00:00:00.000 |                    17 |
+ 2024-07-15 03:00:00.000 |                   170 |
+ 2024-08-15 00:00:00.000 |                    18 |
+ 2024-08-15 03:00:00.000 |                   180 |
+ 2024-09-15 00:00:00.000 |                    19 |
+ 2024-09-15 03:00:00.000 |                   190 |
+
+taos> explain verbose true select ts, total from (select _wstart ts, sum(v) total from dev_d session(ts, 10d) union all select _wstart ts, sum(v) total from dev_e session(ts, 10d)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=16)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=16
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=16)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=16
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Session (functions=2 width=16)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16
+*************************** 11.row ***************************
+QUERY_PLAN:                Window: gap=864000000
+*************************** 12.row ***************************
+QUERY_PLAN:                Filter: conditions=((`u`.`ts` >= 1709222400000) AND (`u`.`ts` <= 1727711999000))
+*************************** 13.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_d (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 14.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 15.row ***************************
+QUERY_PLAN:                   Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 16.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=asc)
+*************************** 17.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 18.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 19.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 20.row ***************************
+QUERY_PLAN:          -> Session (functions=2 width=16)
+*************************** 21.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16
+*************************** 22.row ***************************
+QUERY_PLAN:                Window: gap=864000000
+*************************** 23.row ***************************
+QUERY_PLAN:                Filter: conditions=((`u`.`ts` >= 1709222400000) AND (`u`.`ts` <= 1727711999000))
+*************************** 24.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_e (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 25.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 26.row ***************************
+QUERY_PLAN:                   Time Range: [-9223372036854775808, 9223372036854775807]
+
+taos> select ts, total from (select _wstart ts, sum(v) total from dev_d count_window(3) union all select _wstart ts, sum(v) total from dev_e count_window(3)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |         total         |
+==================================================
+ 2024-04-15 00:00:00.000 |                    45 |
+ 2024-04-15 03:00:00.000 |                   450 |
+ 2024-07-15 00:00:00.000 |                    54 |
+ 2024-07-15 03:00:00.000 |                   540 |
+
+taos> explain verbose true select ts, total from (select _wstart ts, sum(v) total from dev_d count_window(3) union all select _wstart ts, sum(v) total from dev_e count_window(3)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=16)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=16
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=16)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=16
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Count (functions=2 width=16)
+*************************** 10.row ***************************
+QUERY_PLAN:                Window Count=3
+*************************** 11.row ***************************
+QUERY_PLAN:                Window Sliding=3
+*************************** 12.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_d (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 13.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:                   Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 15.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=asc)
+*************************** 16.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 17.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 18.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 19.row ***************************
+QUERY_PLAN:          -> Count (functions=2 width=16)
+*************************** 20.row ***************************
+QUERY_PLAN:                Window Count=3
+*************************** 21.row ***************************
+QUERY_PLAN:                Window Sliding=3
+*************************** 22.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_e (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 23.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 24.row ***************************
+QUERY_PLAN:                   Time Range: [-9223372036854775808, 9223372036854775807]
+
+taos> select ts, total from (select _wstart ts, sum(v) total from dev_d interval(1s) union all select _wstart ts, sum(v) total from dev_e interval(1s)) u where u.ts < '2024-03-01 00:00:00' or u.ts > '2024-09-30 23:59:59' order by ts asc;
+           ts            |         total         |
+==================================================
+ 2024-01-15 00:00:00.000 |                    11 |
+ 2024-01-15 03:00:00.000 |                   110 |
+ 2024-02-15 00:00:00.000 |                    12 |
+ 2024-02-15 03:00:00.000 |                   120 |
+ 2024-10-15 00:00:00.000 |                    20 |
+ 2024-10-15 03:00:00.000 |                   200 |
+ 2024-11-15 00:00:00.000 |                    21 |
+ 2024-11-15 03:00:00.000 |                   210 |
+ 2024-12-15 00:00:00.000 |                    22 |
+ 2024-12-15 03:00:00.000 |                   220 |
+
+taos> explain verbose true select ts, total from (select _wstart ts, sum(v) total from dev_d interval(1s) union all select _wstart ts, sum(v) total from dev_e interval(1s)) u where u.ts < '2024-03-01 00:00:00' or u.ts > '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=16)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=16
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=16)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=16
+*************************** 5.row ***************************
+QUERY_PLAN:          Filter: conditions=((`u`.`ts` < 1709222400000) OR (`u`.`ts` > 1727711999000))
+*************************** 6.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 8.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 9.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 10.row ***************************
+QUERY_PLAN:          -> Interval on Column ts (functions=2 width=16 input_order=asc output_order=asc)
+*************************** 11.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16
+*************************** 12.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 13.row ***************************
+QUERY_PLAN:                Time Window: interval=1s offset=0a sliding=1s
+*************************** 14.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 15.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_d (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=sma)
+*************************** 16.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 17.row ***************************
+QUERY_PLAN:                   Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 18.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 19.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 20.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 21.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 22.row ***************************
+QUERY_PLAN:          -> Interval on Column ts (functions=2 width=16 input_order=asc output_order=asc)
+*************************** 23.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16
+*************************** 24.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 25.row ***************************
+QUERY_PLAN:                Time Window: interval=1s offset=0a sliding=1s
+*************************** 26.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 27.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_e (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=sma)
+*************************** 28.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 29.row ***************************
+QUERY_PLAN:                   Time Range: [-9223372036854775808, 9223372036854775807]
+
+taos> select ts, v from (select _wstart ts, sum(v) v from dev_d interval(1s) union all select _rowts ts, v from dev_c) u where u.ts >= '2024-06-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |           v           |
+==================================================
+ 2024-06-01 02:00:00.000 |                   301 |
+ 2024-06-15 00:00:00.000 |                    16 |
+ 2024-07-15 00:00:00.000 |                    17 |
+ 2024-08-15 00:00:00.000 |                    18 |
+ 2024-08-15 02:00:00.000 |                   302 |
+ 2024-09-15 00:00:00.000 |                    19 |
+
+taos> explain verbose true select ts, v from (select _wstart ts, sum(v) v from dev_d interval(1s) union all select _rowts ts, v from dev_c) u where u.ts >= '2024-06-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=16)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=16
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=16)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=16
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Interval on Column ts (functions=2 width=16 input_order=asc output_order=asc)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 12.row ***************************
+QUERY_PLAN:                Time Window: interval=1s offset=0a sliding=1s
+*************************** 13.row ***************************
+QUERY_PLAN:                Filter: conditions=((`u`.`ts` >= 1717171200000) AND (`u`.`ts` <= 1727711999000))
+*************************** 14.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 15.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_d (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=sma)
+*************************** 16.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 17.row ***************************
+QUERY_PLAN:                   Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 18.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=asc)
+*************************** 19.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 20.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 21.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 22.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_c (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 23.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 24.row ***************************
+QUERY_PLAN:                Time Range: [1717171200000, 1727711999000]
+
+taos> select ts, cnt from (select _rowts ts, count(*) cnt from dev_d group by _rowts union all select _rowts ts, count(*) cnt from dev_e group by _rowts) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |          cnt          |
+==================================================
+ 2024-03-15 00:00:00.000 |                     1 |
+ 2024-03-15 03:00:00.000 |                     1 |
+ 2024-04-15 00:00:00.000 |                     1 |
+ 2024-04-15 03:00:00.000 |                     1 |
+ 2024-05-15 00:00:00.000 |                     1 |
+ 2024-05-15 03:00:00.000 |                     1 |
+ 2024-06-15 00:00:00.000 |                     1 |
+ 2024-06-15 03:00:00.000 |                     1 |
+ 2024-07-15 00:00:00.000 |                     1 |
+ 2024-07-15 03:00:00.000 |                     1 |
+ 2024-08-15 00:00:00.000 |                     1 |
+ 2024-08-15 03:00:00.000 |                     1 |
+ 2024-09-15 00:00:00.000 |                     1 |
+ 2024-09-15 03:00:00.000 |                     1 |
+
+taos> explain verbose true select ts, cnt from (select _rowts ts, count(*) cnt from dev_d group by _rowts union all select _rowts ts, count(*) cnt from dev_e group by _rowts) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=16)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=16
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=16)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=16
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> GroupAggregate (functions=1 width=16 groups=1 input_order=asc)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16 blocking=1
+*************************** 11.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 12.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_d (columns=1 width=8 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 13.row ***************************
+QUERY_PLAN:                   Output: columns=1 width=8
+*************************** 14.row ***************************
+QUERY_PLAN:                   Time Range: [1709222400000, 1727711999000]
+*************************** 15.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 16.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 17.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 18.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 19.row ***************************
+QUERY_PLAN:          -> GroupAggregate (functions=1 width=16 groups=1 input_order=asc)
+*************************** 20.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16 blocking=1
+*************************** 21.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 22.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_e (columns=1 width=8 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 23.row ***************************
+QUERY_PLAN:                   Output: columns=1 width=8
+*************************** 24.row ***************************
+QUERY_PLAN:                   Time Range: [1709222400000, 1727711999000]
+
+taos> select ts, total from (select _rowts ts, sum(v) total from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' group by _rowts union all select _rowts ts, sum(v) total from dev_e where _rowts >= '2024-05-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' group by _rowts) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |         total         |
+==================================================
+ 2024-03-15 00:00:00.000 |                    13 |
+ 2024-04-15 00:00:00.000 |                    14 |
+ 2024-05-15 00:00:00.000 |                    15 |
+ 2024-05-15 03:00:00.000 |                   150 |
+ 2024-06-15 00:00:00.000 |                    16 |
+ 2024-06-15 03:00:00.000 |                   160 |
+ 2024-07-15 03:00:00.000 |                   170 |
+ 2024-08-15 03:00:00.000 |                   180 |
+ 2024-09-15 03:00:00.000 |                   190 |
+
+taos> explain verbose true select ts, total from (select _rowts ts, sum(v) total from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' group by _rowts union all select _rowts ts, sum(v) total from dev_e where _rowts >= '2024-05-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' group by _rowts) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=16)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=16
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=16)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=16
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> GroupAggregate (functions=1 width=16 groups=1 input_order=asc)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16 blocking=1
+*************************** 11.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 12.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_d (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 13.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:                   Time Range: [1709222400000, 1719763199000]
+*************************** 15.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 16.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 17.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 18.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 19.row ***************************
+QUERY_PLAN:          -> GroupAggregate (functions=1 width=16 groups=1 input_order=asc)
+*************************** 20.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16 blocking=1
+*************************** 21.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 22.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_e (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 23.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 24.row ***************************
+QUERY_PLAN:                   Time Range: [1714492800000, 1727711999000]
+
+taos> select ts, total from (select _rowts ts, sum(v) total from dev_d group by _rowts union all select _rowts ts, sum(v) total from dev_e group by _rowts) u where u.ts < '2024-03-01 00:00:00' or u.ts > '2024-09-30 23:59:59' order by ts asc;
+           ts            |         total         |
+==================================================
+ 2024-01-15 00:00:00.000 |                    11 |
+ 2024-01-15 03:00:00.000 |                   110 |
+ 2024-02-15 00:00:00.000 |                    12 |
+ 2024-02-15 03:00:00.000 |                   120 |
+ 2024-10-15 00:00:00.000 |                    20 |
+ 2024-10-15 03:00:00.000 |                   200 |
+ 2024-11-15 00:00:00.000 |                    21 |
+ 2024-11-15 03:00:00.000 |                   210 |
+ 2024-12-15 00:00:00.000 |                    22 |
+ 2024-12-15 03:00:00.000 |                   220 |
+
+taos> explain verbose true select ts, total from (select _rowts ts, sum(v) total from dev_d group by _rowts union all select _rowts ts, sum(v) total from dev_e group by _rowts) u where u.ts < '2024-03-01 00:00:00' or u.ts > '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=16)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=16
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=16)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=16
+*************************** 5.row ***************************
+QUERY_PLAN:          Filter: conditions=((`u`.`ts` < 1709222400000) OR (`u`.`ts` > 1727711999000))
+*************************** 6.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 8.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 9.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 10.row ***************************
+QUERY_PLAN:          -> GroupAggregate (functions=1 width=16 groups=1 input_order=asc)
+*************************** 11.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16 blocking=1
+*************************** 12.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 13.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_d (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 14.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 15.row ***************************
+QUERY_PLAN:                   Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 16.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 17.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 18.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 19.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 20.row ***************************
+QUERY_PLAN:          -> GroupAggregate (functions=1 width=16 groups=1 input_order=asc)
+*************************** 21.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16 blocking=1
+*************************** 22.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 23.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_e (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 24.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 25.row ***************************
+QUERY_PLAN:                   Time Range: [-9223372036854775808, 9223372036854775807]
+
+taos> select ts, total from (select _rowts ts, sum(v) total from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' group by _rowts union all select _rowts ts, sum(v) total from dev_e where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' group by _rowts union all select _rowts ts, v total from dev_c) u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |         total         |
+==================================================
+ 2024-05-15 00:00:00.000 |                    15 |
+ 2024-05-15 03:00:00.000 |                   150 |
+ 2024-06-01 02:00:00.000 |                   301 |
+ 2024-06-15 00:00:00.000 |                    16 |
+ 2024-06-15 03:00:00.000 |                   160 |
+ 2024-07-15 03:00:00.000 |                   170 |
+ 2024-08-15 02:00:00.000 |                   302 |
+ 2024-08-15 03:00:00.000 |                   180 |
+ 2024-09-15 03:00:00.000 |                   190 |
+
+taos> explain verbose true select ts, total from (select _rowts ts, sum(v) total from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' group by _rowts union all select _rowts ts, sum(v) total from dev_e where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' group by _rowts union all select _rowts ts, v total from dev_c) u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=16)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=16
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 3:1 (width=16)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=16
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> GroupAggregate (functions=1 width=16 groups=1 input_order=asc)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16 blocking=1
+*************************** 11.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 12.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_d (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 13.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:                   Time Range: [1714492800000, 1719763199000]
+*************************** 15.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=unknown)
+*************************** 16.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 17.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 18.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 19.row ***************************
+QUERY_PLAN:          -> GroupAggregate (functions=1 width=16 groups=1 input_order=asc)
+*************************** 20.row ***************************
+QUERY_PLAN:                Output: columns=2 width=16 blocking=1
+*************************** 21.row ***************************
+QUERY_PLAN:                Merge ResBlocks: True
+*************************** 22.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_e (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 23.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 24.row ***************************
+QUERY_PLAN:                   Time Range: [1714492800000, 1727711999000]
+*************************** 25.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=16 input_order=asc)
+*************************** 26.row ***************************
+QUERY_PLAN:             Output: columns=2 width=16
+*************************** 27.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 28.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 29.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_c (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 30.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 31.row ***************************
+QUERY_PLAN:                Time Range: [1714492800000, 1727711999000]
+
+taos> select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-02-28 23:59:59' union all select _rowts ts, v from dev_b) u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-06-15 01:00:00.000 |         204 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-02-28 23:59:59' union all select _rowts ts, v from dev_b) u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [9223372036854775807, -9223372036854775808]
+*************************** 12.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 13.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 15.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Time Range: [1714492800000, 1727711999000]
+
+taos> select ts, v from (select _rowts ts, v from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_d where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') u where u.ts >= '2024-04-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-04-15 00:00:00.000 |          14 |
+ 2024-05-15 00:00:00.000 |          15 |
+ 2024-06-15 00:00:00.000 |          16 |
+ 2024-07-15 00:00:00.000 |          17 |
+ 2024-08-15 00:00:00.000 |          18 |
+ 2024-09-15 00:00:00.000 |          19 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_d where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') u where u.ts >= '2024-04-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_d (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [1711900800000, 1719763199000]
+*************************** 12.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 13.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 15.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_d (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Time Range: [1719763200000, 1727711999000]
+
+taos> select ts, v from (select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') inner_u union all select _rowts ts, v from dev_c) mid_u where mid_u.ts >= '2024-05-01 00:00:00' and mid_u.ts <= '2024-09-30 23:59:59' order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-06-01 02:00:00.000 |         301 |
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-06-15 01:00:00.000 |         204 |
+ 2024-08-15 02:00:00.000 |         302 |
+
+taos> explain verbose true select ts, v from (select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') inner_u union all select _rowts ts, v from dev_c) mid_u where mid_u.ts >= '2024-05-01 00:00:00' and mid_u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=unknown)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Data Exchange 2:1 (width=12)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:             -> Projection (columns=2 width=12 input_order=asc)
+*************************** 12.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 13.row ***************************
+QUERY_PLAN:                   Output: Ignore Group Id: true
+*************************** 14.row ***************************
+QUERY_PLAN:                   Merge ResBlocks: False
+*************************** 15.row ***************************
+QUERY_PLAN:                -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 16.row ***************************
+QUERY_PLAN:                      Output: columns=2 width=12
+*************************** 17.row ***************************
+QUERY_PLAN:                      Time Range: [1714492800000, 1719763199000]
+*************************** 18.row ***************************
+QUERY_PLAN:             -> Projection (columns=2 width=12 input_order=asc)
+*************************** 19.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 20.row ***************************
+QUERY_PLAN:                   Output: Ignore Group Id: true
+*************************** 21.row ***************************
+QUERY_PLAN:                   Merge ResBlocks: False
+*************************** 22.row ***************************
+QUERY_PLAN:                -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 23.row ***************************
+QUERY_PLAN:                      Output: columns=2 width=12
+*************************** 24.row ***************************
+QUERY_PLAN:                      Time Range: [1714492800000, 1727711999000]
+*************************** 25.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 26.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 27.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 28.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 29.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_c (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 30.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 31.row ***************************
+QUERY_PLAN:                Time Range: [1714492800000, 1727711999000]
+
+taos> select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_c union all select _rowts ts, v from dev_d where _rowts >= '2024-06-01 00:00:00' and _rowts <= '2024-09-30 23:59:59') u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc, v asc;
+           ts            |      v      |
+========================================
+ 2024-06-01 02:00:00.000 |         301 |
+ 2024-06-15 00:00:00.000 |          16 |
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-06-15 01:00:00.000 |         204 |
+ 2024-07-15 00:00:00.000 |          17 |
+ 2024-08-15 00:00:00.000 |          18 |
+ 2024-08-15 02:00:00.000 |         302 |
+ 2024-09-15 00:00:00.000 |          19 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_c union all select _rowts ts, v from dev_d where _rowts >= '2024-06-01 00:00:00' and _rowts <= '2024-09-30 23:59:59') u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc, v asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 4:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [1714492800000, 1719763199000]
+*************************** 12.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 13.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 15.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Time Range: [1714492800000, 1727711999000]
+*************************** 19.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 20.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 21.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 22.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 23.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_c (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 24.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 25.row ***************************
+QUERY_PLAN:                Time Range: [1714492800000, 1727711999000]
+*************************** 26.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 27.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 28.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 29.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 30.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_d (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 31.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 32.row ***************************
+QUERY_PLAN:                Time Range: [1717171200000, 1727711999000]
+
+taos> select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts <= '2024-06-30 23:59:59' order by ts asc;
+           ts            |      v      |
+========================================
+ 2023-07-15 01:00:00.000 |         201 |
+ 2023-12-15 01:00:00.000 |         202 |
+ 2024-01-15 00:00:00.000 |         101 |
+ 2024-03-15 00:00:00.000 |         102 |
+ 2024-03-15 01:00:00.000 |         203 |
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-06-15 01:00:00.000 |         204 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts <= '2024-06-30 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 1719763199000]
+*************************** 12.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 13.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 15.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 1719763199000]
+
+taos> select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-01 00:00:00' or u.v > 200 order by ts asc;
+           ts            |      v      |
+========================================
+ 2023-07-15 01:00:00.000 |         201 |
+ 2023-12-15 01:00:00.000 |         202 |
+ 2024-03-15 00:00:00.000 |         102 |
+ 2024-03-15 01:00:00.000 |         203 |
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-06-15 01:00:00.000 |         204 |
+ 2024-09-15 00:00:00.000 |         104 |
+ 2024-12-15 00:00:00.000 |         105 |
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-01 00:00:00' or u.v > 200 order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:          Filter: conditions=((`u`.`ts` >= 1709222400000) OR (`u`.`v` > 200))
+*************************** 6.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 8.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 9.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 10.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 11.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 12.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 13.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 15.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 16.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 17.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 18.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 19.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 9223372036854775807]
+
+taos> select ts, v from (select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) inner_u where inner_u.ts >= '2024-01-01 00:00:00' and inner_u.ts <= '2024-09-30 23:59:59') mid where mid.ts >= '2024-03-01 00:00:00' and mid.ts <= '2024-07-31 23:59:59' order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-03-15 00:00:00.000 |         102 |
+ 2024-03-15 01:00:00.000 |         203 |
+ 2024-06-15 00:00:00.000 |         103 |
+ 2024-06-15 01:00:00.000 |         204 |
+
+taos> explain verbose true select ts, v from (select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) inner_u where inner_u.ts >= '2024-01-01 00:00:00' and inner_u.ts <= '2024-09-30 23:59:59') mid where mid.ts >= '2024-03-01 00:00:00' and mid.ts <= '2024-07-31 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Projection (columns=2 width=12 input_order=unknown)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:          Output: Ignore Group Id: true
+*************************** 6.row ***************************
+QUERY_PLAN:          Merge ResBlocks: True
+*************************** 7.row ***************************
+QUERY_PLAN:       -> Data Exchange 2:1 (width=12)
+*************************** 8.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Projection (columns=2 width=12 input_order=asc)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Output: Ignore Group Id: true
+*************************** 12.row ***************************
+QUERY_PLAN:                Merge ResBlocks: False
+*************************** 13.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 14.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 15.row ***************************
+QUERY_PLAN:                   Time Range: [1709222400000, 1722441599000]
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Projection (columns=2 width=12 input_order=asc)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Output: Ignore Group Id: true
+*************************** 19.row ***************************
+QUERY_PLAN:                Merge ResBlocks: False
+*************************** 20.row ***************************
+QUERY_PLAN:             -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 21.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 22.row ***************************
+QUERY_PLAN:                   Time Range: [1709222400000, 1722441599000]
+
+taos> select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59') u where u.ts >= '2024-08-01 00:00:00' and u.ts <= '2024-12-31 23:59:59' order by ts asc;
+
+taos> explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59') u where u.ts >= '2024-08-01 00:00:00' and u.ts <= '2024-12-31 23:59:59' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Time Range: [9223372036854775807, -9223372036854775808]
+*************************** 12.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 13.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 15.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Time Range: [9223372036854775807, -9223372036854775808]
+
+taos> select ts, v from (select _rowts+3600000 ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc;
+           ts            |      v      |
+========================================
+ 2024-03-15 01:00:00.000 |         203 |
+ 2024-03-15 01:00:00.000 |         102 |
+
+taos> explain verbose true select ts, v from (select _rowts+3600000 ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Sort input_order=unknown output_order=asc  (columns=2 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Data Exchange 2:1 (width=12)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:          Filter: conditions=((`u`.`ts` >= 1710433800000) AND (`u`.`ts` <= 1718382600000))
+*************************** 6.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 7.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 8.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 9.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 10.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_a (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 11.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 12.row ***************************
+QUERY_PLAN:                Time Range: [-9223372036854775808, 9223372036854775807]
+*************************** 13.row ***************************
+QUERY_PLAN:       -> Projection (columns=2 width=12 input_order=asc)
+*************************** 14.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 15.row ***************************
+QUERY_PLAN:             Output: Ignore Group Id: true
+*************************** 16.row ***************************
+QUERY_PLAN:             Merge ResBlocks: False
+*************************** 17.row ***************************
+QUERY_PLAN:          -> Table Scan on dev_b (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 18.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 19.row ***************************
+QUERY_PLAN:                Time Range: [1710433800000, 1718382600000]
+

--- a/test/cases/09-DataQuerying/02-Filter/in/test_union_all_ts_pushdown.in
+++ b/test/cases/09-DataQuerying/02-Filter/in/test_union_all_ts_pushdown.in
@@ -187,5 +187,13 @@ explain verbose true select ts, v from (select _rowts ts, v from dev_a where _ro
 ## dev_a scan: full range (no pushdown, filter at setop) -> v=102 (_rowts=Mar15 00:00, alias=01:00 in range)
 ## dev_b scan: pushed Time Range [Mar15 00:30, Jun15 00:30] -> v=203 (_rowts=Mar15 01:00 in range)
 ## 2 rows
-select ts, v from (select _rowts+3600000 ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc;
-explain verbose true select ts, v from (select _rowts+3600000 ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc\G;
+select ts, v from (select _rowts+3600000 ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc, v asc;
+explain verbose true select ts, v from (select _rowts+3600000 ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc, v asc\G;
+
+## case42: pk column at index 1 (v, _rowts+offset ts) -- optimizer checks pkIdx=1, not index 0.
+## dev_a: v at index 0, _rowts+3600000 ts at index 1 -> pkIdx=1 is arithmetic -> no pushdown
+## dev_b: v at index 0, _rowts ts at index 1 -> pkIdx=1 is plain _rowts -> pushed
+## dev_a scan: full range, dev_b scan: pushed [Mar15 00:30, Jun15 00:30]
+## 2 rows: v=102 (dev_a _rowts=Mar15 00:00 -> alias=01:00) and v=203 (dev_b _rowts=Mar15 01:00)
+select ts, v from (select v, _rowts+3600000 ts from dev_a union all select v, _rowts ts from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc, v asc;
+explain verbose true select ts, v from (select v, _rowts+3600000 ts from dev_a union all select v, _rowts ts from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc, v asc\G;

--- a/test/cases/09-DataQuerying/02-Filter/in/test_union_all_ts_pushdown.in
+++ b/test/cases/09-DataQuerying/02-Filter/in/test_union_all_ts_pushdown.in
@@ -1,0 +1,191 @@
+use uts_adv_db;
+
+select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts < '2024-02-01 00:00:00' or u.ts > '2024-09-01 00:00:00' order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts < '2024-02-01 00:00:00' or u.ts > '2024-09-01 00:00:00' order by ts asc\G;
+
+select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59') u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-07-31 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59') u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-07-31 23:59:59' order by ts asc\G;
+
+select ts, v from (select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) inner_u union all select _rowts ts, v from dev_c) outer_u where outer_u.ts >= '2024-03-01 00:00:00' and outer_u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) inner_u union all select _rowts ts, v from dev_c) outer_u where outer_u.ts >= '2024-03-01 00:00:00' and outer_u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+select ts, total from (select _wstart ts, sum(v) total from dev_a interval(1s) union all select _wstart ts, sum(v) total from dev_b interval(1s)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, total from (select _wstart ts, sum(v) total from dev_a interval(1s) union all select _wstart ts, sum(v) total from dev_b interval(1s)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' and u.v > 102 order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' and u.v > 102 order by ts asc\G;
+
+select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-01 00:00:00' order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-01 00:00:00' order by ts asc\G;
+
+select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b union all select _rowts ts, v from dev_c) u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b union all select _rowts ts, v from dev_c) u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case21: 3 branches each with a DIFFERENT inner time range; outer WHERE clips each
+## differently so the EXPLAIN plan shows three distinct scan Time Ranges.
+## dev_a inner[Jan,Jun30] outer[Mar,Sep30] -> scan[Mar,Jun30]
+## dev_b inner[Apr,Dec31] outer[Mar,Sep30] -> scan[Apr,Sep30]
+## dev_c inner[Jul,Dec31] outer[Mar,Sep30] -> scan[Jul,Sep30]
+## 4 rows: 102 103 204 302
+select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_c where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_c where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case22: 2 branches with different inner ranges; outer is tighter than dev_a's inner
+## but dev_c inner lower bound is tighter than outer.
+## dev_a inner[Jan,Dec31] outer[Mar,Sep30] -> scan[Mar,Sep30]
+## dev_c inner[Jul,Dec31] outer[Mar,Sep30] -> scan[Jul,Sep30]
+## 4 rows: 102 103 302 104
+select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_c where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_c where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case23: 3 branches; dev_a and dev_c have inner filters, dev_b has none.
+## outer[Jun,Sep30] pushed to all three; each gets different scan range.
+## dev_a inner[May,Dec31] -> scan[Jun,Sep30]
+## dev_b no inner -> scan[Jun,Sep30]
+## dev_c inner[Jan,Aug31] -> scan[Jun,Aug31]
+## 5 rows: 301 103 204 302 104
+select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-05-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_b union all select _rowts ts, v from dev_c where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-08-31 23:59:59') u where u.ts >= '2024-06-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-05-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_b union all select _rowts ts, v from dev_c where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-08-31 23:59:59') u where u.ts >= '2024-06-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case24: INTERVAL branches each with inner _rowts filter.
+## inner _rowts filter -> pushed as scan Time Range (primary key).
+## outer WHERE on _wstart (not primary key) -> stays as Filter on Interval node.
+## dev_d inner[Jan,Jun30] scan[Jan,Jun30]; dev_e inner[May,Dec31] scan[May,Dec31].
+## outer[Mar,Sep30] filters interval output only.
+## 9 rows: 13 14 15 150 16 160 170 180 190
+select ts, total from (select _wstart ts, sum(v) total from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' interval(1s) union all select _wstart ts, sum(v) total from dev_e where _rowts >= '2024-05-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' interval(1s)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, total from (select _wstart ts, sum(v) total from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' interval(1s) union all select _wstart ts, sum(v) total from dev_e where _rowts >= '2024-05-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' interval(1s)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case25: SESSION_WINDOW branches. Rows are ~30 days apart so 10d gap makes each
+## row its own session. ts aliases _wstart -> outer WHERE NOT pushed to scan.
+## 14 rows: 7 from dev_d + 7 from dev_e, interleaved
+select ts, total from (select _wstart ts, sum(v) total from dev_d session(ts, 10d) union all select _wstart ts, sum(v) total from dev_e session(ts, 10d)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, total from (select _wstart ts, sum(v) total from dev_d session(ts, 10d) union all select _wstart ts, sum(v) total from dev_e session(ts, 10d)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case26: COUNT_WINDOW(3) branches. Each 3-row window has _wstart = first row ts.
+## dev_d windows: [Jan-Mar sum36 wstart=Jan15], [Apr-Jun sum45 wstart=Apr15],
+##                [Jul-Sep sum54 wstart=Jul15], [Oct-Dec sum63 wstart=Oct15]
+## Filter [Mar,Sep30]: Apr15(45) Jul15(54)
+## dev_e windows: [Jan-Mar 360 wstart=Jan15+3h], [Apr-Jun 450 wstart=Apr15+3h],
+##                [Jul-Sep 540 wstart=Jul15+3h], [Oct-Dec 630 wstart=Oct15+3h]
+## Filter [Mar,Sep30]: Apr15+3h(450) Jul15+3h(540)
+## 4 rows
+select ts, total from (select _wstart ts, sum(v) total from dev_d count_window(3) union all select _wstart ts, sum(v) total from dev_e count_window(3)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, total from (select _wstart ts, sum(v) total from dev_d count_window(3) union all select _wstart ts, sum(v) total from dev_e count_window(3)) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case27: INTERVAL branches with OR ts condition. OR cannot form a contiguous range
+## so the condition stays as Filter; scan Time Ranges remain full.
+## 10 rows: Jan/Feb/Oct/Nov/Dec from each of dev_d, dev_e
+select ts, total from (select _wstart ts, sum(v) total from dev_d interval(1s) union all select _wstart ts, sum(v) total from dev_e interval(1s)) u where u.ts < '2024-03-01 00:00:00' or u.ts > '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, total from (select _wstart ts, sum(v) total from dev_d interval(1s) union all select _wstart ts, sum(v) total from dev_e interval(1s)) u where u.ts < '2024-03-01 00:00:00' or u.ts > '2024-09-30 23:59:59' order by ts asc\G;
+
+## case28: mixed INTERVAL + raw scan branches.
+## dev_d branch: INTERVAL, ts=_wstart not primary key -> outer ts NOT pushed to scan.
+## dev_c branch: raw scan, ts=_rowts primary key -> outer ts IS pushed to scan.
+## dev_d [Jun,Sep] from filter: 16 17 18 19
+## dev_c scan pushed [Jun1,Sep30]: 301 302
+## 6 rows
+select ts, v from (select _wstart ts, sum(v) v from dev_d interval(1s) union all select _rowts ts, v from dev_c) u where u.ts >= '2024-06-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select _wstart ts, sum(v) v from dev_d interval(1s) union all select _rowts ts, v from dev_c) u where u.ts >= '2024-06-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case29: GROUP BY _rowts branches. _rowts is primary key so outer ts should be
+## pushed to the scan. Each row forms its own group with count=1.
+## 14 rows: 7 from dev_d + 7 from dev_e in [Mar,Sep30]
+select ts, cnt from (select _rowts ts, count(*) cnt from dev_d group by _rowts union all select _rowts ts, count(*) cnt from dev_e group by _rowts) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, cnt from (select _rowts ts, count(*) cnt from dev_d group by _rowts union all select _rowts ts, count(*) cnt from dev_e group by _rowts) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case30: GROUP BY _rowts with different inner ranges per branch.
+## dev_d inner[Jan,Jun30] -> scan intersected; dev_e inner[May,Dec31] -> scan intersected.
+## dev_d in [Mar,Jun]: 4 rows; dev_e in [May,Sep]: 5 rows
+## 9 rows
+select ts, total from (select _rowts ts, sum(v) total from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' group by _rowts union all select _rowts ts, sum(v) total from dev_e where _rowts >= '2024-05-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' group by _rowts) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, total from (select _rowts ts, sum(v) total from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' group by _rowts union all select _rowts ts, sum(v) total from dev_e where _rowts >= '2024-05-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' group by _rowts) u where u.ts >= '2024-03-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case31: GROUP BY _rowts with OR condition (not pushed).
+## 10 rows: Jan/Feb/Oct/Nov/Dec from dev_d + dev_e
+select ts, total from (select _rowts ts, sum(v) total from dev_d group by _rowts union all select _rowts ts, sum(v) total from dev_e group by _rowts) u where u.ts < '2024-03-01 00:00:00' or u.ts > '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, total from (select _rowts ts, sum(v) total from dev_d group by _rowts union all select _rowts ts, sum(v) total from dev_e group by _rowts) u where u.ts < '2024-03-01 00:00:00' or u.ts > '2024-09-30 23:59:59' order by ts asc\G;
+
+## case32: GROUP BY, 3 branches mixed (two with inner ranges, one raw).
+## dev_d inner[Jan,Jun30] -> intersect [May,Sep30] = [May,Jun30]: 2 rows
+## dev_e inner[Apr,Dec31] -> intersect [May,Sep30] = [May,Sep30]: 5 rows
+## dev_c raw -> scan [May,Sep30]: 301(Jun01) 302(Aug15)
+## 9 rows
+select ts, total from (select _rowts ts, sum(v) total from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' group by _rowts union all select _rowts ts, sum(v) total from dev_e where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' group by _rowts union all select _rowts ts, v total from dev_c) u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, total from (select _rowts ts, sum(v) total from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' group by _rowts union all select _rowts ts, sum(v) total from dev_e where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' group by _rowts union all select _rowts ts, v total from dev_c) u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case33: one branch inner range completely disjoint from outer.
+## dev_a inner[Jan,Feb28] ends before outer[May,Sep30] starts -> impossible intersection.
+## dev_a scan gets Time Range [TSKEY_MAX,TSKEY_MIN] -> 0 rows from dev_a.
+## dev_b (no inner) scan gets outer [May,Sep30] -> only 2024-06-15+1h(204) qualifies.
+## 1 row
+select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-02-28 23:59:59' union all select _rowts ts, v from dev_b) u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-02-28 23:59:59' union all select _rowts ts, v from dev_b) u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case34: same table used twice as self-union with different inner ranges.
+## branch1: dev_d inner[Jan,Jun30] intersect outer[Apr,Sep30] = [Apr,Jun30] -> Apr15(14),May15(15),Jun15(16)
+## branch2: dev_d inner[Jul,Dec31] intersect outer[Apr,Sep30] = [Jul,Sep30] -> Jul15(17),Aug15(18),Sep15(19)
+## plan shows two separate scan nodes for dev_d with different Time Ranges.
+## 6 rows
+select ts, v from (select _rowts ts, v from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_d where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') u where u.ts >= '2024-04-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_d where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_d where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') u where u.ts >= '2024-04-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case35: 3-level deep nested UNION ALL with inner conditions at innermost level.
+## inner_u: dev_a inner[Jan,Jun30] union dev_b inner[Apr,Dec31]
+## mid_u: inner_u union dev_c (no inner)
+## outer WHERE[May,Sep30] must propagate through 3 levels to each scan.
+## dev_a: [Jan,Jun30] intersect [May,Sep30]=[May,Jun30] -> Jun15(103)
+## dev_b: [Apr,Dec31] intersect [May,Sep30]=[May,Sep30] -> Jun15+1h(204)
+## dev_c: raw -> scan[May,Sep30] -> Jun01+2h(301),Aug15+2h(302)
+## 4 rows
+select ts, v from (select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') inner_u union all select _rowts ts, v from dev_c) mid_u where mid_u.ts >= '2024-05-01 00:00:00' and mid_u.ts <= '2024-09-30 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59') inner_u union all select _rowts ts, v from dev_c) mid_u where mid_u.ts >= '2024-05-01 00:00:00' and mid_u.ts <= '2024-09-30 23:59:59' order by ts asc\G;
+
+## case36: 4-branch UNION ALL each with different inner ranges -> 4 distinct scan Time Ranges.
+## dev_a inner[Jan,Jun30] intersect outer[May,Sep30]=[May,Jun30] -> Jun15(103)
+## dev_b inner[Apr,Dec31] intersect outer[May,Sep30]=[May,Sep30] -> Jun15+1h(204)
+## dev_c raw -> scan[May,Sep30] -> Jun01+2h(301),Aug15+2h(302)
+## dev_d inner[Jun01,Sep30] intersect outer[May,Sep30]=[Jun01,Sep30] -> Jun15(16),Jul15(17),Aug15(18),Sep15(19)
+## 8 rows (ORDER BY ts ASC, v ASC to break ties at same ts)
+select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_c union all select _rowts ts, v from dev_d where _rowts >= '2024-06-01 00:00:00' and _rowts <= '2024-09-30 23:59:59') u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc, v asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-04-01 00:00:00' and _rowts <= '2024-12-31 23:59:59' union all select _rowts ts, v from dev_c union all select _rowts ts, v from dev_d where _rowts >= '2024-06-01 00:00:00' and _rowts <= '2024-09-30 23:59:59') u where u.ts >= '2024-05-01 00:00:00' and u.ts <= '2024-09-30 23:59:59' order by ts asc, v asc\G;
+
+## case37: one-sided upper bound (ts <= only, no lower bound).
+## outer WHERE ts <= '2024-06-30' pushed as upper-only scan range.
+## dev_a: Jan15(101),Mar15(102),Jun15(103) -- 3 rows
+## dev_b: all 4 rows (201-204) are <= Jun30 2024 -- 4 rows
+## 7 rows
+select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts <= '2024-06-30 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts <= '2024-06-30 23:59:59' order by ts asc\G;
+
+## case38: OR with non-ts condition prevents all pushdown.
+## WHERE ts >= Mar OR v > 200 -- cannot push because OR connects ts with non-ts predicate.
+## plan shows Filter node at exchange; both scans keep full Time Range.
+## dev_a: ts>=Mar(102,103,104,105) OR v>200(none) -> 4 rows
+## dev_b: all 4 rows satisfy v>200 -> 4 rows
+## 8 rows
+select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-01 00:00:00' or u.v > 200 order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-01 00:00:00' or u.v > 200 order by ts asc\G;
+
+## case39: two-level WHERE wrapping UNION ALL compounds the pushdown.
+## inner_u WHERE[Jan,Sep30] AND outer WHERE[Mar,Jul31] -> scan gets intersection [Mar,Jul31].
+## dev_a in [Mar,Jul31]: Mar15(102),Jun15(103) -- 2 rows
+## dev_b in [Mar,Jul31]: Mar15+1h(203),Jun15+1h(204) -- 2 rows
+## 4 rows
+select ts, v from (select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) inner_u where inner_u.ts >= '2024-01-01 00:00:00' and inner_u.ts <= '2024-09-30 23:59:59') mid where mid.ts >= '2024-03-01 00:00:00' and mid.ts <= '2024-07-31 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select ts, v from (select _rowts ts, v from dev_a union all select _rowts ts, v from dev_b) inner_u where inner_u.ts >= '2024-01-01 00:00:00' and inner_u.ts <= '2024-09-30 23:59:59') mid where mid.ts >= '2024-03-01 00:00:00' and mid.ts <= '2024-07-31 23:59:59' order by ts asc\G;
+
+## case40: all branches disjoint from outer range -> 0 total rows.
+## dev_a inner[Jan,Jun30] and dev_b inner[Jan,Jun30] both end before outer[Aug,Dec31] starts.
+## both scans get impossible Time Range [TSKEY_MAX, TSKEY_MIN] -> 0 rows each.
+## 0 rows
+select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59') u where u.ts >= '2024-08-01 00:00:00' and u.ts <= '2024-12-31 23:59:59' order by ts asc;
+explain verbose true select ts, v from (select _rowts ts, v from dev_a where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59' union all select _rowts ts, v from dev_b where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-06-30 23:59:59') u where u.ts >= '2024-08-01 00:00:00' and u.ts <= '2024-12-31 23:59:59' order by ts asc\G;
+
+## case41: one branch uses _rowts+3600000 alias -> that branch skipped from pushdown.
+## dev_a projects _rowts+3600000 as ts; outer WHERE ts in [Mar15 00:30, Jun15 00:30].
+## dev_a scan: full range (no pushdown, filter at setop) -> v=102 (_rowts=Mar15 00:00, alias=01:00 in range)
+## dev_b scan: pushed Time Range [Mar15 00:30, Jun15 00:30] -> v=203 (_rowts=Mar15 01:00 in range)
+## 2 rows
+select ts, v from (select _rowts+3600000 ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc;
+explain verbose true select ts, v from (select _rowts+3600000 ts, v from dev_a union all select _rowts ts, v from dev_b) u where u.ts >= '2024-03-15 00:30:00' and u.ts <= '2024-06-15 00:30:00' order by ts asc\G;

--- a/test/cases/09-DataQuerying/02-Filter/test_filter_timestamp.py
+++ b/test/cases/09-DataQuerying/02-Filter/test_filter_timestamp.py
@@ -1,4 +1,4 @@
-from new_test_framework.utils import tdLog, tdSql, tdStream, sc, clusterComCheck
+from new_test_framework.utils import tdLog, tdSql, tdStream, sc, clusterComCheck, tdCom, etool
 
 
 class TestFilterTimestamp:
@@ -43,6 +43,7 @@ class TestFilterTimestamp:
         self.do_ts_range()
         tdStream.dropAllStreamsAndDbs()
         self.do_union_all_ts_pushdown()
+        self.do_union_all_ts_pushdown_advanced()
 
     def TableTime(self):
         dbPrefix = "m_tt_db"
@@ -1941,5 +1942,89 @@ class TestFilterTimestamp:
         )
         tdSql.checkRows(1)
         tdSql.checkData(0, 1, 102)   # 2024-03-15 00:00
+
+        tdSql.execute(f"drop database if exists {db}")
+    def do_union_all_ts_pushdown_advanced(self):
+        """Advanced UNION ALL timestamp push-down scenarios compared via .in/.ans files.
+
+        Cases 14-20: basic pushdown, OR condition, nested UNION ALL, INTERVAL,
+          mixed AND, single-sided bound, 3-branch.
+
+        Cases 21-23: multiple branches each with a DIFFERENT inner time range so the
+          plan shows distinct scan Time Ranges per branch.
+
+        Cases 24-28: window function branches (INTERVAL with inner filter, SESSION,
+          COUNT_WINDOW, INTERVAL OR not-pushed, mixed INTERVAL+raw).
+
+        Cases 29-32: GROUP BY _rowts branches (pushdown through aggregation).
+        """
+        db = "uts_adv_db"
+        tdSql.execute(f"drop database if exists {db}")
+        tdSql.execute(f"create database {db} precision 'ms'")
+        tdSql.execute(f"use {db}")
+
+        for tbl in ("dev_a", "dev_b", "dev_c", "dev_d", "dev_e"):
+            tdSql.execute(f"create table {tbl} (ts timestamp, v int)")
+
+        # dev_a: 5 sparse rows across 2024
+        tdSql.execute(
+            "insert into dev_a values"
+            " ('2024-01-15 00:00:00',101)"
+            " ('2024-03-15 00:00:00',102)"
+            " ('2024-06-15 00:00:00',103)"
+            " ('2024-09-15 00:00:00',104)"
+            " ('2024-12-15 00:00:00',105)"
+        )
+        # dev_b: 4 rows spanning late-2023 to mid-2024, +1 h offset
+        tdSql.execute(
+            "insert into dev_b values"
+            " ('2023-07-15 01:00:00',201)"
+            " ('2023-12-15 01:00:00',202)"
+            " ('2024-03-15 01:00:00',203)"
+            " ('2024-06-15 01:00:00',204)"
+        )
+        # dev_c: 3 rows in 2024, +2 h offset
+        tdSql.execute(
+            "insert into dev_c values"
+            " ('2024-06-01 02:00:00',301)"
+            " ('2024-08-15 02:00:00',302)"
+            " ('2024-11-15 02:00:00',303)"
+        )
+        # dev_d: 12 monthly rows in 2024 (for window / GROUP BY tests)
+        tdSql.execute(
+            "insert into dev_d values"
+            " ('2024-01-15 00:00:00',11)"
+            " ('2024-02-15 00:00:00',12)"
+            " ('2024-03-15 00:00:00',13)"
+            " ('2024-04-15 00:00:00',14)"
+            " ('2024-05-15 00:00:00',15)"
+            " ('2024-06-15 00:00:00',16)"
+            " ('2024-07-15 00:00:00',17)"
+            " ('2024-08-15 00:00:00',18)"
+            " ('2024-09-15 00:00:00',19)"
+            " ('2024-10-15 00:00:00',20)"
+            " ('2024-11-15 00:00:00',21)"
+            " ('2024-12-15 00:00:00',22)"
+        )
+        # dev_e: 12 monthly rows in 2024, +3 h offset (parallel to dev_d)
+        tdSql.execute(
+            "insert into dev_e values"
+            " ('2024-01-15 03:00:00',110)"
+            " ('2024-02-15 03:00:00',120)"
+            " ('2024-03-15 03:00:00',130)"
+            " ('2024-04-15 03:00:00',140)"
+            " ('2024-05-15 03:00:00',150)"
+            " ('2024-06-15 03:00:00',160)"
+            " ('2024-07-15 03:00:00',170)"
+            " ('2024-08-15 03:00:00',180)"
+            " ('2024-09-15 03:00:00',190)"
+            " ('2024-10-15 03:00:00',200)"
+            " ('2024-11-15 03:00:00',210)"
+            " ('2024-12-15 03:00:00',220)"
+        )
+
+        sqlFile = etool.curFile(__file__, "in/test_union_all_ts_pushdown.in")
+        ansFile = etool.curFile(__file__, "ans/test_union_all_ts_pushdown.ans")
+        tdCom.compare_testcase_result(sqlFile, ansFile, "test_union_all_ts_pushdown_advanced")
 
         tdSql.execute(f"drop database if exists {db}")

--- a/test/cases/09-DataQuerying/02-Filter/test_filter_timestamp.py
+++ b/test/cases/09-DataQuerying/02-Filter/test_filter_timestamp.py
@@ -41,6 +41,8 @@ class TestFilterTimestamp:
         self.MetricsTime()
         tdStream.dropAllStreamsAndDbs()
         self.do_ts_range()
+        tdStream.dropAllStreamsAndDbs()
+        self.do_union_all_ts_pushdown()
 
     def TableTime(self):
         dbPrefix = "m_tt_db"
@@ -1566,3 +1568,378 @@ class TestFilterTimestamp:
 	 
         tdSql.query('select count(*) from stb1 where ts > 1636592400000 + 3s')
         tdSql.checkData(0, 0, 6)
+
+    def do_union_all_ts_pushdown(self):
+        """Verify that an outer WHERE timestamp range is pushed through UNION ALL
+        into each child scan so the effective scan range becomes the intersection
+        of the inner and outer time ranges.  Result sets must be identical to a
+        naive (unpushed) scan.
+
+        Data layout
+        -----------
+        dev_a  "bind period" 2024-01-01 ~ 2024-12-31:
+            2024-01-15 00:00:00  v=101
+            2024-03-15 00:00:00  v=102   <- in outer [2024-03-01, 2024-09-30]
+            2024-06-15 00:00:00  v=103   <- in outer
+            2024-09-15 00:00:00  v=104   <- in outer
+            2024-12-15 00:00:00  v=105
+
+        dev_b  "bind period" 2023-06-01 ~ 2024-06-30 (timestamps +1 h to avoid collisions):
+            2023-07-15 01:00:00  v=201
+            2023-12-15 01:00:00  v=202
+            2024-03-15 01:00:00  v=203   <- in outer
+            2024-06-15 01:00:00  v=204   <- in outer
+
+        dev_c  "bind period" 2024-06-01 ~ 2025-01-31 (timestamps +2 h):
+            2024-06-01 02:00:00  v=301   <- in outer
+            2024-08-15 02:00:00  v=302   <- in outer
+            2024-11-15 02:00:00  v=303
+        """
+
+        db = "uts_push_db"
+        tdSql.execute(f"drop database if exists {db}")
+        tdSql.execute(f"create database {db} precision 'ms'")
+        tdSql.execute(f"use {db}")
+
+        tdSql.execute("create table dev_a (ts timestamp, v int)")
+        tdSql.execute("create table dev_b (ts timestamp, v int)")
+        tdSql.execute("create table dev_c (ts timestamp, v int)")
+
+        # dev_a: bind period 2024-01-01 ~ 2024-12-31
+        tdSql.execute(
+            "insert into dev_a values"
+            " ('2024-01-15 00:00:00', 101)"
+            " ('2024-03-15 00:00:00', 102)"
+            " ('2024-06-15 00:00:00', 103)"
+            " ('2024-09-15 00:00:00', 104)"
+            " ('2024-12-15 00:00:00', 105)"
+        )
+
+        # dev_b: bind period 2023-06-01 ~ 2024-06-30 (offset +1 h)
+        tdSql.execute(
+            "insert into dev_b values"
+            " ('2023-07-15 01:00:00', 201)"
+            " ('2023-12-15 01:00:00', 202)"
+            " ('2024-03-15 01:00:00', 203)"
+            " ('2024-06-15 01:00:00', 204)"
+        )
+
+        # dev_c: bind period 2024-06-01 ~ 2025-01-31 (offset +2 h)
+        tdSql.execute(
+            "insert into dev_c values"
+            " ('2024-06-01 02:00:00', 301)"
+            " ('2024-08-15 02:00:00', 302)"
+            " ('2024-11-15 02:00:00', 303)"
+        )
+
+        # ------------------------------------------------------------------
+        # Case 1: 2-branch UNION ALL, outer range partially overlaps both
+        # inner bind periods.
+        # Expected rows in outer [2024-03-01, 2024-09-30] order by ts asc:
+        #   2024-03-15 00:00 v=102, 2024-03-15 01:00 v=203,
+        #   2024-06-15 00:00 v=103, 2024-06-15 01:00 v=204,
+        #   2024-09-15 00:00 v=104    ->  total 5 rows
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 1: partial overlap, 2 branches")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            "  where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59'"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            "  where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59'"
+            ") where ts >= '2024-03-01 00:00:00' and ts <= '2024-09-30 23:59:59'"
+            " order by ts asc"
+        )
+        tdSql.checkRows(5)
+        tdSql.checkData(0, 1, 102)
+        tdSql.checkData(1, 1, 203)
+        tdSql.checkData(2, 1, 103)
+        tdSql.checkData(3, 1, 204)
+        tdSql.checkData(4, 1, 104)
+
+        # ------------------------------------------------------------------
+        # Case 2: same outer range + ORDER BY ts DESC LIMIT 2 — LIMIT must
+        # not break result correctness.
+        # Top 2 rows DESC: 2024-09-15 00:00 v=104, 2024-06-15 01:00 v=204
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 2: ORDER BY ts DESC LIMIT 2")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            "  where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59'"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            "  where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59'"
+            ") where ts >= '2024-03-01 00:00:00' and ts <= '2024-09-30 23:59:59'"
+            " order by ts desc limit 2"
+        )
+        tdSql.checkRows(2)
+        tdSql.checkData(0, 1, 104)   # 2024-09-15 00:00:00
+        tdSql.checkData(1, 1, 204)   # 2024-06-15 01:00:00
+
+        # ------------------------------------------------------------------
+        # Case 3: No intersection — outer range entirely after both inner
+        # bind periods → 0 rows.
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 3: outer range has no intersection with inner")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            "  where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59'"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            "  where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59'"
+            ") where ts >= '2025-01-01 00:00:00' and ts <= '2025-12-31 23:59:59'"
+        )
+        tdSql.checkRows(0)
+
+        # ------------------------------------------------------------------
+        # Case 4: Outer range fully contains both inner bind periods → all
+        # 9 rows (5 from dev_a, 4 from dev_b) pass.
+        # ASC order: 201 202 101 102 203 103 204 104 105
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 4: outer range fully contains inner")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            "  where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59'"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            "  where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59'"
+            ") where ts >= '2020-01-01 00:00:00' and ts <= '2030-12-31 23:59:59'"
+            " order by ts asc"
+        )
+        tdSql.checkRows(9)
+        tdSql.checkData(0, 1, 201)   # 2023-07-15 01:00 — earliest
+        tdSql.checkData(8, 1, 105)   # 2024-12-15 00:00 — latest
+
+        # ------------------------------------------------------------------
+        # Case 5: 3-branch UNION ALL (a ∪ b ∪ c), outer [2024-03-01, 2024-09-30]
+        # dev_a ∩ outer: 102 103 104 (3)
+        # dev_b ∩ outer: 203 204 (2)
+        # dev_c ∩ outer: 301 302 (2)   [dev_c bind starts 2024-06-01]
+        # ASC order: 102 203 301 103 204 302 104  → 7 rows
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 5: 3-branch UNION ALL")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            "  where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59'"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            "  where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59'"
+            " union all"
+            " select _rowts ts, v from dev_c"
+            "  where _rowts >= '2024-06-01 00:00:00' and _rowts <= '2025-01-31 23:59:59'"
+            ") where ts >= '2024-03-01 00:00:00' and ts <= '2024-09-30 23:59:59'"
+            " order by ts asc"
+        )
+        tdSql.checkRows(7)
+        tdSql.checkData(0, 1, 102)   # 2024-03-15 00:00
+        tdSql.checkData(6, 1, 104)   # 2024-09-15 00:00
+
+        # ------------------------------------------------------------------
+        # Case 6: No inner ts condition — outer filter works without help
+        # from inner predicates.
+        # dev_a rows in outer [2024-03-01, 2024-09-30]: 102 103 104 (3)
+        # dev_b rows in outer:                           203 204 (2)  → 5 rows
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 6: no inner ts condition")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            ") where ts >= '2024-03-01 00:00:00' and ts <= '2024-09-30 23:59:59'"
+            " order by ts asc"
+        )
+        tdSql.checkRows(5)
+        tdSql.checkData(0, 1, 102)
+        tdSql.checkData(4, 1, 104)
+
+        # ------------------------------------------------------------------
+        # Case 7: Result consistency — verify that adding a wide inner ts
+        # filter (which fully contains the outer range) does not change the
+        # result vs having no inner filter at all.
+        # Both queries should return the same 5 rows.
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 7: result consistency with/without wide inner filter")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            "  where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59'"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            "  where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59'"
+            ") where ts >= '2024-03-01 00:00:00' and ts <= '2024-09-30 23:59:59'"
+            " order by ts asc"
+        )
+        # dev_b inner [2024-01-01,2024-12-31]: 203, 204 pass; 201, 202 filtered out
+        tdSql.checkRows(5)
+
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            ") where ts >= '2024-03-01 00:00:00' and ts <= '2024-09-30 23:59:59'"
+            " order by ts asc"
+        )
+        tdSql.checkRows(5)
+
+        # ------------------------------------------------------------------
+        # Case 8: One-sided outer bound (lower bound only, no upper bound).
+        # dev_a ∩ [2024-03-01, +∞) ∩ [2024-01-01, 2024-12-31]:
+        #   102 103 104 105 → 4 rows
+        # dev_b ∩ [2024-03-01, +∞) ∩ [2023-06-01, 2024-06-30]:
+        #   203 204 → 2 rows   → total 6 rows
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 8: one-sided outer range (lower bound only)")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            "  where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59'"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            "  where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59'"
+            ") where ts >= '2024-03-01 00:00:00'"
+            " order by ts asc"
+        )
+        tdSql.checkRows(6)
+        tdSql.checkData(0, 1, 102)   # 2024-03-15 00:00
+        tdSql.checkData(5, 1, 105)   # 2024-12-15 00:00
+
+        # ------------------------------------------------------------------
+        # Case 9: Partial inner overlap on only one branch.
+        # dev_a bind period starts AFTER outer range start, so outer range
+        # is clipped from the front by dev_b only.
+        # inner dev_a: 2024-07-01 ~ 2024-12-31
+        # inner dev_b: 2023-06-01 ~ 2024-06-30
+        # outer:       2024-03-01 ~ 2024-09-30
+        # dev_a ∩: [2024-07-01, 2024-09-30] → rows: 2024-09-15 v=104 (1 row)
+        # dev_b ∩: [2024-03-01, 2024-06-30] → rows: 203 204 (2 rows) → total 3
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 9: asymmetric inner ranges")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            "  where _rowts >= '2024-07-01 00:00:00' and _rowts <= '2024-12-31 23:59:59'"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            "  where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59'"
+            ") where ts >= '2024-03-01 00:00:00' and ts <= '2024-09-30 23:59:59'"
+            " order by ts asc"
+        )
+        tdSql.checkRows(3)
+        tdSql.checkData(0, 1, 203)   # 2024-03-15 01:00
+        tdSql.checkData(1, 1, 204)   # 2024-06-15 01:00
+        tdSql.checkData(2, 1, 104)   # 2024-09-15 00:00
+
+        # ------------------------------------------------------------------
+        # Case 10: Exact boundary match — outer start equals inner start,
+        # outer end equals inner end.  All rows in inner range pass.
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 10: exact boundary match")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            "  where _rowts >= '2024-01-15 00:00:00' and _rowts <= '2024-12-15 00:00:00'"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            "  where _rowts >= '2024-03-15 01:00:00' and _rowts <= '2024-06-15 01:00:00'"
+            ") where ts >= '2024-01-15 00:00:00' and ts <= '2024-12-15 00:00:00'"
+            " order by ts asc"
+        )
+        # dev_a: all 5 rows are within inner AND outer (same boundary) → 5 rows
+        # dev_b: 203, 204 are within inner [03-15, 06-15] AND outer [01-15, 12-15] → 2 rows
+        # total: 7 rows
+        tdSql.checkRows(7)
+
+        # ------------------------------------------------------------------
+        # Case 11 (Issue 3 coverage): single-table subquery with inner LIMIT,
+        # outer WHERE must be applied AFTER the inner LIMIT, not pushed into
+        # the scan before LIMIT boundary.
+        #
+        # dev_a rows in ascending ts order: 101(Jan), 102(Mar), 103(Jun),
+        #   104(Sep), 105(Dec)
+        # LIMIT 3 takes the first 3: 101, 102, 103
+        # outer WHERE ts >= '2024-05-01': only 103 passes
+        # Expected: 1 row, v=103
+        # If the optimizer wrongly pushes WHERE before LIMIT, the scan returns
+        # 103, 104, 105 (>= May) and LIMIT 3 takes all 3 → 3 rows (BUG).
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 11: inner LIMIT + outer WHERE semantics")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a order by ts asc limit 3"
+            ") where ts >= '2024-05-01 00:00:00' and ts <= '2024-12-31 23:59:59'"
+            " order by ts"
+        )
+        tdSql.checkRows(1)
+        tdSql.checkData(0, 1, 103)
+
+        # ------------------------------------------------------------------
+        # Case 12 (Issue 2 coverage): UNION ALL with a setop-level LIMIT.
+        # The outer WHERE condition must be PRESERVED on the setop project
+        # (not moved away) so it is applied correctly after LIMIT.
+        # With LIMIT 100 (larger than total rows), all 9 rows pass the LIMIT,
+        # and the outer WHERE filters down to 5 rows — confirming the outer
+        # filter was not lost during optimization.
+        #
+        # inner dev_a ∩ inner filter: 5 rows (101–105)
+        # inner dev_b ∩ inner filter: 4 rows (201–204)
+        # UNION ALL LIMIT 100: all 9 rows
+        # outer WHERE [2024-03-01, 2024-09-30]: 102, 203, 103, 204, 104 → 5 rows
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 12: UNION ALL with setop LIMIT + outer WHERE")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            "  where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59'"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            "  where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59'"
+            " limit 100"
+            ") where ts >= '2024-03-01 00:00:00' and ts <= '2024-09-30 23:59:59'"
+            " order by ts asc"
+        )
+        tdSql.checkRows(5)
+        tdSql.checkData(0, 1, 102)   # 2024-03-15 00:00
+        tdSql.checkData(1, 1, 203)   # 2024-03-15 01:00
+        tdSql.checkData(2, 1, 103)   # 2024-06-15 00:00
+        tdSql.checkData(3, 1, 204)   # 2024-06-15 01:00
+        tdSql.checkData(4, 1, 104)   # 2024-09-15 00:00
+
+        # ------------------------------------------------------------------
+        # Case 13 (truncating LIMIT): UNION ALL with a setop-level LIMIT that
+        # actually truncates the result set.  The outer WHERE must be applied
+        # AFTER the LIMIT; it must NOT be pushed into children before LIMIT.
+        #
+        # UNION ALL dev_a + dev_b (inner filters as before), ORDER BY ts ASC:
+        #   201(2023-07), 202(2023-12), 101(2024-01), 102(2024-03),
+        #   203(2024-03), 103(2024-06), 204(2024-06), 104(2024-09), 105(2024-12)
+        # LIMIT 4: takes 201, 202, 101, 102
+        # outer WHERE [2024-03-01, 2024-09-30]: only 102 passes
+        # Expected: 1 row, v=102
+        #
+        # If the optimizer wrongly pushed outer WHERE before LIMIT:
+        #   filtered union = 102, 203, 103, 204, 104 → LIMIT 4 → 102, 203, 103, 204
+        #   outer WHERE passes all 4 → 4 rows (BUG).
+        # ------------------------------------------------------------------
+        tdLog.info("union_all_ts_pushdown case 13: setop LIMIT truncates, outer WHERE after LIMIT")
+        tdSql.query(
+            "select ts, v from ("
+            " select _rowts ts, v from dev_a"
+            "  where _rowts >= '2024-01-01 00:00:00' and _rowts <= '2024-12-31 23:59:59'"
+            " union all"
+            " select _rowts ts, v from dev_b"
+            "  where _rowts >= '2023-06-01 00:00:00' and _rowts <= '2024-06-30 23:59:59'"
+            " order by ts asc limit 4"
+            ") where ts >= '2024-03-01 00:00:00' and ts <= '2024-09-30 23:59:59'"
+            " order by ts asc"
+        )
+        tdSql.checkRows(1)
+        tdSql.checkData(0, 1, 102)   # 2024-03-15 00:00
+
+        tdSql.execute(f"drop database if exists {db}")

--- a/test/cases/09-DataQuerying/15-Explain/r/test_explain.result
+++ b/test/cases/09-DataQuerying/15-Explain/r/test_explain.result
@@ -4319,3 +4319,83 @@ QUERY_PLAN:             Time Range: [-9223372036854775808, 9223372036854775807]
 *************************** 10.row ***************************
 QUERY_PLAN:             Tag Index Filter: conditions=(`test`.`meters`.`cc` = 'a')
 
+taos> explain verbose true select ts, c2 from (select _rowts ts, c2 from d1 where _rowts >= '2022-05-16 00:01:08.000' and _rowts <= '2022-05-22 00:01:08.000' union all select _rowts ts, c2 from d2 where _rowts >= '2022-05-17 00:01:08.000' and _rowts <= '2022-05-23 00:01:08.000') where ts >= '2022-05-18 00:01:08.000' and ts <= '2022-05-21 00:01:08.000'\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Data Exchange 2:1 (width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:    -> Projection (columns=2 width=12 input_order=asc)
+*************************** 4.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 5.row ***************************
+QUERY_PLAN:          Output: Ignore Group Id: true
+*************************** 6.row ***************************
+QUERY_PLAN:          Merge ResBlocks: False
+*************************** 7.row ***************************
+QUERY_PLAN:       -> Table Scan on d1 (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 8.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 9.row ***************************
+QUERY_PLAN:             Time Range: [1652803268000, 1653062468000]
+*************************** 10.row ***************************
+QUERY_PLAN:    -> Projection (columns=2 width=12 input_order=asc)
+*************************** 11.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 12.row ***************************
+QUERY_PLAN:          Output: Ignore Group Id: true
+*************************** 13.row ***************************
+QUERY_PLAN:          Merge ResBlocks: False
+*************************** 14.row ***************************
+QUERY_PLAN:       -> Table Scan on d2 (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 15.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 16.row ***************************
+QUERY_PLAN:             Time Range: [1652803268000, 1653062468000]
+
+taos> explain verbose true select ts, c2 from (select _rowts ts, c2 from d1 where _rowts >= '2022-05-16 00:01:08.000' and _rowts <= '2022-05-22 00:01:08.000' union all select _rowts ts, c2 from d2 where _rowts >= '2022-05-17 00:01:08.000' and _rowts <= '2022-05-23 00:01:08.000') where ts >= '2022-05-18 00:01:08.000' and ts <= '2022-05-21 00:01:08.000' order by ts desc limit 3\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Projection (columns=2 width=12 input_order=desc)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12 limit=3
+*************************** 3.row ***************************
+QUERY_PLAN:       Output: Ignore Group Id: true
+*************************** 4.row ***************************
+QUERY_PLAN:       Merge ResBlocks: True
+*************************** 5.row ***************************
+QUERY_PLAN:    -> Sort input_order=unknown output_order=desc  (columns=2 width=12)
+*************************** 6.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12 limit=3
+*************************** 7.row ***************************
+QUERY_PLAN:       -> Data Exchange 2:1 (width=12)
+*************************** 8.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 9.row ***************************
+QUERY_PLAN:          -> Projection (columns=2 width=12 input_order=asc)
+*************************** 10.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 11.row ***************************
+QUERY_PLAN:                Output: Ignore Group Id: true
+*************************** 12.row ***************************
+QUERY_PLAN:                Merge ResBlocks: False
+*************************** 13.row ***************************
+QUERY_PLAN:             -> Table Scan on d1 (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 14.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 15.row ***************************
+QUERY_PLAN:                   Time Range: [1652803268000, 1653062468000]
+*************************** 16.row ***************************
+QUERY_PLAN:          -> Projection (columns=2 width=12 input_order=asc)
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 18.row ***************************
+QUERY_PLAN:                Output: Ignore Group Id: true
+*************************** 19.row ***************************
+QUERY_PLAN:                Merge ResBlocks: False
+*************************** 20.row ***************************
+QUERY_PLAN:             -> Table Scan on d2 (columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 21.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 22.row ***************************
+QUERY_PLAN:                   Time Range: [1652803268000, 1653062468000]
+

--- a/test/cases/09-DataQuerying/15-Explain/r/test_explain_analyze.result
+++ b/test/cases/09-DataQuerying/15-Explain/r/test_explain_analyze.result
@@ -4860,3 +4860,135 @@ QUERY_PLAN:
 *************************** 19.row ***************************
 QUERY_PLAN: 
 
+taos> explain analyze verbose true select ts, c2 from (select _rowts ts, c2 from d1 where _rowts >= '2022-05-16 00:01:08.000' and _rowts <= '2022-05-22 00:01:08.000' union all select _rowts ts, c2 from d2 where _rowts >= '2022-05-17 00:01:08.000' and _rowts <= '2022-05-23 00:01:08.000') where ts >= '2022-05-18 00:01:08.000' and ts <= '2022-05-21 00:01:08.000'\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Data Exchange 2:1 ( rows=8 width=12)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12
+*************************** 3.row ***************************
+QUERY_PLAN:       Network: mode=concurrent  fetch_rows=4.0(4) 
+*************************** 4.row ***************************
+*************************** 5.row ***************************
+QUERY_PLAN:    -> Projection ( rows=4 columns=2 width=12 input_order=asc)
+*************************** 6.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 7.row ***************************
+QUERY_PLAN:          Output: Ignore Group Id: true
+*************************** 8.row ***************************
+QUERY_PLAN:          Merge ResBlocks: False
+*************************** 9.row ***************************
+*************************** 10.row ***************************
+QUERY_PLAN:       -> Table Scan on d1 ( rows=4 columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 11.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 12.row ***************************
+QUERY_PLAN:             Time Range: [1652803268000, 1653062468000]
+*************************** 13.row ***************************
+*************************** 14.row ***************************
+QUERY_PLAN:             I/O cost: total_blocks=1 file_load_blocks=0 stt_load_blocks=0 mem_load_blocks=1 sma_load_blocks=0 composed_blocks=1
+*************************** 15.row ***************************
+QUERY_PLAN:                    
+*************************** 16.row ***************************
+QUERY_PLAN:                check_rows=4
+*************************** 17.row ***************************
+QUERY_PLAN:    -> Projection ( rows=4 columns=2 width=12 input_order=asc)
+*************************** 18.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12
+*************************** 19.row ***************************
+QUERY_PLAN:          Output: Ignore Group Id: true
+*************************** 20.row ***************************
+QUERY_PLAN:          Merge ResBlocks: False
+*************************** 21.row ***************************
+*************************** 22.row ***************************
+QUERY_PLAN:       -> Table Scan on d2 ( rows=4 columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 23.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 24.row ***************************
+QUERY_PLAN:             Time Range: [1652803268000, 1653062468000]
+*************************** 25.row ***************************
+*************************** 26.row ***************************
+QUERY_PLAN:             I/O cost: total_blocks=1 file_load_blocks=0 stt_load_blocks=0 mem_load_blocks=1 sma_load_blocks=0 composed_blocks=1
+*************************** 27.row ***************************
+QUERY_PLAN:                    
+*************************** 28.row ***************************
+QUERY_PLAN:                check_rows=4
+*************************** 29.row ***************************
+QUERY_PLAN: 
+*************************** 30.row ***************************
+QUERY_PLAN: 
+
+taos> explain analyze verbose true select ts, c2 from (select _rowts ts, c2 from d1 where _rowts >= '2022-05-16 00:01:08.000' and _rowts <= '2022-05-22 00:01:08.000' union all select _rowts ts, c2 from d2 where _rowts >= '2022-05-17 00:01:08.000' and _rowts <= '2022-05-23 00:01:08.000') where ts >= '2022-05-18 00:01:08.000' and ts <= '2022-05-21 00:01:08.000' order by ts desc limit 3\G;
+*************************** 1.row ***************************
+QUERY_PLAN: -> Projection ( rows=3 columns=2 width=12 input_order=desc)
+*************************** 2.row ***************************
+QUERY_PLAN:       Output: columns=2 width=12 limit=3
+*************************** 3.row ***************************
+QUERY_PLAN:       Output: Ignore Group Id: true
+*************************** 4.row ***************************
+QUERY_PLAN:       Merge ResBlocks: True
+*************************** 5.row ***************************
+*************************** 6.row ***************************
+QUERY_PLAN:    -> Sort input_order=unknown output_order=desc  ( rows=3 columns=2 width=12)
+*************************** 7.row ***************************
+QUERY_PLAN:          Sort Key: ts 
+*************************** 8.row ***************************
+QUERY_PLAN:          Sort Method: merge sort  Buffers:1 b  loops:0
+*************************** 9.row ***************************
+QUERY_PLAN:          Output: columns=2 width=12 limit=3
+*************************** 10.row ***************************
+*************************** 11.row ***************************
+QUERY_PLAN:       -> Data Exchange 2:1 ( rows=8 width=12)
+*************************** 12.row ***************************
+QUERY_PLAN:             Output: columns=2 width=12
+*************************** 13.row ***************************
+QUERY_PLAN:             Network: mode=concurrent  fetch_rows=4.0(4) 
+*************************** 14.row ***************************
+*************************** 15.row ***************************
+QUERY_PLAN:          -> Projection ( rows=4 columns=2 width=12 input_order=asc)
+*************************** 16.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 17.row ***************************
+QUERY_PLAN:                Output: Ignore Group Id: true
+*************************** 18.row ***************************
+QUERY_PLAN:                Merge ResBlocks: False
+*************************** 19.row ***************************
+*************************** 20.row ***************************
+QUERY_PLAN:             -> Table Scan on d1 ( rows=4 columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 21.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 22.row ***************************
+QUERY_PLAN:                   Time Range: [1652803268000, 1653062468000]
+*************************** 23.row ***************************
+*************************** 24.row ***************************
+QUERY_PLAN:                   I/O cost: total_blocks=1 file_load_blocks=0 stt_load_blocks=0 mem_load_blocks=1 sma_load_blocks=0 composed_blocks=1
+*************************** 25.row ***************************
+QUERY_PLAN:                          
+*************************** 26.row ***************************
+QUERY_PLAN:                      check_rows=4
+*************************** 27.row ***************************
+QUERY_PLAN:          -> Projection ( rows=4 columns=2 width=12 input_order=asc)
+*************************** 28.row ***************************
+QUERY_PLAN:                Output: columns=2 width=12
+*************************** 29.row ***************************
+QUERY_PLAN:                Output: Ignore Group Id: true
+*************************** 30.row ***************************
+QUERY_PLAN:                Merge ResBlocks: False
+*************************** 31.row ***************************
+*************************** 32.row ***************************
+QUERY_PLAN:             -> Table Scan on d2 ( rows=4 columns=2 width=12 order=[asc|1 desc|0] mode=ts_order data_load=data)
+*************************** 33.row ***************************
+QUERY_PLAN:                   Output: columns=2 width=12
+*************************** 34.row ***************************
+QUERY_PLAN:                   Time Range: [1652803268000, 1653062468000]
+*************************** 35.row ***************************
+*************************** 36.row ***************************
+QUERY_PLAN:                   I/O cost: total_blocks=1 file_load_blocks=0 stt_load_blocks=0 mem_load_blocks=1 sma_load_blocks=0 composed_blocks=1
+*************************** 37.row ***************************
+QUERY_PLAN:                          
+*************************** 38.row ***************************
+QUERY_PLAN:                      check_rows=4
+*************************** 39.row ***************************
+QUERY_PLAN: 
+*************************** 40.row ***************************
+QUERY_PLAN: 
+

--- a/test/cases/09-DataQuerying/15-Explain/t/test_explain.sql
+++ b/test/cases/09-DataQuerying/15-Explain/t/test_explain.sql
@@ -183,3 +183,5 @@ explain verbose true select * from meters where cc = 'a' and cc = 'b'\G;
 explain verbose true select * from meters where cc = 'a' and cc != 'b'\G;
 explain verbose true select * from meters where cc = 'a' and cc2 = 'b'\G;
 explain verbose true select * from meters where cc = 'a' and cc2 != 'b'\G;
+explain verbose true select ts, c2 from (select _rowts ts, c2 from d1 where _rowts >= '2022-05-16 00:01:08.000' and _rowts <= '2022-05-22 00:01:08.000' union all select _rowts ts, c2 from d2 where _rowts >= '2022-05-17 00:01:08.000' and _rowts <= '2022-05-23 00:01:08.000') where ts >= '2022-05-18 00:01:08.000' and ts <= '2022-05-21 00:01:08.000'\G;
+explain verbose true select ts, c2 from (select _rowts ts, c2 from d1 where _rowts >= '2022-05-16 00:01:08.000' and _rowts <= '2022-05-22 00:01:08.000' union all select _rowts ts, c2 from d2 where _rowts >= '2022-05-17 00:01:08.000' and _rowts <= '2022-05-23 00:01:08.000') where ts >= '2022-05-18 00:01:08.000' and ts <= '2022-05-21 00:01:08.000' order by ts desc limit 3\G;

--- a/test/cases/09-DataQuerying/15-Explain/t/test_explain_analyze.sql
+++ b/test/cases/09-DataQuerying/15-Explain/t/test_explain_analyze.sql
@@ -98,3 +98,5 @@ explain analyze verbose true select * from meters where cc = 'a' and cc = 'b'\G;
 explain analyze verbose true select * from meters where cc = 'a' and cc != 'b'\G;
 explain analyze verbose true select * from meters where cc = 'a' and cc2 = 'b'\G;
 explain analyze verbose true select * from meters where cc = 'a' and cc2 != 'b'\G;
+explain analyze verbose true select ts, c2 from (select _rowts ts, c2 from d1 where _rowts >= '2022-05-16 00:01:08.000' and _rowts <= '2022-05-22 00:01:08.000' union all select _rowts ts, c2 from d2 where _rowts >= '2022-05-17 00:01:08.000' and _rowts <= '2022-05-23 00:01:08.000') where ts >= '2022-05-18 00:01:08.000' and ts <= '2022-05-21 00:01:08.000'\G;
+explain analyze verbose true select ts, c2 from (select _rowts ts, c2 from d1 where _rowts >= '2022-05-16 00:01:08.000' and _rowts <= '2022-05-22 00:01:08.000' union all select _rowts ts, c2 from d2 where _rowts >= '2022-05-17 00:01:08.000' and _rowts <= '2022-05-23 00:01:08.000') where ts >= '2022-05-18 00:01:08.000' and ts <= '2022-05-21 00:01:08.000' order by ts desc limit 3\G;


### PR DESCRIPTION

# Description
Optimize query performance by pushing outer WHERE timestamp conditions into each UNION ALL branch as I/O time-range hints on the scan operator, reducing data read before the merge. Full-condition correctness is preserved at the setop project node.

<!-- Please briefly describe the code changes in this pull request. -->

# Issue(s)


# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
