### PR TITLE
fix: mark reference management variables as volatile for thread safety

### DIFF
--- a/source/client/inc/clientInt.h
+++ b/source/client/inc/clientInt.h
@@ -394,8 +394,8 @@ static FORCE_INLINE SReqResultInfo* tscGetCurResInfo(TAOS_RES* res) {
 }
 
 extern SAppInfo appInfo;
-extern int32_t  clientReqRefPool;
-extern int32_t   clientConnRefPool;
+extern volatile int32_t  clientReqRefPool;
+extern volatile int32_t  clientConnRefPool;
 extern int64_t  lastClusterId;
 extern SHashObj* pTimezoneMap;
 

--- a/source/client/src/clientEnv.c
+++ b/source/client/src/clientEnv.c
@@ -64,8 +64,8 @@
 STscDbg   tscDbg = {0};
 SAppInfo  appInfo;
 int64_t   lastClusterId = 0;
-int32_t   clientReqRefPool = -1;
-int32_t   clientConnRefPool = -1;
+volatile int32_t   clientReqRefPool = -1;
+volatile int32_t   clientConnRefPool = -1;
 int32_t   clientStop = -1;
 SHashObj *pTimezoneMap = NULL;
 

--- a/source/client/src/clientTmq.c
+++ b/source/client/src/clientTmq.c
@@ -79,8 +79,8 @@ enum {
 };
 
 typedef struct {
-  tmr_h               timer;
-  int32_t             rsetId;
+  volatile tmr_h      timer;
+  volatile int32_t    rsetId;
   TdThreadMutex       lock;
 } SMqMgmt;
 

--- a/source/libs/executor/inc/executorInt.h
+++ b/source/libs/executor/inc/executorInt.h
@@ -91,7 +91,7 @@ enum {
   STREAM_RECOVER_STEP__SCAN1,
 };
 
-extern int32_t fetchObjRefPool;
+extern volatile int32_t fetchObjRefPool;
 
 typedef struct {
   char*   pData;

--- a/source/libs/executor/src/executor.c
+++ b/source/libs/executor/src/executor.c
@@ -38,7 +38,7 @@
 #include "wal.h"
 
 static TdThreadOnce initPoolOnce = PTHREAD_ONCE_INIT;
-int32_t             fetchObjRefPool = -1;
+volatile int32_t    fetchObjRefPool = -1;
 SGlobalExecInfo     gExecInfo = {0};
 
 void setTaskScalarExtraInfo(qTaskInfo_t tinfo) {

--- a/source/libs/index/inc/indexInt.h
+++ b/source/libs/index/inc/indexInt.h
@@ -40,7 +40,7 @@ extern "C" {
 #define indexTrace(...) do { if (idxDebugFlag & DEBUG_TRACE) { taosPrintLog("IDX TRACE ", DEBUG_TRACE, idxDebugFlag, __VA_ARGS__);}} while (0)
 // clang-format on
 
-extern volatile void* indexQhandle;
+extern void* indexQhandle;
 
 typedef enum { LT, LE, GT, GE, CONTAINS, EQ } RangeType;
 typedef enum { kTypeValue, kTypeDeletion } STermValueType;

--- a/source/libs/index/inc/indexInt.h
+++ b/source/libs/index/inc/indexInt.h
@@ -40,7 +40,7 @@ extern "C" {
 #define indexTrace(...) do { if (idxDebugFlag & DEBUG_TRACE) { taosPrintLog("IDX TRACE ", DEBUG_TRACE, idxDebugFlag, __VA_ARGS__);}} while (0)
 // clang-format on
 
-extern void* indexQhandle;
+extern volatile void* indexQhandle;
 
 typedef enum { LT, LE, GT, GE, CONTAINS, EQ } RangeType;
 typedef enum { kTypeValue, kTypeDeletion } STermValueType;

--- a/source/libs/index/src/index.c
+++ b/source/libs/index/src/index.c
@@ -53,8 +53,8 @@
 #define INDEX_DATA_NULL_STR   "NULL"
 #define INDEX_DATA_NULL_STR_L "null"
 
-void*   indexQhandle = NULL;
-int32_t indexRefMgt;
+volatile void*   indexQhandle = NULL;
+volatile int32_t indexRefMgt;
 
 int32_t indexThreads = 5;
 

--- a/source/libs/index/src/index.c
+++ b/source/libs/index/src/index.c
@@ -72,7 +72,7 @@ void indexEnvInit() {
 }
 void indexCleanup() {
   // refacto later
-  taosCleanUpScheduler(indexQhandle);
+  taosCleanUpScheduler((void*)indexQhandle);
   taosMemoryFreeClear(indexQhandle);
   taosCloseRef(indexRefMgt);
 }

--- a/source/libs/index/src/index.c
+++ b/source/libs/index/src/index.c
@@ -53,7 +53,7 @@
 #define INDEX_DATA_NULL_STR   "NULL"
 #define INDEX_DATA_NULL_STR_L "null"
 
-volatile void*   indexQhandle = NULL;
+void*            indexQhandle = NULL;
 volatile int32_t indexRefMgt;
 
 int32_t indexThreads = 5;

--- a/source/libs/transport/src/transComm.c
+++ b/source/libs/transport/src/transComm.c
@@ -25,10 +25,10 @@
 
 static TdThreadOnce transModuleInit = PTHREAD_ONCE_INIT;
 
-static int32_t refMgt;
-static int32_t svrRefMgt;
-static int32_t instMgt;
-static int32_t transSyncMsgMgt;
+volatile int32_t refMgt;
+volatile int32_t svrRefMgt;
+volatile int32_t instMgt;
+volatile int32_t transSyncMsgMgt;
 
 static void transDestroySyncMsg(void* msg);
 typedef struct {
@@ -1302,10 +1302,10 @@ TdThreadMutex       mutex[2];
 MultiThreadQhandle* multiQ[2] = {NULL, NULL};
 static TdThreadOnce transModuleInit = PTHREAD_ONCE_INIT;
 
-static int32_t refMgt;
-static int32_t svrRefMgt;
-static int32_t instMgt;
-static int32_t transSyncMsgMgt;
+volatile int32_t refMgt;
+volatile int32_t svrRefMgt;
+volatile int32_t instMgt;
+volatile int32_t transSyncMsgMgt;
 TdThreadMutex  mutex[2];
 
 TdThreadMutex tableMutex;

--- a/source/util/src/tref.c
+++ b/source/util/src/tref.c
@@ -48,8 +48,8 @@ typedef struct {
 static SRefSet       tsRefSetList[TSDB_REF_OBJECTS];
 static TdThreadOnce  tsRefModuleInit = PTHREAD_ONCE_INIT;
 static TdThreadMutex tsRefMutex;
-static int32_t       tsRefSetNum = 0;
-static int32_t       tsNextId = 0;
+volatile int32_t       tsRefSetNum = 0;
+volatile int32_t       tsNextId = 0;
 
 static void    taosInitRefModule(void);
 static void    taosLockList(int64_t *lockedBy);


### PR DESCRIPTION
# Description

<!-- Please briefly describe the code changes in this pull request. -->

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
