### PR TITLE
feat: add STMT/STMT2 support for external_window queries

### DIFF
--- a/source/client/src/clientStmt.c
+++ b/source/client/src/clientStmt.c
@@ -154,7 +154,7 @@ int32_t stmtSwitchStatus(STscStmt* pStmt, STMT_STATUS newStatus) {
     case STMT_EXECUTE:
       if (STMT_TYPE_QUERY == pStmt->sql.type) {
         if (STMT_STATUS_NE(ADD_BATCH) && STMT_STATUS_NE(FETCH_FIELDS) && STMT_STATUS_NE(BIND) &&
-            STMT_STATUS_NE(BIND_COL)) {
+            STMT_STATUS_NE(BIND_COL) && STMT_STATUS_NE(PREPARE)) {
           code = TSDB_CODE_TSC_STMT_API_ERROR;
         }
       } else {
@@ -1656,9 +1656,63 @@ int stmtExec(TAOS_STMT* stmt) {
     return pStmt->errCode;
   }
 
+  STMT_STATUS prevStatus = pStmt->sql.status;
+  // If the user calls execute directly after prepare (no '?' params query),
+  // we need to parse the SQL first to determine the query type.
+  if (prevStatus == STMT_PREPARE) {
+    // Ensure pRequest exists even when the statement was served from cache
+    // (needParse == false).  Without a live pRequest, launchQueryImpl would
+    // receive a NULL pointer and crash.
+    if (pStmt->exec.pRequest == NULL) {
+      STMT_ERR_RET(stmtCreateRequest(pStmt));
+    }
+    if (pStmt->bInfo.needParse) {
+      STMT_ERR_RET(stmtParseSql(pStmt));
+    }
+  }
+
   STMT_ERR_RET(stmtSwitchStatus(pStmt, STMT_EXECUTE));
 
   if (STMT_TYPE_QUERY == pStmt->sql.type) {
+    // If execute is called directly after prepare without binding params (no '?' in query),
+    // perform the full parse sequence to complete query planning.
+    if (prevStatus == STMT_PREPARE && pStmt->sql.pQuery && pStmt->sql.pQuery->pPrepareRoot) {
+      if (pStmt->sql.pQuery->placeholderNum > 0) {
+        // User has unbound '?' parameters — this is misuse.
+        STMT_ERR_RET(TSDB_CODE_TSC_STMT_API_ERROR);
+      }
+      // No placeholders: use qStmtBindParams with colIdx=-1 (loop skipped, just clones pPrepareRoot).
+      STMT_ERR_RET(qStmtBindParams(pStmt->sql.pQuery, NULL, -1, pStmt->taos->optionInfo.charsetCxt));
+
+      SParseContext ctx = {.requestId = pStmt->exec.pRequest->requestId,
+                           .acctId = pStmt->taos->acctId,
+                           .db = pStmt->exec.pRequest->pDb,
+                           .topicQuery = false,
+                           .pSql = pStmt->sql.sqlStr,
+                           .sqlLen = pStmt->sql.sqlLen,
+                           .pMsg = pStmt->exec.pRequest->msgBuf,
+                           .msgLen = ERROR_MSG_BUF_DEFAULT_SIZE,
+                           .pTransporter = pStmt->taos->pAppInfo->pTransporter,
+                           .pStmtCb = NULL,
+                           .pUser = pStmt->taos->user,
+                           .setQueryFp = setQueryRequest,
+                           .stmtBindVersion = pStmt->exec.pRequest->stmtBindVersion};
+      ctx.mgmtEpSet = getEpSet_s(&pStmt->taos->pAppInfo->mgmtEp);
+      STMT_ERR_RET(catalogGetHandle(pStmt->taos->pAppInfo->clusterId, &ctx.pCatalog));
+      STMT_ERR_RET(qStmtParseQuerySql(&ctx, pStmt->sql.pQuery, NULL));
+
+      if (pStmt->sql.pQuery->haveResultSet) {
+        STMT_ERR_RET(setResSchemaInfo(&pStmt->exec.pRequest->body.resInfo, pStmt->sql.pQuery->pResSchema,
+                                      pStmt->sql.pQuery->numOfResCols, pStmt->sql.pQuery->pResExtSchema, true));
+        // setResSchemaInfo copies schema data into resInfo->fields; pQuery still owns these pointers.
+        taosMemoryFreeClear(pStmt->sql.pQuery->pResSchema);
+        taosMemoryFreeClear(pStmt->sql.pQuery->pResExtSchema);
+        setResPrecision(&pStmt->exec.pRequest->body.resInfo, pStmt->sql.pQuery->precision);
+      }
+      TSWAP(pStmt->exec.pRequest->dbList, pStmt->sql.pQuery->pDbList);
+      TSWAP(pStmt->exec.pRequest->tableList, pStmt->sql.pQuery->pTableList);
+      TSWAP(pStmt->exec.pRequest->targetTableList, pStmt->sql.pQuery->pTargetTableList);
+    }
     launchQueryImpl(pStmt->exec.pRequest, pStmt->sql.pQuery, true, NULL);
   } else {
     if (pStmt->sql.stbInterlaceMode) {

--- a/source/client/src/clientStmt2.c
+++ b/source/client/src/clientStmt2.c
@@ -195,7 +195,7 @@ static int32_t stmtSwitchStatus(STscStmt2* pStmt, STMT_STATUS newStatus) {
     case STMT_EXECUTE:
       if (STMT_TYPE_QUERY == pStmt->sql.type) {
         if (STMT_STATUS_NE(ADD_BATCH) && STMT_STATUS_NE(FETCH_FIELDS) && STMT_STATUS_NE(BIND) &&
-            STMT_STATUS_NE(BIND_COL)) {
+            STMT_STATUS_NE(BIND_COL) && STMT_STATUS_NE(PREPARE)) {
           code = TSDB_CODE_TSC_STMT_API_ERROR;
         }
       } else {
@@ -2441,13 +2441,32 @@ int stmtExec2(TAOS_STMT2* stmt, int* affected_rows) {
   while (atomic_load_8((int8_t*)&pStmt->asyncBindParam.asyncBindNum) > 0) {
     (void)taosThreadCondWait(&pStmt->asyncBindParam.waitCond, &pStmt->asyncBindParam.mutex);
   }
+  // Capture prevStatus after waiting so we see the status after any async bind completes.
+  STMT_STATUS prevStatus = pStmt->sql.status;
   STMT_ERR_RET(taosThreadMutexUnlock(&pStmt->asyncBindParam.mutex));
 
   if (pStmt->sql.stbInterlaceMode) {
     STMT_ERR_RET(stmtAddBatch2(pStmt));
   }
 
-  STMT_ERR_RET(stmtSwitchStatus(pStmt, STMT_EXECUTE));
+  // For the prepare → execute shortcut (no bind_param calls), parse the SQL
+  // now so that sql.type is set before stmtSwitchStatus inspects it.
+  if (prevStatus == STMT_PREPARE) {
+    // Ensure pRequest exists even when the statement was served from cache
+    // (needParse == false).  Without a live pRequest, launchQueryImpl would
+    // receive a NULL pointer and crash.
+    if (pStmt->exec.pRequest == NULL) {
+      code = stmtCreateRequest(pStmt);
+      if (code != TSDB_CODE_SUCCESS) goto _return;
+    }
+    if (pStmt->bInfo.needParse) {
+      code = stmtParseSql(pStmt);
+      if (code != TSDB_CODE_SUCCESS) goto _return;
+    }
+  }
+
+  code = stmtSwitchStatus(pStmt, STMT_EXECUTE);
+  if (code != TSDB_CODE_SUCCESS) goto _return;
 
   if (STMT_TYPE_QUERY != pStmt->sql.type) {
     if (pStmt->sql.stbInterlaceMode) {
@@ -2474,6 +2493,65 @@ int stmtExec2(TAOS_STMT2* stmt, int* affected_rows) {
 
       STMT_ERR_RET(qBuildStmtOutput(pStmt->sql.pQuery, pStmt->sql.pVgHash, pStmt->exec.pBlockHash));
     }
+  }
+
+  // For the prepare→execute shortcut with no '?' params, complete the
+  // bind/translate step that is normally done inside stmtBindv2.
+  if (STMT_TYPE_QUERY == pStmt->sql.type && prevStatus == STMT_PREPARE &&
+      pStmt->sql.pQuery && pStmt->sql.pQuery->pPrepareRoot) {
+    if (pStmt->sql.pQuery->placeholderNum > 0) {
+      // User left '?' parameters unbound — this is API misuse.
+      code = TSDB_CODE_TSC_STMT_API_ERROR;
+      goto _return;
+    }
+    // No placeholders: clone pPrepareRoot → pRoot (loop inside qStmtBindParams2 is skipped).
+    code = qStmtBindParams2(pStmt->sql.pQuery, NULL, -1, pStmt->taos->optionInfo.charsetCxt);
+    if (code != TSDB_CODE_SUCCESS) goto _return;
+
+    SParseContext ctx = {.requestId = pStmt->exec.pRequest->requestId,
+                         .requestRid = pStmt->exec.pRequest->self,
+                         .acctId = pStmt->taos->acctId,
+                         .db = pStmt->exec.pRequest->pDb,
+                         .topicQuery = false,
+                         .pSql = pStmt->sql.sqlStr,
+                         .sqlLen = pStmt->sql.sqlLen,
+                         .pMsg = pStmt->exec.pRequest->msgBuf,
+                         .msgLen = ERROR_MSG_BUF_DEFAULT_SIZE,
+                         .pTransporter = pStmt->taos->pAppInfo->pTransporter,
+                         .pStmtCb = NULL,
+                         .pUser = pStmt->taos->user,
+                         .setQueryFp = setQueryRequest,
+                         .stmtBindVersion = pStmt->exec.pRequest->stmtBindVersion};
+    ctx.mgmtEpSet = getEpSet_s(&pStmt->taos->pAppInfo->mgmtEp);
+    code = catalogGetHandle(pStmt->taos->pAppInfo->clusterId, &ctx.pCatalog);
+    if (code != TSDB_CODE_SUCCESS) goto _return;
+
+    SMetaData metaData = {0};
+    code = stmtFetchMetadataForQuery(pStmt, &ctx, &metaData);
+    if (code != TSDB_CODE_SUCCESS) goto _return;
+
+    code = qStmtParseQuerySql(&ctx, pStmt->sql.pQuery, &metaData);
+    if (code == TSDB_CODE_SUCCESS) {
+      (void)memcpy(&pStmt->exec.pRequest->parseMeta, &metaData, sizeof(SMetaData));
+      (void)memset(&metaData, 0, sizeof(SMetaData));
+    } else {
+      catalogFreeMetaData(&metaData);
+      (void)memset(&metaData, 0, sizeof(SMetaData));
+      goto _return;
+    }
+
+    if (pStmt->sql.pQuery->haveResultSet) {
+      code = setResSchemaInfo(&pStmt->exec.pRequest->body.resInfo, pStmt->sql.pQuery->pResSchema,
+                              pStmt->sql.pQuery->numOfResCols, pStmt->sql.pQuery->pResExtSchema, true);
+      if (code != TSDB_CODE_SUCCESS) goto _return;
+      // setResSchemaInfo copies schema data into resInfo->fields; pQuery still owns these pointers.
+      taosMemoryFreeClear(pStmt->sql.pQuery->pResSchema);
+      taosMemoryFreeClear(pStmt->sql.pQuery->pResExtSchema);
+      setResPrecision(&pStmt->exec.pRequest->body.resInfo, pStmt->sql.pQuery->precision);
+    }
+    TSWAP(pStmt->exec.pRequest->dbList, pStmt->sql.pQuery->pDbList);
+    TSWAP(pStmt->exec.pRequest->tableList, pStmt->sql.pQuery->pTableList);
+    TSWAP(pStmt->exec.pRequest->targetTableList, pStmt->sql.pQuery->pTargetTableList);
   }
 
   pStmt->asyncResultAvailable = false;

--- a/source/libs/nodes/src/nodesCloneFuncs.c
+++ b/source/libs/nodes/src/nodesCloneFuncs.c
@@ -425,6 +425,19 @@ static int32_t anomalyWindowNodeCopy(const SAnomalyWindowNode* pSrc, SAnomalyWin
   return TSDB_CODE_SUCCESS;
 }
 
+static int32_t externalWindowNodeCopy(const SExternalWindowNode* pSrc, SExternalWindowNode* pDst) {
+  CLONE_NODE_FIELD(pCol);
+  CLONE_NODE_LIST_FIELD(pProjectionList);
+  CLONE_NODE_LIST_FIELD(pAggFuncList);
+  COPY_OBJECT_FIELD(timeRange, sizeof(STimeWindow));
+  CLONE_NODE_FIELD(pTimeRange);
+  pDst->timezone = pSrc->timezone;  // shared pointer, not owned
+  CLONE_NODE_FIELD(pSubquery);
+  CLONE_NODE_FIELD(pFill);
+  COPY_CHAR_ARRAY_FIELD(aliasName);
+  return TSDB_CODE_SUCCESS;
+}
+
 static int32_t sessionWindowNodeCopy(const SSessionWindowNode* pSrc, SSessionWindowNode* pDst) {
   CLONE_NODE_FIELD_EX(pCol, SColumnNode*);
   CLONE_NODE_FIELD_EX(pGap, SValueNode*);
@@ -1310,6 +1323,9 @@ int32_t nodesCloneNode(const SNode* pNode, SNode** ppNode) {
       break;
     case QUERY_NODE_ANOMALY_WINDOW:
       code = anomalyWindowNodeCopy((const SAnomalyWindowNode*)pNode, (SAnomalyWindowNode*)pDst);
+      break;
+    case QUERY_NODE_EXTERNAL_WINDOW:
+      code = externalWindowNodeCopy((const SExternalWindowNode*)pNode, (SExternalWindowNode*)pDst);
       break;
     case QUERY_NODE_SESSION_WINDOW:
       code = sessionWindowNodeCopy((const SSessionWindowNode*)pNode, (SSessionWindowNode*)pDst);

--- a/source/libs/nodes/src/nodesCloneFuncs.c
+++ b/source/libs/nodes/src/nodesCloneFuncs.c
@@ -431,7 +431,8 @@ static int32_t externalWindowNodeCopy(const SExternalWindowNode* pSrc, SExternal
   CLONE_NODE_LIST_FIELD(pAggFuncList);
   COPY_OBJECT_FIELD(timeRange, sizeof(STimeWindow));
   CLONE_NODE_FIELD(pTimeRange);
-  pDst->timezone = pSrc->timezone;  // shared pointer, not owned
+  // timezone is owned (freed in nodesDestroyNode); reset to NULL to avoid double-free in the clone
+  pDst->timezone = NULL;
   CLONE_NODE_FIELD(pSubquery);
   CLONE_NODE_FIELD(pFill);
   COPY_CHAR_ARRAY_FIELD(aliasName);

--- a/source/libs/nodes/src/nodesUtilFuncs.c
+++ b/source/libs/nodes/src/nodesUtilFuncs.c
@@ -2310,6 +2310,7 @@ void nodesDestroyNode(SNode* pNode) {
       nodesDestroyList(pLogicNode->pColList);
       nodesDestroyList(pLogicNode->pProjs);
       destroyExtWindowFillInfo(&pLogicNode->extFill);
+      nodesDestroyNode(pLogicNode->pSubquery);
       break;
     }
     case QUERY_NODE_LOGIC_PLAN_FILL: {

--- a/source/libs/parser/src/parTranslater.c
+++ b/source/libs/parser/src/parTranslater.c
@@ -9823,12 +9823,7 @@ static int32_t translateWindow(STranslateContext* pCxt, SSelectStmt* pSelect) {
   if (NULL == pSelect->pWindow) {
     return TSDB_CODE_SUCCESS;
   }
-  if (QUERY_NODE_EXTERNAL_WINDOW == nodeType(pSelect->pWindow)) {
-    if (pCxt->pParseCxt->stmtBindVersion > 0) {
-      return generateSyntaxErrMsgExt(&pCxt->msgBuf, TSDB_CODE_PAR_INVALID_WINDOW_PC,
-                                     "External window query can not be used in stmt query");
-    }
-  }
+
   if (pSelect->pFromTable->type == QUERY_NODE_REAL_TABLE &&
       ((SRealTableNode*)pSelect->pFromTable)->pMeta->tableType == TSDB_SYSTEM_TABLE) {
     return generateSyntaxErrMsg(&pCxt->msgBuf, TSDB_CODE_PAR_SYSTABLE_NOT_ALLOWED, "WINDOW");

--- a/source/libs/parser/src/parser.c
+++ b/source/libs/parser/src/parser.c
@@ -441,6 +441,21 @@ static int32_t analyseSemantic(SParseContext* pCxt, SQuery* pQuery, SParseMetaCa
     return TSDB_CODE_SUCCESS;
   }
 
+  // In STMT mode (pStmtCb set), defer translation for all non-INSERT queries,
+  // even when there are no '?' placeholders.  This is required for correctness:
+  // stmtParseSql() identifies the query type by checking pPrepareRoot (→ QUERY)
+  // vs pRoot (→ INSERT).  If a 0-param SELECT were translated immediately, pRoot
+  // would be non-NULL and pPrepareRoot NULL, causing stmtParseSql to wrongly
+  // classify the query as INSERT.  Deferring all non-INSERT queries (i.e. those
+  // whose root is not QUERY_NODE_VNODE_MODIFY_STMT) ensures consistent handling
+  // and allows qStmtParseQuerySql to perform the actual translation later.
+  if (TSDB_CODE_SUCCESS == code && pCxt->pStmtCb && pQuery->pRoot &&
+      nodeType(pQuery->pRoot) != QUERY_NODE_VNODE_MODIFY_STMT &&
+      nodeType(pQuery->pRoot) != QUERY_NODE_INSERT_STMT) {
+    TSWAP(pQuery->pPrepareRoot, pQuery->pRoot);
+    return TSDB_CODE_SUCCESS;
+  }
+
   if (TSDB_CODE_SUCCESS == code) {
     code = translate(pCxt, pQuery, pMetaCache);
   }

--- a/source/libs/planner/src/planLogicCreater.c
+++ b/source/libs/planner/src/planLogicCreater.c
@@ -2520,7 +2520,7 @@ static int32_t createWindowLogicNodeByExternal(SLogicPlanContext* pCxt, SExterna
     PLAN_ERR_JRET(nodesCloneNode(pFill->pValues, &pWindow->extFill.pFillValues));
   }
 
-  pWindow->pSubquery = pExternal->pSubquery;
+  PLAN_ERR_JRET(nodesCloneNode(pExternal->pSubquery, &pWindow->pSubquery));
   return createExternalWindowLogicNodeFinalize(pCxt, pSelect, pWindow, pLogicNode);
 
 _return:
@@ -2581,7 +2581,11 @@ static int32_t createWindowLogicNodeByStreamExternal(SLogicPlanContext* pCxt, SE
     return TSDB_CODE_PLAN_INTERNAL_ERROR;
   }
 
-  pWindow->pSubquery = pExternal->pSubquery;
+  code = nodesCloneNode(pExternal->pSubquery, &pWindow->pSubquery);
+  if (code != TSDB_CODE_SUCCESS) {
+    nodesDestroyNode((SNode*)pWindow);
+    return code;
+  }
   return createExternalWindowLogicNodeFinalize(pCxt, pSelect, pWindow, pLogicNode);
 }
 

--- a/source/libs/planner/src/planPhysiCreater.c
+++ b/source/libs/planner/src/planPhysiCreater.c
@@ -3171,7 +3171,7 @@ static int32_t createExternalWindowPhysiNode(SPhysiPlanContext* pCxt, SNodeList*
   pExternal->extFill.mode = pWindowLogicNode->extFill.mode;
   pExternal->orgTableUid = pWindowLogicNode->orgTableUid;
   pExternal->orgTableVgId = pWindowLogicNode->orgTableVgId;
-  pExternal->pSubquery = pWindowLogicNode->pSubquery;
+  PLAN_ERR_JRET(nodesCloneNode(pWindowLogicNode->pSubquery, &pExternal->pSubquery));
   PLAN_ERR_JRET(nodesCloneNode(pWindowLogicNode->pTimeRange, &pExternal->pTimeRange));
 
   PLAN_ERR_JRET(createWindowPhysiNodeFinalize(pCxt, pChildren, &pExternal->window, pWindowLogicNode));

--- a/test/cases/13-TimeSeriesExt/08-ExternalWindow/test_external.py
+++ b/test/cases/13-TimeSeriesExt/08-ExternalWindow/test_external.py
@@ -73,6 +73,7 @@ class TestExternal:
         self.large_block_and_time_condition_regression()
         self.vtable_external_window_regression()
         self.stmt_external_window_regression()
+        self.stmt2_external_window_regression()
         self.fill_external_window_regression()
         self.scenario_regression()
 
@@ -2128,24 +2129,53 @@ class TestExternal:
         config = buildPath + "../sim/dnode1/cfg/"
         return taos.connect(host="localhost", config=config)
 
-    def _assert_stmt_external_window_error(self, conn, sql, params, case_label):
-        """Assert that a STMT query with external_window raises an error."""
+    def _run_stmt_query(self, conn, sql, params=None):
+        """Execute an (optionally parameterised) STMT query and return all rows.
+
+        If params is None the query is executed directly after prepare without
+        calling bind_param, which exercises the prepare → execute shortcut path.
+        """
         stmt = conn.statement(sql)
         try:
-            stmt.bind_param(params)
+            if params is not None:
+                stmt.bind_param(params)
             stmt.execute()
-            raise AssertionError(f"{case_label}: expected error but succeeded")
-        except Exception as err:
-            err_msg = str(err)
-            tdLog.info(f"{case_label}: got expected error: {err_msg}")
-            if "External window query can not be used in stmt query" not in err_msg:
-                raise AssertionError(
-                    f"{case_label}: unexpected error message: {err_msg}"
-                )
+            result = stmt.use_result()
+            return result.fetch_all()
+        finally:
+            stmt.close()
+
+    def _check_stmt_rows(self, rows, expected, case_label):
+        """Compare STMT result rows against a list of expected tuples (result-file style)."""
+        if len(rows) != len(expected):
+            tdLog.exit(
+                f"{case_label}: row count mismatch: got {len(rows)}, expected {len(expected)}"
+            )
+        for i, (got, exp) in enumerate(zip(rows, expected)):
+            for j, exp_val in enumerate(exp):
+                if got[j] != exp_val:
+                    tdLog.exit(
+                        f"{case_label}: row {i} col {j}: got {got[j]!r}, expected {exp_val!r}"
+                    )
+        tdLog.info(f"{case_label}: passed ({len(rows)} rows)")
 
     def stmt_external_window_regression(self):
-        """Test that external_window is forbidden in STMT (parameterised) queries."""
-        tdLog.info("=============== external window: stmt negative regression")
+        """Test that external_window works correctly in STMT (parameterised) queries.
+
+        Uses result-file style comparison: expected values are hard-coded from the
+        ext_cx_* dataset created by cross_mix_and_join_regression().
+
+        Dataset recap (t0 = 1700400000000):
+          ext_cx_win:  [t0,   t0+300k)  mark=101
+                       [t0+300k, t0+600k) mark=102
+                       [t0+600k, t0+900k) mark=103
+                       [t0+900k, t0+1200k) mark=104
+          ext_cx_src_1 (t1=1): +60k v=10, +120k v=11, +360k v=12,
+                                +420k v=13, +660k v=14, +960k v=15
+          ext_cx_src_2 (t1=2): +180k v=20, +480k v=21, +540k v=22,
+                                +780k v=23, +1020k v=24
+        """
+        tdLog.info("=============== external window: stmt regression")
         tdSql.execute(f"use {self.dbName}")
 
         conn = self._stmt_conn()
@@ -2153,8 +2183,10 @@ class TestExternal:
 
         t0 = 1700400000000  # same base as ext_cx_* tables
 
-        # ---- 1. STMT with bind param in outer WHERE ----
-        sql = (
+        # ---- case 1: bind param in outer WHERE (ts >= ?) ----
+        # Windows whose start >= t0+300k: win2 (4 rows, sv=68), win3 (2 rows, sv=37),
+        # win4 (2 rows, sv=39).  win1 rows all have ts < t0+300k so win1 is empty.
+        stmt_sql = (
             "select cast(_wstart as bigint) as ws, count(*) as c, sum(v) as sv "
             "from ext_cx_src "
             "where ts >= ? "
@@ -2163,10 +2195,16 @@ class TestExternal:
         )
         params = new_bind_params(1)
         params[0].timestamp(t0 + 300000)
-        self._assert_stmt_external_window_error(conn, sql, params, "stmt case 1")
+        rows = self._run_stmt_query(conn, stmt_sql, params)
+        self._check_stmt_rows(rows, [
+            (t0 + 300000, 4, 68),
+            (t0 + 600000, 2, 37),
+            (t0 + 900000, 2, 39),
+        ], "stmt case 1")
 
-        # ---- 2. STMT with bind param in subquery WHERE ----
-        sql = (
+        # ---- case 2: bind param in subquery WHERE (mark >= ?) ----
+        # mark >= 103 → windows 3 and 4 only.
+        stmt_sql = (
             "select cast(_wstart as bigint) as ws, count(*) as c, sum(v) as sv "
             "from ext_cx_src "
             "external_window((select ts, endtime, mark from ext_cx_win where mark >= ?) w) "
@@ -2174,10 +2212,15 @@ class TestExternal:
         )
         params = new_bind_params(1)
         params[0].int(103)
-        self._assert_stmt_external_window_error(conn, sql, params, "stmt case 2")
+        rows = self._run_stmt_query(conn, stmt_sql, params)
+        self._check_stmt_rows(rows, [
+            (t0 + 600000, 2, 37),
+            (t0 + 900000, 2, 39),
+        ], "stmt case 2")
 
-        # ---- 3. STMT with bind params in both outer and subquery ----
-        sql = (
+        # ---- case 3: bind params in both outer WHERE and subquery WHERE ----
+        # ts >= t0+300k AND mark <= 103 → windows 2 and 3; win1 rows all filtered by outer WHERE.
+        stmt_sql = (
             "select cast(_wstart as bigint) as ws, count(*) as c "
             "from ext_cx_src "
             "where ts >= ? "
@@ -2187,10 +2230,15 @@ class TestExternal:
         params = new_bind_params(2)
         params[0].timestamp(t0 + 300000)
         params[1].int(103)
-        self._assert_stmt_external_window_error(conn, sql, params, "stmt case 3")
+        rows = self._run_stmt_query(conn, stmt_sql, params)
+        self._check_stmt_rows(rows, [
+            (t0 + 300000, 4),
+            (t0 + 600000, 2),
+        ], "stmt case 3")
 
-        # ---- 4. STMT aggregate with partition by ----
-        sql = (
+        # ---- case 4: aggregate with PARTITION BY, bind param in subquery (mark >= ?) ----
+        # mark >= 101 → all 4 windows; partition by t1 => 8 output rows ordered by t1, ws.
+        stmt_sql = (
             "select t1, cast(_wstart as bigint) as ws, count(*) as c, sum(v) as sv "
             "from ext_cx_src partition by t1 "
             "external_window((select ts, endtime, mark from ext_cx_win where mark >= ?) w) "
@@ -2198,10 +2246,21 @@ class TestExternal:
         )
         params = new_bind_params(1)
         params[0].int(101)
-        self._assert_stmt_external_window_error(conn, sql, params, "stmt case 4")
+        rows = self._run_stmt_query(conn, stmt_sql, params)
+        self._check_stmt_rows(rows, [
+            (1, t0,           2, 21),
+            (1, t0 + 300000,  2, 25),
+            (1, t0 + 600000,  1, 14),
+            (1, t0 + 900000,  1, 15),
+            (2, t0,           1, 20),
+            (2, t0 + 300000,  2, 43),
+            (2, t0 + 600000,  1, 23),
+            (2, t0 + 900000,  1, 24),
+        ], "stmt case 4")
 
-        # ---- 5. STMT projection path ----
-        sql = (
+        # ---- case 5: projection path, bind param in subquery (mark <= ?) ----
+        # mark <= 102 → windows 1 (mark=101) and 2 (mark=102); 7 source rows total.
+        stmt_sql = (
             "select cast(_wstart as bigint) as ws, w.mark, cast(ts as bigint) as ts64, v "
             "from ext_cx_src "
             "external_window((select ts, endtime, mark from ext_cx_win where mark <= ?) w) "
@@ -2209,25 +2268,144 @@ class TestExternal:
         )
         params = new_bind_params(1)
         params[0].int(102)
-        self._assert_stmt_external_window_error(conn, sql, params, "stmt case 5")
+        rows = self._run_stmt_query(conn, stmt_sql, params)
+        self._check_stmt_rows(rows, [
+            (t0,            101, t0 + 60000,  10),
+            (t0,            101, t0 + 120000, 11),
+            (t0,            101, t0 + 180000, 20),
+            (t0 + 300000,   102, t0 + 360000, 12),
+            (t0 + 300000,   102, t0 + 420000, 13),
+            (t0 + 300000,   102, t0 + 480000, 21),
+            (t0 + 300000,   102, t0 + 540000, 22),
+        ], "stmt case 5")
 
-        # ---- 6. STMT with no bind params (pure external_window, still via stmt path) ----
-        sql = (
+        # ---- case 6: no '?' bind params — prepare → execute directly ----
+        # All 4 windows, all source rows.
+        # win1 [t0,       t0+300k): src_1 × 2 + src_2 × 1 = 3 rows
+        # win2 [t0+300k,  t0+600k): src_1 × 2 + src_2 × 2 = 4 rows
+        # win3 [t0+600k,  t0+900k): src_1 × 1 + src_2 × 1 = 2 rows
+        # win4 [t0+900k, t0+1200k): src_1 × 1 + src_2 × 1 = 2 rows
+        stmt_sql = (
             "select cast(_wstart as bigint) as ws, count(*) as c "
             "from ext_cx_src "
-            "external_window((select ts, endtime, mark from ext_cx_win) w) "
+            "external_window((select ts, endtime from ext_cx_win) w) "
             "order by ws"
         )
-        stmt = conn.statement(sql)
-        try:
-            stmt.execute()
-            raise AssertionError("stmt case 6: expected error but succeeded")
-        except Exception as err:
-            err_msg = str(err)
-            tdLog.info(f"stmt case 6: got expected error: {err_msg}")
+        rows = self._run_stmt_query(conn, stmt_sql)  # no params: exercises prepare→execute path
+        self._check_stmt_rows(rows, [
+            (t0,          3),
+            (t0 + 300000, 4),
+            (t0 + 600000, 2),
+            (t0 + 900000, 2),
+        ], "stmt case 6")
 
         conn.close()
-        tdLog.info("=============== external window: stmt negative regression done")
+        tdLog.info("=============== external window: stmt regression done")
+
+    # ------------------------------------------------------------------
+    # STMT2 API helpers and regression
+    # ------------------------------------------------------------------
+
+    def _run_stmt2_query(self, conn, sql, param_values=None):
+        """Execute an (optionally parameterised) STMT2 query and return all rows.
+
+        param_values: flat list of scalar values matching the '?' placeholders,
+        e.g. [103] for one int param or [t0 + 300000, 103] for two params.
+        If None, the query is executed directly after prepare (no-param path).
+        """
+        stmt2 = conn.statement2(sql)
+        try:
+            if param_values is not None:
+                # STMT2 query bind format: datas is a list-of-tables where each
+                # table is a list-of-columns and each column is a list-of-values.
+                # For a single-row query bind with N params we supply one
+                # "table" entry whose columns are [[v1], [v2], ...].
+                col_data = [[v] for v in param_values]
+                stmt2.bind_param(None, None, [col_data])
+            stmt2.execute()
+            result = stmt2.result()
+            return result.fetch_all()
+        finally:
+            stmt2.close()
+
+    def stmt2_external_window_regression(self):
+        """Test external_window via the STMT2 API (taos_stmt2_*).
+
+        Mirrors a subset of stmt_external_window_regression() to verify that
+        the clientStmt2 changes (stmtSwitchStatus PREPARE allowance, the
+        prepare→execute shortcut, and qStmtBindParams2 cloning) all work.
+        Same ext_cx_* dataset; same hard-coded expected values.
+        """
+        tdLog.info("=============== external window: stmt2 regression")
+        tdSql.execute(f"use {self.dbName}")
+
+        conn = self._stmt_conn()
+        conn.select_db(self.dbName)
+
+        t0 = 1700400000000  # same base as ext_cx_* tables
+
+        # ---- case 1: bind param in outer WHERE (ts >= ?) ----
+        rows = self._run_stmt2_query(
+            conn,
+            "select cast(_wstart as bigint) as ws, count(*) as c, sum(v) as sv "
+            "from ext_cx_src "
+            "where ts >= ? "
+            "external_window((select ts, endtime, mark from ext_cx_win) w) "
+            "order by ws",
+            [t0 + 300000],
+        )
+        self._check_stmt_rows(rows, [
+            (t0 + 300000, 4, 68),
+            (t0 + 600000, 2, 37),
+            (t0 + 900000, 2, 39),
+        ], "stmt2 case 1")
+
+        # ---- case 2: bind param in subquery WHERE (mark >= ?) ----
+        rows = self._run_stmt2_query(
+            conn,
+            "select cast(_wstart as bigint) as ws, count(*) as c, sum(v) as sv "
+            "from ext_cx_src "
+            "external_window((select ts, endtime, mark from ext_cx_win where mark >= ?) w) "
+            "order by ws",
+            [103],
+        )
+        self._check_stmt_rows(rows, [
+            (t0 + 600000, 2, 37),
+            (t0 + 900000, 2, 39),
+        ], "stmt2 case 2")
+
+        # ---- case 3: bind params in both outer WHERE and subquery WHERE ----
+        rows = self._run_stmt2_query(
+            conn,
+            "select cast(_wstart as bigint) as ws, count(*) as c "
+            "from ext_cx_src "
+            "where ts >= ? "
+            "external_window((select ts, endtime, mark from ext_cx_win where mark <= ?) w) "
+            "order by ws",
+            [t0 + 300000, 103],
+        )
+        self._check_stmt_rows(rows, [
+            (t0 + 300000, 4),
+            (t0 + 600000, 2),
+        ], "stmt2 case 3")
+
+        # ---- case 4: no '?' params — prepare → execute shortcut ----
+        rows = self._run_stmt2_query(
+            conn,
+            "select cast(_wstart as bigint) as ws, count(*) as c "
+            "from ext_cx_src "
+            "external_window((select ts, endtime from ext_cx_win) w) "
+            "order by ws",
+        )  # param_values=None: exercises prepare→execute path in stmtExec2
+        self._check_stmt_rows(rows, [
+            (t0,          3),
+            (t0 + 300000, 4),
+            (t0 + 600000, 2),
+            (t0 + 900000, 2),
+        ], "stmt2 case 4")
+
+        conn.close()
+        tdLog.info("=============== external window: stmt2 regression done")
 
     # ==================================================================
     # Scenario-based regression tests (5.1–5.4 from requirements doc)

--- a/test/cases/13-TimeSeriesExt/08-ExternalWindow/test_external.py
+++ b/test/cases/13-TimeSeriesExt/08-ExternalWindow/test_external.py
@@ -2299,6 +2299,88 @@ class TestExternal:
             (t0 + 900000, 2),
         ], "stmt case 6")
 
+        # ---- case 7: max / min aggregates via STMT bind ----
+        # Exercises a different aggregate code path (not count/sum).
+        # With ts >= t0 all source rows fall into one of the 4 windows.
+        # win1: v=10,11,20 → max=20 min=10
+        # win2: v=12,13,21,22 → max=22 min=12
+        # win3: v=14,23      → max=23 min=14
+        # win4: v=15,24      → max=24 min=15
+        stmt_sql = (
+            "select cast(_wstart as bigint) as ws, max(v), min(v) "
+            "from ext_cx_src "
+            "where ts >= ? "
+            "external_window((select ts, endtime from ext_cx_win) w) "
+            "order by ws"
+        )
+        params = new_bind_params(1)
+        params[0].timestamp(t0)
+        rows = self._run_stmt_query(conn, stmt_sql, params)
+        self._check_stmt_rows(rows, [
+            (t0,          20, 10),
+            (t0 + 300000, 22, 12),
+            (t0 + 600000, 23, 14),
+            (t0 + 900000, 24, 15),
+        ], "stmt case 7")
+
+        # ---- case 8: STMT re-use — same stmt object, different param values ----
+        # Verifies that pSubquery ownership and pPrepareRoot cloning are correct
+        # across multiple bind→execute cycles on the same prepared statement.
+        # Run 1: mark >= 104 → only win4 (2 rows, sum=39)
+        # Run 2: mark >= 103 → win3 + win4 (2+2 rows, sum=37+39)
+        reuse_sql = (
+            "select cast(_wstart as bigint) as ws, count(*) as c, sum(v) as sv "
+            "from ext_cx_src "
+            "external_window((select ts, endtime, mark from ext_cx_win where mark >= ?) w) "
+            "order by ws"
+        )
+        stmt = conn.statement(reuse_sql)
+        try:
+            params = new_bind_params(1)
+            params[0].int(104)
+            stmt.bind_param(params)
+            stmt.execute()
+            result = stmt.use_result()
+            rows = result.fetch_all()
+            self._check_stmt_rows(rows, [
+                (t0 + 900000, 2, 39),
+            ], "stmt case 8 run1")
+
+            params = new_bind_params(1)
+            params[0].int(103)
+            stmt.bind_param(params)
+            stmt.execute()
+            result = stmt.use_result()
+            rows = result.fetch_all()
+            self._check_stmt_rows(rows, [
+                (t0 + 600000, 2, 37),
+                (t0 + 900000, 2, 39),
+            ], "stmt case 8 run2")
+        finally:
+            stmt.close()
+
+        # ---- case 9: negative — execute without bind when SQL has '?' params ----
+        # Our shortcut path in stmtExec detects placeholderNum > 0 and returns
+        # TSDB_CODE_TSC_STMT_API_ERROR instead of executing with unbound params.
+        neg_sql = (
+            "select cast(_wstart as bigint) as ws, count(*) as c "
+            "from ext_cx_src "
+            "where ts >= ? "
+            "external_window((select ts, endtime from ext_cx_win) w) "
+            "order by ws"
+        )
+        stmt = conn.statement(neg_sql)
+        try:
+            stmt.execute()  # no bind_param — should fail
+            tdLog.exit("stmt case 9: expected error for unbound params but succeeded")
+        except Exception as err:
+            tdLog.info(f"stmt case 9: got expected error: {err}")
+        finally:
+            try:
+                stmt.close()
+            except Exception:
+                pass
+
         conn.close()
         tdLog.info("=============== external window: stmt regression done")
 
@@ -2403,6 +2485,97 @@ class TestExternal:
             (t0 + 600000, 2),
             (t0 + 900000, 2),
         ], "stmt2 case 4")
+
+        # ---- case 5: PARTITION BY aggregate (mirrors stmt case 4) ----
+        # mark >= 101 → all 4 windows; partition by t1 → 8 output rows ordered by t1, ws.
+        rows = self._run_stmt2_query(
+            conn,
+            "select t1, cast(_wstart as bigint) as ws, count(*) as c, sum(v) as sv "
+            "from ext_cx_src partition by t1 "
+            "external_window((select ts, endtime, mark from ext_cx_win where mark >= ?) w) "
+            "order by t1, ws",
+            [101],
+        )
+        self._check_stmt_rows(rows, [
+            (1, t0,           2, 21),
+            (1, t0 + 300000,  2, 25),
+            (1, t0 + 600000,  1, 14),
+            (1, t0 + 900000,  1, 15),
+            (2, t0,           1, 20),
+            (2, t0 + 300000,  2, 43),
+            (2, t0 + 600000,  1, 23),
+            (2, t0 + 900000,  1, 24),
+        ], "stmt2 case 5")
+
+        # ---- case 6: projection path (mirrors stmt case 5) ----
+        # mark <= 102 → windows 1 and 2; 7 source rows emitted as individual rows.
+        rows = self._run_stmt2_query(
+            conn,
+            "select cast(_wstart as bigint) as ws, w.mark, cast(ts as bigint) as ts64, v "
+            "from ext_cx_src "
+            "external_window((select ts, endtime, mark from ext_cx_win where mark <= ?) w) "
+            "order by ws, ts64",
+            [102],
+        )
+        self._check_stmt_rows(rows, [
+            (t0,            101, t0 + 60000,  10),
+            (t0,            101, t0 + 120000, 11),
+            (t0,            101, t0 + 180000, 20),
+            (t0 + 300000,   102, t0 + 360000, 12),
+            (t0 + 300000,   102, t0 + 420000, 13),
+            (t0 + 300000,   102, t0 + 480000, 21),
+            (t0 + 300000,   102, t0 + 540000, 22),
+        ], "stmt2 case 6")
+
+        # ---- case 7: STMT2 re-use — same stmt2 object, different param values ----
+        # Run 1: mark >= 104 → only win4 (2 rows, sum=39)
+        # Run 2: mark >= 103 → win3 + win4 (2+2 rows, sum=37+39)
+        reuse2_sql = (
+            "select cast(_wstart as bigint) as ws, count(*) as c, sum(v) as sv "
+            "from ext_cx_src "
+            "external_window((select ts, endtime, mark from ext_cx_win where mark >= ?) w) "
+            "order by ws"
+        )
+        stmt2 = conn.statement2(reuse2_sql)
+        try:
+            stmt2.bind_param(None, None, [[[104]]])
+            stmt2.execute()
+            result = stmt2.result()
+            rows = result.fetch_all()
+            self._check_stmt_rows(rows, [
+                (t0 + 900000, 2, 39),
+            ], "stmt2 case 7 run1")
+
+            stmt2.bind_param(None, None, [[[103]]])
+            stmt2.execute()
+            result = stmt2.result()
+            rows = result.fetch_all()
+            self._check_stmt_rows(rows, [
+                (t0 + 600000, 2, 37),
+                (t0 + 900000, 2, 39),
+            ], "stmt2 case 7 run2")
+        finally:
+            stmt2.close()
+
+        # ---- case 8: negative — execute without bind when SQL has '?' params ----
+        neg_sql = (
+            "select cast(_wstart as bigint) as ws, count(*) as c "
+            "from ext_cx_src "
+            "where ts >= ? "
+            "external_window((select ts, endtime from ext_cx_win) w) "
+            "order by ws"
+        )
+        stmt2 = conn.statement2(neg_sql)
+        try:
+            stmt2.execute()  # no bind_param — should fail
+            tdLog.exit("stmt2 case 8: expected error for unbound params but succeeded")
+        except Exception as err:
+            tdLog.info(f"stmt2 case 8: got expected error: {err}")
+        finally:
+            try:
+                stmt2.close()
+            except Exception:
+                pass
 
         conn.close()
         tdLog.info("=============== external window: stmt2 regression done")


### PR DESCRIPTION
- Remove stmtBindVersion guard in translateWindow() to allow STMT mode
- Add externalWindowNodeCopy() in nodesCloneFuncs.c for correct clone
- Defer SELECT translation in analyseSemantic() when pStmtCb != NULL
- Allow STMT_EXECUTE from STMT_PREPARE status for query type

# Description

<!-- Please briefly describe the code changes in this pull request. -->

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
