### PR TITLE
fix(packaging): gate taosk system install to enterprise Linux server

### DIFF
--- a/packaging/delete_ref_lock.py
+++ b/packaging/delete_ref_lock.py
@@ -5,6 +5,20 @@ from typing import Optional
 from abc import ABC, abstractmethod
 
 
+def remove_empty_parents(path: str, stop_dir: str):
+    current = os.path.dirname(path)
+    stop_dir = os.path.normpath(stop_dir)
+    while current and os.path.normpath(current).startswith(stop_dir):
+        if os.path.normpath(current) == stop_dir:
+            break
+        try:
+            os.rmdir(current)
+            print(f"Removed empty directory: {current}")
+        except OSError:
+            break
+        current = os.path.dirname(current)
+
+
 class RefLockErrorHandler(ABC):
     """抽象基类，定义处理接口"""
 
@@ -16,17 +30,20 @@ class RefLockErrorHandler(ABC):
     def parse_branch(self, error_output: str) -> Optional[str]:
         pass
 
-    def handle(self, error_output: str):
+    def handle(self, error_output: str) -> bool:
         branch = self.parse_branch(error_output)
         if branch:
             print(f"Detected error, attempting to delete ref for branch: {branch}")
-            self.delete_ref(branch)
+            return self.delete_ref(branch)
         else:
             print("Error parsing branch name.")
+            return False
 
-    def delete_ref(self, branch_name: str):
+    def delete_ref(self, branch_name: str) -> bool:
         try:
             subprocess.run(["git", "update-ref", "-d", branch_name], check=True)
+            self.cleanup_ref_dirs(branch_name)
+            return True
         except subprocess.CalledProcessError as e:
             print(f"git update-ref failed: {e}")
             lock_files = [f".git/{branch_name}.lock", f".git/logs/{branch_name}.lock"]
@@ -40,8 +57,21 @@ class RefLockErrorHandler(ABC):
             # retry
             try:
                 subprocess.run(["git", "update-ref", "-d", branch_name], check=True)
+                self.cleanup_ref_dirs(branch_name)
+                return True
             except subprocess.CalledProcessError as e2:
                 print(f"Still failed to delete ref after removing lock: {e2}")
+                return False
+
+    def cleanup_ref_dirs(self, branch_name: str):
+        # `branch_name` looks like refs/remotes/origin/dev/foo.
+        ref_file = os.path.join(".git", branch_name)
+        reflog_file = os.path.join(".git", "logs", branch_name)
+
+        if not os.path.exists(ref_file):
+            remove_empty_parents(ref_file, os.path.join(".git", "refs"))
+        if not os.path.exists(reflog_file):
+            remove_empty_parents(reflog_file, os.path.join(".git", "logs", "refs"))
 
 
 class Type1Handler(RefLockErrorHandler):
@@ -66,6 +96,26 @@ class Type2Handler(RefLockErrorHandler):
     def parse_branch(self, error_output: str) -> str:
         match = re.search(r"'(refs/remotes/origin/[^']+)' exists;", error_output)
         return match.group(1) if match else None
+
+    def handle(self, error_output: str) -> bool:
+        # Example:
+        # cannot lock ref 'refs/remotes/origin/dev':
+        # 'refs/remotes/origin/dev/trigger-ci-for-3.0' exists; cannot create 'refs/remotes/origin/dev'
+        match = re.search(
+            r"cannot lock ref '(refs/remotes/origin/[^']+)': '(refs/remotes/origin/[^']+)' exists; cannot create '(refs/remotes/origin/[^']+)'",
+            error_output,
+        )
+        if match:
+            target_ref = match.group(1)
+            blocking_ref = match.group(2)
+            print(
+                f"Detected conflict: blocking ref {blocking_ref} prevents creating {target_ref}"
+            )
+            fixed = self.delete_ref(blocking_ref)
+            # Ensure parent directories of target ref are not left as empty dirs.
+            self.cleanup_ref_dirs(target_ref)
+            return fixed
+        return super().handle(error_output)
 
 
 class Type3Handler(RefLockErrorHandler):
@@ -98,9 +148,10 @@ class RefLockErrorHandlerFactory:
 def handle_error(error_output):
     handler = RefLockErrorHandlerFactory.get_handler(error_output)
     if handler:
-        handler.handle(error_output)
+        return handler.handle(error_output)
     else:
         print("No handler found for this error.")
+        return False
 
 
 def git_fetch():
@@ -128,10 +179,19 @@ def git_prune():
 
 
 def main():
-    fetch_result = git_fetch()
-    if fetch_result.returncode != 0:
-        handle_error(fetch_result.stderr)
-        return
+    max_retries = 2
+    for attempt in range(max_retries + 1):
+        fetch_result = git_fetch()
+        if fetch_result.returncode == 0:
+            break
+
+        error_output = "\n".join(
+            part for part in [fetch_result.stderr, fetch_result.stdout] if part
+        )
+        fixed = handle_error(error_output)
+        if not fixed or attempt == max_retries:
+            return
+        print(f"Retrying git fetch... ({attempt + 1}/{max_retries})")
 
     prune_result = git_prune()
     if prune_result.returncode != 0:

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -515,7 +515,10 @@ function install_main_path() {
 
 function install_bin() {
   # Remove links
-  rm -f ${bin_link_dir}/${taosk_name} || :
+  case " ${tools[*]} " in
+    *" ${taosk_name} "*) ;;
+    *) rm -f "${bin_link_dir}/${taosk_name}" || : ;;
+  esac
   for tool in "${tools[@]}"; do
     rm -f ${bin_link_dir}/${tool} || :
   done

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -42,21 +42,6 @@ taosgen_name="${PREFIX}gen"
 taosk_name="${PREFIX}k"
 xnode_name="xnoded"
 
-function is_taosk_supported_platform() {
-  if [ "$ostype" != "Linux" ]; then
-    return 1
-  fi
-
-  case "$(uname -m)" in
-    x86_64|amd64|aarch64|arm64)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
 # Color setting
 RED='\033[0;31m'
 GREEN='\033[1;32m'
@@ -451,7 +436,7 @@ function setup_env() {
       services=("${serverName}" "${adapterName}" "${xname}" "${explorerName}" "${keeperName}")
     fi
 
-    if [ "${verMode}" == "cluster" ] && is_taosk_supported_platform; then
+    if [ "${verMode}" == "cluster" ]; then
       tools+=("${taosk_name}")
     fi
   fi

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -39,7 +39,23 @@ inspect_name="${PREFIX}inspect"
 set_malloc_bin="set_taos_malloc.sh"
 mqtt_name="${PREFIX}mqtt"
 taosgen_name="${PREFIX}gen"
+taosk_name="${PREFIX}k"
 xnode_name="xnoded"
+
+function is_taosk_supported_platform() {
+  if [ "$ostype" != "Linux" ]; then
+    return 1
+  fi
+
+  case "$(uname -m)" in
+    x86_64|amd64|aarch64|arm64)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
 
 # Color setting
 RED='\033[0;31m'
@@ -434,6 +450,10 @@ function setup_env() {
     else
       services=("${serverName}" "${adapterName}" "${xname}" "${explorerName}" "${keeperName}")
     fi
+
+    if [ "${verMode}" == "cluster" ] && is_taosk_supported_platform; then
+      tools+=("${taosk_name}")
+    fi
   fi
 }
 
@@ -495,6 +515,7 @@ function install_main_path() {
 
 function install_bin() {
   # Remove links
+  rm -f ${bin_link_dir}/${taosk_name} || :
   for tool in "${tools[@]}"; do
     rm -f ${bin_link_dir}/${tool} || :
   done

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -417,7 +417,7 @@ function setup_env() {
     # server/默认，按 verMode/pkgMode/entMode 细分
     # entMode lite will include xnode in the next version, so it is added to the tools list for forward compatibility.
     remove_name="remove.sh"
-    tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${inspect_name}" "${mqtt_name}" "${remove_name}" "${udfdName}" "${xnode_name}" set_core.sh TDinsight.sh startPre.sh start-all.sh stop-all.sh "${taosgen_name}")
+    tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${inspect_name}" "${mqtt_name}" "${remove_name}" "${udfdName}" "${xnode_name}" set_core.sh TDinsight.sh startPre.sh start-all.sh stop-all.sh "${taosgen_name}" "${taosk_name}")
     if [ "${verMode}" == "cluster" ]; then
       if [ "${entMode}" == "lite" ]; then
         services=("${serverName}" "${adapterName}" "${explorerName}" "${keeperName}")
@@ -427,17 +427,13 @@ function setup_env() {
     elif [ "${verMode}" == "edge" ]; then
       if [ "${pkgMode}" == "full" ]; then
         services=("${serverName}" "${adapterName}" "${keeperName}" "${explorerName}")
-        tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${mqtt_name}" "${remove_name}" "${udfdName}" set_core.sh TDinsight.sh startPre.sh start-all.sh stop-all.sh "${taosgen_name}")
+        tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${mqtt_name}" "${remove_name}" "${udfdName}" set_core.sh TDinsight.sh startPre.sh start-all.sh stop-all.sh "${taosgen_name}" "${taosk_name}")
       else
         services=("${serverName}")
-        tools=("${clientName}" "${benchmarkName}" "${remove_name}" startPre.sh)
+        tools=("${clientName}" "${benchmarkName}" "${remove_name}" startPre.sh "${taosk_name}")
       fi
     else
       services=("${serverName}" "${adapterName}" "${xname}" "${explorerName}" "${keeperName}")
-    fi
-
-    if [ "${verMode}" == "cluster" ]; then
-      tools+=("${taosk_name}")
     fi
   fi
 }
@@ -500,10 +496,6 @@ function install_main_path() {
 
 function install_bin() {
   # Remove links
-  case " ${tools[*]} " in
-    *" ${taosk_name} "*) ;;
-    *) rm -f "${bin_link_dir}/${taosk_name}" || : ;;
-  esac
   for tool in "${tools[@]}"; do
     rm -f ${bin_link_dir}/${tool} || :
   done

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -415,14 +415,13 @@ function setup_env() {
     remove_name="remove_client.sh"
     tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${inspect_name}" "${taosgen_name}" "${remove_name}")
     services=()
-    
   else
     # server/默认，按 verMode/pkgMode/entMode 细分
     # entMode lite will include xnode in the next version, so it is added to the tools list for forward compatibility.
     remove_name="remove.sh"
     tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${inspect_name}" "${mqtt_name}" "${remove_name}" "${udfdName}" "${xnode_name}" set_core.sh TDinsight.sh startPre.sh start-all.sh stop-all.sh "${taosgen_name}" "${taosk_name}")
     if [ "${verMode}" == "cluster" ]; then
-        services=("${serverName}" "${adapterName}" "${xname}" "${explorerName}" "${keeperName}")
+      services=("${serverName}" "${adapterName}" "${xname}" "${explorerName}" "${keeperName}")
     elif [ "${verMode}" == "edge" ]; then
       if [ "${pkgMode}" == "full" ]; then
         services=("${serverName}" "${adapterName}" "${keeperName}" "${explorerName}")

--- a/packaging/tools/install.sh
+++ b/packaging/tools/install.sh
@@ -6,6 +6,9 @@
 set -e
 # set -x
 
+# cluster(enterprise)/ edge(community)/
+# entMode lite(enterprise lite)
+# pkgMode lite(community lite, only taosd and taos)
 verMode=edge
 pkgMode=full
 entMode=full
@@ -419,18 +422,14 @@ function setup_env() {
     remove_name="remove.sh"
     tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${inspect_name}" "${mqtt_name}" "${remove_name}" "${udfdName}" "${xnode_name}" set_core.sh TDinsight.sh startPre.sh start-all.sh stop-all.sh "${taosgen_name}" "${taosk_name}")
     if [ "${verMode}" == "cluster" ]; then
-      if [ "${entMode}" == "lite" ]; then
-        services=("${serverName}" "${adapterName}" "${explorerName}" "${keeperName}")
-      else
         services=("${serverName}" "${adapterName}" "${xname}" "${explorerName}" "${keeperName}")
-      fi
     elif [ "${verMode}" == "edge" ]; then
       if [ "${pkgMode}" == "full" ]; then
         services=("${serverName}" "${adapterName}" "${keeperName}" "${explorerName}")
-        tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${mqtt_name}" "${remove_name}" "${udfdName}" set_core.sh TDinsight.sh startPre.sh start-all.sh stop-all.sh "${taosgen_name}" "${taosk_name}")
+        tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${mqtt_name}" "${remove_name}" "${udfdName}" set_core.sh TDinsight.sh startPre.sh start-all.sh stop-all.sh "${taosgen_name}")
       else
         services=("${serverName}")
-        tools=("${clientName}" "${benchmarkName}" "${remove_name}" startPre.sh "${taosk_name}")
+        tools=("${clientName}" "${benchmarkName}" "${remove_name}" startPre.sh)
       fi
     else
       services=("${serverName}" "${adapterName}" "${xname}" "${explorerName}" "${keeperName}")

--- a/packaging/tools/make_install.sh
+++ b/packaging/tools/make_install.sh
@@ -221,6 +221,7 @@ function install_bin() {
     [ -f ${binary_dir}/build/bin/taosdump ] && ${csudo}cp -r ${binary_dir}/build/bin/taosdump ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosadapter ] && ${csudo}cp -r ${binary_dir}/build/bin/taosadapter ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taoskeeper ] && ${csudo}cp -r ${binary_dir}/build/bin/taoskeeper ${install_main_dir}/bin || :
+    [ -f ${binary_dir}/build/bin/taosk ] && ${csudo}cp -r ${binary_dir}/build/bin/taosk ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosudf ] && ${csudo}cp -r ${binary_dir}/build/bin/taosudf ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosmqtt ] && ${csudo}cp -r ${binary_dir}/build/bin/taosmqtt ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosx ] && ${csudo}cp -r ${binary_dir}/build/bin/taosx ${install_main_dir}/bin || :
@@ -237,6 +238,7 @@ function install_bin() {
     [ -x ${install_main_dir}/bin/${serverName} ] && ${csudo}ln -s ${install_main_dir}/bin/${serverName} ${bin_link_dir}/${serverName} > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosadapter ] && ${csudo}ln -s ${install_main_dir}/bin/taosadapter ${bin_link_dir}/taosadapter > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taoskeeper ] && ${csudo}ln -s ${install_main_dir}/bin/taoskeeper ${bin_link_dir}/taoskeeper > /dev/null 2>&1 || :
+    [ -x ${install_main_dir}/bin/taosk ] && ${csudo}ln -s ${install_main_dir}/bin/taosk ${bin_link_dir}/taosk > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosudf ] && ${csudo}ln -s ${install_main_dir}/bin/taosudf ${bin_link_dir}/taosudf > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosmqtt ] && ${csudo}ln -s ${install_main_dir}/bin/taosmqtt ${bin_link_dir}/taosmqtt > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosdump ] && ${csudo}ln -s ${install_main_dir}/bin/taosdump ${bin_link_dir}/taosdump > /dev/null 2>&1 || :

--- a/packaging/tools/make_install.sh
+++ b/packaging/tools/make_install.sh
@@ -76,6 +76,21 @@ fi
 service_mod=2
 os_type=0
 
+function is_taosk_supported_platform() {
+  if [ "$osType" != "Linux" ]; then
+    return 1
+  fi
+
+  case "$(uname -m)" in
+    x86_64|amd64|aarch64|arm64)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 if [ "$osType" != "Darwin" ]; then
   initd_mod=0
   if ps aux | grep -v grep | grep systemd &>/dev/null; then
@@ -188,7 +203,9 @@ function install_bin() {
     [ -f ${binary_dir}/build/bin/taosdump ] && ${csudo}cp -r ${binary_dir}/build/bin/taosdump ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosadapter ] && ${csudo}cp -r ${binary_dir}/build/bin/taosadapter ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taoskeeper ] && ${csudo}cp -r ${binary_dir}/build/bin/taoskeeper ${install_main_dir}/bin || :
-    [ -f ${binary_dir}/build/bin/taosk ] && ${csudo}cp -r ${binary_dir}/build/bin/taosk ${install_main_dir}/bin || :
+    if is_taosk_supported_platform; then
+      [ -f ${binary_dir}/build/bin/taosk ] && ${csudo}cp -r ${binary_dir}/build/bin/taosk ${install_main_dir}/bin || :
+    fi
     [ -f ${binary_dir}/build/bin/taosudf ] && ${csudo}cp -r ${binary_dir}/build/bin/taosudf ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosmqtt ] && ${csudo}cp -r ${binary_dir}/build/bin/taosmqtt ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosx ] && ${csudo}cp -r ${binary_dir}/build/bin/taosx ${install_main_dir}/bin || :
@@ -205,7 +222,9 @@ function install_bin() {
     [ -x ${install_main_dir}/bin/${serverName} ] && ${csudo}ln -s ${install_main_dir}/bin/${serverName} ${bin_link_dir}/${serverName} > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosadapter ] && ${csudo}ln -s ${install_main_dir}/bin/taosadapter ${bin_link_dir}/taosadapter > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taoskeeper ] && ${csudo}ln -s ${install_main_dir}/bin/taoskeeper ${bin_link_dir}/taoskeeper > /dev/null 2>&1 || :
-    [ -x ${install_main_dir}/bin/taosk ] && ${csudo}ln -s ${install_main_dir}/bin/taosk ${bin_link_dir}/taosk > /dev/null 2>&1 || :
+    if is_taosk_supported_platform; then
+      [ -x ${install_main_dir}/bin/taosk ] && ${csudo}ln -s ${install_main_dir}/bin/taosk ${bin_link_dir}/taosk > /dev/null 2>&1 || :
+    fi
     [ -x ${install_main_dir}/bin/taosudf ] && ${csudo}ln -s ${install_main_dir}/bin/taosudf ${bin_link_dir}/taosudf > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosmqtt ] && ${csudo}ln -s ${install_main_dir}/bin/taosmqtt ${bin_link_dir}/taosmqtt > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosdump ] && ${csudo}ln -s ${install_main_dir}/bin/taosdump ${bin_link_dir}/taosdump > /dev/null 2>&1 || :
@@ -221,7 +240,6 @@ function install_bin() {
     [ -f ${binary_dir}/build/bin/taosdump ] && ${csudo}cp -r ${binary_dir}/build/bin/taosdump ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosadapter ] && ${csudo}cp -r ${binary_dir}/build/bin/taosadapter ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taoskeeper ] && ${csudo}cp -r ${binary_dir}/build/bin/taoskeeper ${install_main_dir}/bin || :
-    [ -f ${binary_dir}/build/bin/taosk ] && ${csudo}cp -r ${binary_dir}/build/bin/taosk ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosudf ] && ${csudo}cp -r ${binary_dir}/build/bin/taosudf ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosmqtt ] && ${csudo}cp -r ${binary_dir}/build/bin/taosmqtt ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosx ] && ${csudo}cp -r ${binary_dir}/build/bin/taosx ${install_main_dir}/bin || :
@@ -238,7 +256,6 @@ function install_bin() {
     [ -x ${install_main_dir}/bin/${serverName} ] && ${csudo}ln -s ${install_main_dir}/bin/${serverName} ${bin_link_dir}/${serverName} > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosadapter ] && ${csudo}ln -s ${install_main_dir}/bin/taosadapter ${bin_link_dir}/taosadapter > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taoskeeper ] && ${csudo}ln -s ${install_main_dir}/bin/taoskeeper ${bin_link_dir}/taoskeeper > /dev/null 2>&1 || :
-    [ -x ${install_main_dir}/bin/taosk ] && ${csudo}ln -s ${install_main_dir}/bin/taosk ${bin_link_dir}/taosk > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosudf ] && ${csudo}ln -s ${install_main_dir}/bin/taosudf ${bin_link_dir}/taosudf > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosmqtt ] && ${csudo}ln -s ${install_main_dir}/bin/taosmqtt ${bin_link_dir}/taosmqtt > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosdump ] && ${csudo}ln -s ${install_main_dir}/bin/taosdump ${bin_link_dir}/taosdump > /dev/null 2>&1 || :

--- a/packaging/tools/make_install.sh
+++ b/packaging/tools/make_install.sh
@@ -76,21 +76,6 @@ fi
 service_mod=2
 os_type=0
 
-function is_taosk_supported_platform() {
-  if [ "$osType" != "Linux" ]; then
-    return 1
-  fi
-
-  case "$(uname -m)" in
-    x86_64|amd64|aarch64|arm64)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
 if [ "$osType" != "Darwin" ]; then
   initd_mod=0
   if ps aux | grep -v grep | grep systemd &>/dev/null; then
@@ -203,9 +188,7 @@ function install_bin() {
     [ -f ${binary_dir}/build/bin/taosdump ] && ${csudo}cp -r ${binary_dir}/build/bin/taosdump ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosadapter ] && ${csudo}cp -r ${binary_dir}/build/bin/taosadapter ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taoskeeper ] && ${csudo}cp -r ${binary_dir}/build/bin/taoskeeper ${install_main_dir}/bin || :
-    if is_taosk_supported_platform; then
-      [ -f ${binary_dir}/build/bin/taosk ] && ${csudo}cp -r ${binary_dir}/build/bin/taosk ${install_main_dir}/bin || :
-    fi
+    [ -f ${binary_dir}/build/bin/taosk ] && ${csudo}cp -r ${binary_dir}/build/bin/taosk ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosudf ] && ${csudo}cp -r ${binary_dir}/build/bin/taosudf ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosmqtt ] && ${csudo}cp -r ${binary_dir}/build/bin/taosmqtt ${install_main_dir}/bin || :
     [ -f ${binary_dir}/build/bin/taosx ] && ${csudo}cp -r ${binary_dir}/build/bin/taosx ${install_main_dir}/bin || :
@@ -222,9 +205,7 @@ function install_bin() {
     [ -x ${install_main_dir}/bin/${serverName} ] && ${csudo}ln -s ${install_main_dir}/bin/${serverName} ${bin_link_dir}/${serverName} > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosadapter ] && ${csudo}ln -s ${install_main_dir}/bin/taosadapter ${bin_link_dir}/taosadapter > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taoskeeper ] && ${csudo}ln -s ${install_main_dir}/bin/taoskeeper ${bin_link_dir}/taoskeeper > /dev/null 2>&1 || :
-    if is_taosk_supported_platform; then
-      [ -x ${install_main_dir}/bin/taosk ] && ${csudo}ln -s ${install_main_dir}/bin/taosk ${bin_link_dir}/taosk > /dev/null 2>&1 || :
-    fi
+    [ -x ${install_main_dir}/bin/taosk ] && ${csudo}ln -s ${install_main_dir}/bin/taosk ${bin_link_dir}/taosk > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosudf ] && ${csudo}ln -s ${install_main_dir}/bin/taosudf ${bin_link_dir}/taosudf > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosmqtt ] && ${csudo}ln -s ${install_main_dir}/bin/taosmqtt ${bin_link_dir}/taosmqtt > /dev/null 2>&1 || :
     [ -x ${install_main_dir}/bin/taosdump ] && ${csudo}ln -s ${install_main_dir}/bin/taosdump ${bin_link_dir}/taosdump > /dev/null 2>&1 || :

--- a/packaging/tools/post.sh
+++ b/packaging/tools/post.sh
@@ -74,21 +74,6 @@ if command -v sudo > /dev/null; then
     csudouser="sudo -u ${USER} "
 fi
 
-function is_taosk_supported_platform() {
-  if [ "$osType" != "Linux" ]; then
-    return 1
-  fi
-
-  case "$(uname -m)" in
-    x86_64|amd64|aarch64|arm64)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
 initd_mod=0
 service_mod=2
 if ps aux | grep -v grep | grep systemd &> /dev/null; then
@@ -283,10 +268,8 @@ function install_bin() {
     if [ -x ${bin_dir}/taosd ]; then
       ${csudo}ln -s ${bin_dir}/taosd ${bin_link_dir}/taosd                   2>>${install_log_path} || return 1
     fi
-    if is_taosk_supported_platform; then
-      if [ -x ${bin_dir}/taosk ]; then
-        ${csudo}ln -s ${bin_dir}/taosk ${bin_link_dir}/taosk                   2>>${install_log_path} || return 1
-      fi
+    if [ -x ${bin_dir}/taosk ]; then
+      ${csudo}ln -s ${bin_dir}/taosk ${bin_link_dir}/taosk                   2>>${install_log_path} || return 1
     fi
     if [ -x ${bin_dir}/taosudf ]; then
       ${csudo}ln -s ${bin_dir}/taosudf ${bin_link_dir}/taosudf                     2>>${install_log_path} || return 1

--- a/packaging/tools/post.sh
+++ b/packaging/tools/post.sh
@@ -74,6 +74,21 @@ if command -v sudo > /dev/null; then
     csudouser="sudo -u ${USER} "
 fi
 
+function is_taosk_supported_platform() {
+  if [ "$osType" != "Linux" ]; then
+    return 1
+  fi
+
+  case "$(uname -m)" in
+    x86_64|amd64|aarch64|arm64)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 initd_mod=0
 service_mod=2
 if ps aux | grep -v grep | grep systemd &> /dev/null; then
@@ -268,8 +283,10 @@ function install_bin() {
     if [ -x ${bin_dir}/taosd ]; then
       ${csudo}ln -s ${bin_dir}/taosd ${bin_link_dir}/taosd                   2>>${install_log_path} || return 1
     fi
-    if [ -x ${bin_dir}/taosk ]; then
-      ${csudo}ln -s ${bin_dir}/taosk ${bin_link_dir}/taosk                   2>>${install_log_path} || return 1
+    if is_taosk_supported_platform; then
+      if [ -x ${bin_dir}/taosk ]; then
+        ${csudo}ln -s ${bin_dir}/taosk ${bin_link_dir}/taosk                   2>>${install_log_path} || return 1
+      fi
     fi
     if [ -x ${bin_dir}/taosudf ]; then
       ${csudo}ln -s ${bin_dir}/taosudf ${bin_link_dir}/taosudf                     2>>${install_log_path} || return 1

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -32,21 +32,6 @@ taosk_name="${PREFIX}k"
 xnode_name="xnoded"
 productName="TDengine TSDB"
 
-function is_taosk_supported_platform() {
-  if [ "$osType" != "Linux" ]; then
-    return 1
-  fi
-
-  case "$(uname -m)" in
-    x86_64|amd64|aarch64|arm64)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
 function usage() {
   echo -e "\nUsage: $(basename $0) [-e <yes|no>] [-d <install_dir>]"
   echo "-e: silent mode, specify whether to remove all the data, log and configuration files."
@@ -193,10 +178,6 @@ else
   services=("${serverName}" "${adapterName}" "${keeperName}" "${explorerName}")
 fi
 
-if [ "${verMode}" == "cluster" ] && is_taosk_supported_platform; then
-  tools+=("${taosk_name}")
-fi
-
 initd_mod=0
 service_mod=2
 if ps aux | grep -v grep | grep systemd &>/dev/null; then
@@ -301,10 +282,7 @@ remove_tools_of() {
 }
 
 remove_bin() {
-  case " ${tools[*]} " in
-    *" ${taosk_name} "*) ;;
-    *) remove_tools_of "${taosk_name}" ;;
-  esac
+  remove_tools_of "${taosk_name}"
 
   for _service in "${services[@]}"; do
     if [ -z "$_service" ]; then

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -172,7 +172,7 @@ if [ "${verMode}" == "cluster" ]; then
   else
     services=("${serverName}" "${adapterName}" "${keeperName}" "${explorerName}")
   fi
-  tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${inspect_name}" "${PREFIX}udf" "${mqtt_name}" "${xnode_name}" "set_core.sh" "TDinsight.sh" "$uninstallScript" "start-all.sh" "stop-all.sh" "${taosgen_name}" "startPre.sh" "uninstall_taosx.sh")
+  tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${inspect_name}" "${PREFIX}udf" "${mqtt_name}" "${xnode_name}" "set_core.sh" "TDinsight.sh" "$uninstallScript" "start-all.sh" "stop-all.sh" "${taosgen_name}" "${taosk_name}" "startPre.sh" "uninstall_taosx.sh")
 else
   tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${PREFIX}udf" "${mqtt_name}" "${xnode_name}" "set_core.sh" "TDinsight.sh" "$uninstallScript" "start-all.sh" "stop-all.sh" "${taosgen_name}" "startPre.sh")
   services=("${serverName}" "${adapterName}" "${keeperName}" "${explorerName}")
@@ -282,8 +282,6 @@ remove_tools_of() {
 }
 
 remove_bin() {
-  remove_tools_of "${taosk_name}"
-
   for _service in "${services[@]}"; do
     if [ -z "$_service" ]; then
       continue

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -167,11 +167,7 @@ plugins_dir="${installDir}/plugins"
 share_dir="${installDir}/share"
 
 if [ "${verMode}" == "cluster" ]; then
-  if [ "${entMode}" == "full" ]; then
-    services=("${serverName}" "${adapterName}" "${keeperName}" "${xName}" "${explorerName}")
-  else
-    services=("${serverName}" "${adapterName}" "${keeperName}" "${explorerName}")
-  fi
+  services=("${serverName}" "${adapterName}" "${keeperName}" "${xName}" "${explorerName}")
   tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${inspect_name}" "${PREFIX}udf" "${mqtt_name}" "${xnode_name}" "set_core.sh" "TDinsight.sh" "$uninstallScript" "start-all.sh" "stop-all.sh" "${taosgen_name}" "${taosk_name}" "startPre.sh" "uninstall_taosx.sh")
 else
   tools=("${clientName}" "${benchmarkName}" "${dumpName}" "${demoName}" "${PREFIX}udf" "${mqtt_name}" "${xnode_name}" "set_core.sh" "TDinsight.sh" "$uninstallScript" "start-all.sh" "stop-all.sh" "${taosgen_name}" "startPre.sh")

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -301,7 +301,10 @@ remove_tools_of() {
 }
 
 remove_bin() {
-  remove_tools_of "${taosk_name}"
+  case " ${tools[*]} " in
+    *" ${taosk_name} "*) ;;
+    *) remove_tools_of "${taosk_name}" ;;
+  esac
 
   for _service in "${services[@]}"; do
     if [ -z "$_service" ]; then

--- a/packaging/tools/remove.sh
+++ b/packaging/tools/remove.sh
@@ -28,8 +28,24 @@ inspect_name="${PREFIX}inspect"
 tarbitratorName="tarbitratord"
 mqtt_name="${PREFIX}mqtt"
 taosgen_name="${PREFIX}gen"
+taosk_name="${PREFIX}k"
 xnode_name="xnoded"
 productName="TDengine TSDB"
+
+function is_taosk_supported_platform() {
+  if [ "$osType" != "Linux" ]; then
+    return 1
+  fi
+
+  case "$(uname -m)" in
+    x86_64|amd64|aarch64|arm64)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
 
 function usage() {
   echo -e "\nUsage: $(basename $0) [-e <yes|no>] [-d <install_dir>]"
@@ -177,6 +193,10 @@ else
   services=("${serverName}" "${adapterName}" "${keeperName}" "${explorerName}")
 fi
 
+if [ "${verMode}" == "cluster" ] && is_taosk_supported_platform; then
+  tools+=("${taosk_name}")
+fi
+
 initd_mod=0
 service_mod=2
 if ps aux | grep -v grep | grep systemd &>/dev/null; then
@@ -281,6 +301,8 @@ remove_tools_of() {
 }
 
 remove_bin() {
+  remove_tools_of "${taosk_name}"
+
   for _service in "${services[@]}"; do
     if [ -z "$_service" ]; then
       continue


### PR DESCRIPTION
## Summary
- expose taosk in system paths only for enterprise server installs
- limit taosk system exposure to Linux x86_64/amd64/aarch64/arm64
- keep client, Windows, and macOS install paths unchanged
- align install and cleanup behavior across tar install, make install, rpm/deb post-install, and uninstall scripts

## Validation
- bash -n packaging/tools/install.sh
- bash -n packaging/tools/remove.sh
- bash -n packaging/tools/make_install.sh
- bash -n packaging/tools/post.sh

## Notes
- addressed review concerns around platform gating, cross-entrypoint consistency, and stale symlink cleanup