### PR TITLE
feat(stream): support external window join subqueries

### DIFF
--- a/source/libs/parser/test/parStreamTest.cpp
+++ b/source/libs/parser/test/parStreamTest.cpp
@@ -1,19 +1,20 @@
 /*
-* Copyright (c) 2019 TAOS Data, Inc. <jhtao@taosdata.com>
-*
-* This program is free software: you can use, redistribute, and/or modify
-* it under the terms of the GNU Affero General Public License, version 3
-* or later ("AGPL"), AS published by the Free Software Foundation.
-*
-* This program is distributed in the hope that it will be useful, but WITHOUT
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-* FITNESS FOR A PARTICULAR PURPOSE.
-*
-* You should have received a copy of the GNU Affero General Public License
-* along with this program. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * Copyright (c) 2019 TAOS Data, Inc. <jhtao@taosdata.com>
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), AS published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include <fstream>
+#include <memory>
 
 #include "cJSON.h"
 #include "mockCatalogService.h"
@@ -56,7 +57,7 @@ static const SExternalWindowPhysiNode* pstFindExternalWindowNode(const SQueryPla
     SNodeListNode* pLevel = (SNodeListNode*)pLevelNode;
     SNode*         pSubplanNode = nullptr;
     FOREACH(pSubplanNode, pLevel->pNodeList) {
-      const SSubplan* pSubplan = (const SSubplan*)pSubplanNode;
+      const SSubplan*                 pSubplan = (const SSubplan*)pSubplanNode;
       const SExternalWindowPhysiNode* pExternal = pstFindExternalWindowNode(pSubplan->pNode);
       if (nullptr != pExternal) {
         return pExternal;
@@ -65,6 +66,142 @@ static const SExternalWindowPhysiNode* pstFindExternalWindowNode(const SQueryPla
   }
 
   return nullptr;
+}
+
+static int32_t pstCountExternalWindowNodes(const SPhysiNode* pNode) {
+  if (nullptr == pNode) {
+    return 0;
+  }
+
+  int32_t count = (QUERY_NODE_PHYSICAL_PLAN_HASH_EXTERNAL == nodeType((const SNode*)pNode) ||
+                   QUERY_NODE_PHYSICAL_PLAN_MERGE_ALIGNED_EXTERNAL == nodeType((const SNode*)pNode))
+                      ? 1
+                      : 0;
+
+  SNode* pChild = nullptr;
+  FOREACH(pChild, pNode->pChildren) { count += pstCountExternalWindowNodes((const SPhysiNode*)pChild); }
+
+  return count;
+}
+
+static int32_t pstCountExternalWindowNodes(const SQueryPlan* pPlan) {
+  if (nullptr == pPlan) {
+    return 0;
+  }
+
+  int32_t count = 0;
+  SNode*  pLevelNode = nullptr;
+  FOREACH(pLevelNode, pPlan->pSubplans) {
+    SNodeListNode* pLevel = (SNodeListNode*)pLevelNode;
+    SNode*         pSubplanNode = nullptr;
+    FOREACH(pSubplanNode, pLevel->pNodeList) {
+      const SSubplan* pSubplan = (const SSubplan*)pSubplanNode;
+      count += pstCountExternalWindowNodes(pSubplan->pNode);
+    }
+  }
+
+  return count;
+}
+
+static int32_t pstCountExternalWindowNodesNeedCalcTimeRange(const SPhysiNode* pNode) {
+  if (nullptr == pNode) {
+    return 0;
+  }
+
+  int32_t count =
+      ((QUERY_NODE_PHYSICAL_PLAN_HASH_EXTERNAL == nodeType((const SNode*)pNode) ||
+        QUERY_NODE_PHYSICAL_PLAN_MERGE_ALIGNED_EXTERNAL == nodeType((const SNode*)pNode)) &&
+       ((const SExternalWindowPhysiNode*)pNode)->pTimeRange != nullptr &&
+       ((const STimeRangeNode*)((const SExternalWindowPhysiNode*)pNode)->pTimeRange)->needCalc)
+          ? 1
+          : 0;
+
+  SNode* pChild = nullptr;
+  FOREACH(pChild, pNode->pChildren) { count += pstCountExternalWindowNodesNeedCalcTimeRange((const SPhysiNode*)pChild); }
+
+  return count;
+}
+
+static int32_t pstCountExternalWindowNodesNeedCalcTimeRange(const SQueryPlan* pPlan) {
+  if (nullptr == pPlan) {
+    return 0;
+  }
+
+  int32_t count = 0;
+  SNode*  pLevelNode = nullptr;
+  FOREACH(pLevelNode, pPlan->pSubplans) {
+    SNodeListNode* pLevel = (SNodeListNode*)pLevelNode;
+    SNode*         pSubplanNode = nullptr;
+    FOREACH(pSubplanNode, pLevel->pNodeList) {
+      const SSubplan* pSubplan = (const SSubplan*)pSubplanNode;
+      count += pstCountExternalWindowNodesNeedCalcTimeRange(pSubplan->pNode);
+    }
+  }
+
+  return count;
+}
+
+static void pstCheckCalcPlanExternalWindowCount(const SQuery* pQuery, ParserStage stage, int32_t expectedCount) {
+  ASSERT_EQ(stage, PARSER_STAGE_TRANSLATE);
+  ASSERT_EQ(nodeType(pQuery->pRoot), QUERY_NODE_CREATE_STREAM_STMT);
+
+  SCMCreateStreamReq req = {0};
+  ASSERT_EQ(TSDB_CODE_SUCCESS, tDeserializeSCMCreateStreamReq(pQuery->pCmdMsg->pMsg, pQuery->pCmdMsg->msgLen, &req));
+  unique_ptr<SCMCreateStreamReq, decltype(&tFreeSCMCreateStreamReq)> reqGuard(&req, tFreeSCMCreateStreamReq);
+  ASSERT_NE(req.calcPlan, nullptr);
+
+  SNode* pPlanNode = nullptr;
+  ASSERT_EQ(TSDB_CODE_SUCCESS, nodesStringToNode((char*)req.calcPlan, &pPlanNode));
+  unique_ptr<SNode, decltype(&nodesDestroyNode)> planGuard(pPlanNode, nodesDestroyNode);
+  ASSERT_NE(pPlanNode, nullptr);
+
+  int32_t count = pstCountExternalWindowNodes((const SQueryPlan*)pPlanNode);
+  EXPECT_EQ(count, expectedCount);
+}
+
+static void pstCheckCalcPlanExternalWindowNeedCalcTimeRangeCount(const SQuery* pQuery, ParserStage stage,
+                                                                 int32_t expectedCount) {
+  ASSERT_EQ(stage, PARSER_STAGE_TRANSLATE);
+  ASSERT_EQ(nodeType(pQuery->pRoot), QUERY_NODE_CREATE_STREAM_STMT);
+
+  SCMCreateStreamReq req = {0};
+  ASSERT_EQ(TSDB_CODE_SUCCESS, tDeserializeSCMCreateStreamReq(pQuery->pCmdMsg->pMsg, pQuery->pCmdMsg->msgLen, &req));
+  unique_ptr<SCMCreateStreamReq, decltype(&tFreeSCMCreateStreamReq)> reqGuard(&req, tFreeSCMCreateStreamReq);
+  ASSERT_NE(req.calcPlan, nullptr);
+
+  SNode* pPlanNode = nullptr;
+  ASSERT_EQ(TSDB_CODE_SUCCESS, nodesStringToNode((char*)req.calcPlan, &pPlanNode));
+  unique_ptr<SNode, decltype(&nodesDestroyNode)> planGuard(pPlanNode, nodesDestroyNode);
+  ASSERT_NE(pPlanNode, nullptr);
+
+  int32_t count = pstCountExternalWindowNodesNeedCalcTimeRange((const SQueryPlan*)pPlanNode);
+  EXPECT_EQ(count, expectedCount);
+}
+
+static const SSelectStmt* pstGetCreateStreamSelect(const SQuery* pQuery, ParserStage stage) {
+  EXPECT_EQ(stage, PARSER_STAGE_TRANSLATE);
+  EXPECT_EQ(nodeType(pQuery->pRoot), QUERY_NODE_CREATE_STREAM_STMT);
+
+  const SCreateStreamStmt* pStmt = (const SCreateStreamStmt*)pQuery->pRoot;
+  EXPECT_NE(pStmt->pQuery, nullptr);
+  EXPECT_EQ(nodeType(pStmt->pQuery), QUERY_NODE_SELECT_STMT);
+  return (const SSelectStmt*)pStmt->pQuery;
+}
+
+static void pstCheckCreateStreamSelectTimeRange(const SQuery* pQuery, ParserStage stage, bool expectedPresent,
+                                                bool expectedNeedCalc = false) {
+  const SSelectStmt* pSelect = pstGetCreateStreamSelect(pQuery, stage);
+  ASSERT_NE(pSelect, nullptr);
+
+  if (!expectedPresent) {
+    EXPECT_EQ(pSelect->pTimeRange, nullptr);
+    return;
+  }
+
+  ASSERT_NE(pSelect->pTimeRange, nullptr);
+  ASSERT_EQ(nodeType(pSelect->pTimeRange), QUERY_NODE_TIME_RANGE);
+  const STimeRangeNode* pTimeRange = (const STimeRangeNode*)pSelect->pTimeRange;
+  EXPECT_EQ(pTimeRange->needCalc, expectedNeedCalc);
 }
 
 /*
@@ -1728,15 +1865,172 @@ TEST_F(ParserStreamTest, TestQueryFromPartTbnamePlaceholder) {
       "from %%tbname where ts >= _twstart and ts < _twstart + 5m");
 }
 
+TEST_F(ParserStreamTest, TestStreamExternalWindowInnerJoinAggSubqueries) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc(
+      [&](const SQuery* pQuery, ParserStage stage) { pstCheckCalcPlanExternalWindowCount(pQuery, stage, 3); });
+
+  run("create stream stream_streamdb.s1 interval(1s) sliding(1s) from stream_triggerdb.stream_t1 "
+      "into stream_outdb.stream_out as select a.ts, a.cnt, b.minv from "
+      "(select _twstart ts, count(*) cnt from stream_querydb.stream_t1 where ts >= _twstart and ts < _twend) a "
+      "join "
+      "(select _twstart ts, min(c1) minv from stream_querydb.stream_t2 where ts >= _twstart and ts < _twend) b "
+      "on a.ts = b.ts");
+}
+
+TEST_F(ParserStreamTest, TestStreamExternalWindowInnerJoinAggSubqueriesByTwend) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc([&](const SQuery* pQuery, ParserStage stage) {
+    pstCheckCalcPlanExternalWindowCount(pQuery, stage, 3);
+    pstCheckCalcPlanExternalWindowNeedCalcTimeRangeCount(pQuery, stage, 1);
+  });
+
+  run("create stream stream_streamdb.s1 interval(1s) sliding(1s) from stream_triggerdb.stream_t1 "
+      "into stream_outdb.stream_out as select a.te, a.cnt, b.minv from "
+      "(select _twend te, count(*) cnt from stream_querydb.stream_t1 where ts >= _twstart and ts < _twend) a "
+      "join "
+      "(select _twend te, min(c1) minv from stream_querydb.stream_t2 where ts >= _twstart and ts < _twend) b "
+      "on a.te = b.te");
+}
+
+TEST_F(ParserStreamTest, TestStreamExternalWindowInnerJoinAggSubqueriesByTwendAddsOuterTimeRange) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc(
+      [&](const SQuery* pQuery, ParserStage stage) { pstCheckCreateStreamSelectTimeRange(pQuery, stage, true, true); });
+
+  run("create stream stream_streamdb.s1 interval(1s) sliding(1s) from stream_triggerdb.stream_t1 "
+      "into stream_outdb.stream_out as select a.te, a.cnt, b.minv from "
+      "(select _twend te, count(*) cnt from stream_querydb.stream_t1 where ts >= _twstart and ts < _twend) a "
+      "join "
+      "(select _twend te, min(c1) minv from stream_querydb.stream_t2 where ts >= _twstart and ts < _twend) b "
+      "on a.te = b.te");
+}
+
+TEST_F(ParserStreamTest, TestStreamExternalWindowLeftJoinAggSubqueriesDisabled) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc(
+      [&](const SQuery* pQuery, ParserStage stage) { pstCheckCalcPlanExternalWindowCount(pQuery, stage, 0); });
+
+  run("create stream stream_streamdb.s1 interval(1s) sliding(1s) from stream_triggerdb.stream_t1 "
+      "into stream_outdb.stream_out as select a.ts, a.cnt, b.minv from "
+      "(select _twstart ts, count(*) cnt from stream_querydb.stream_t1 where ts >= _twstart and ts < _twend) a "
+      "left join "
+      "(select _twstart ts, min(c1) minv from stream_querydb.stream_t2 where ts >= _twstart and ts < _twend) b "
+      "on a.ts = b.ts");
+}
+
+TEST_F(ParserStreamTest, TestStreamExternalWindowThreeInnerJoinAggSubqueries) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc(
+      [&](const SQuery* pQuery, ParserStage stage) { pstCheckCalcPlanExternalWindowCount(pQuery, stage, 4); });
+
+  run("create stream stream_streamdb.s1 interval(1s) sliding(1s) from stream_triggerdb.stream_t1 "
+      "into stream_outdb.stream_out as select a.ts, a.cnt, b.minv, c.maxv from "
+      "(select _twstart ts, count(*) cnt from stream_querydb.stream_t1 where ts >= _twstart and ts < _twend) a "
+      "join "
+      "(select _twstart ts, min(c1) minv from stream_querydb.stream_t2 where ts >= _twstart and ts < _twend) b "
+      "on a.ts = b.ts "
+      "join "
+      "(select _twstart ts, max(c1) maxv from stream_querydb.stream_t1 where ts >= _twstart and ts < _twend) c "
+      "on b.ts = c.ts");
+}
+
+TEST_F(ParserStreamTest, TestStreamExternalWindowInnerJoinNonWindowKeyDisabled) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc(
+      [&](const SQuery* pQuery, ParserStage stage) { pstCheckCalcPlanExternalWindowCount(pQuery, stage, 0); });
+
+  run("create stream stream_streamdb.s1 interval(1s) sliding(1s) from stream_triggerdb.stream_t1 "
+      "into stream_outdb.stream_out as select a.ts, a.cnt, b.minv from "
+      "(select _twstart ts, count(*) cnt from stream_querydb.stream_t1 where ts >= _twstart and ts < _twend) a "
+      "join "
+      "(select _twstart ts, min(c1) minv from stream_querydb.stream_t2 where ts >= _twstart and ts < _twend) b "
+      "on a.ts = b.ts and a.cnt = b.minv");
+}
+
+TEST_F(ParserStreamTest, TestStreamExternalWindowInnerJoinParentLimitDisablesAll) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc(
+      [&](const SQuery* pQuery, ParserStage stage) { pstCheckCalcPlanExternalWindowCount(pQuery, stage, 0); });
+
+  run("create stream stream_streamdb.s1 interval(1s) sliding(1s) from stream_triggerdb.stream_t1 "
+      "into stream_outdb.stream_out as select a.ts, a.cnt, b.minv from "
+      "(select _twstart ts, count(*) cnt from stream_querydb.stream_t1 where ts >= _twstart and ts < _twend) a "
+      "join "
+      "(select _twstart ts, min(c1) minv from stream_querydb.stream_t2 where ts >= _twstart and ts < _twend) b "
+      "on a.ts = b.ts limit 10");
+}
+
+TEST_F(ParserStreamTest, TestStreamExternalWindowInnerJoinChildPlaceholderDisablesAll) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc(
+      [&](const SQuery* pQuery, ParserStage stage) { pstCheckCalcPlanExternalWindowCount(pQuery, stage, 0); });
+
+  run("create stream stream_streamdb.s1 interval(1s) sliding(1s) from stream_triggerdb.stream_t1 "
+      "into stream_outdb.stream_out as select a.ts, a.cnt, b.minv from "
+      "(select _twstart ts, count(*) cnt from stream_querydb.stream_t1 "
+      "where ts >= _twstart and ts < _twend and c1 > cast(_twstart as bigint)) a "
+      "join "
+      "(select _twstart ts, min(c1) minv from stream_querydb.stream_t2 where ts >= _twstart and ts < _twend) b "
+      "on a.ts = b.ts");
+}
+
+TEST_F(ParserStreamTest, TestStreamExternalWindowInnerJoinChildLimitKeepsOuterTimeRangeEmpty) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc([&](const SQuery* pQuery, ParserStage stage) {
+    pstCheckCalcPlanExternalWindowCount(pQuery, stage, 0);
+    pstCheckCreateStreamSelectTimeRange(pQuery, stage, false);
+  });
+
+  run("create stream stream_streamdb.s1 interval(1s) sliding(1s) from stream_triggerdb.stream_t1 "
+      "into stream_outdb.stream_out as select a.te, a.cnt, b.minv from "
+      "(select _twend te, count(*) cnt from stream_querydb.stream_t1 "
+      "where ts >= _twstart and ts < _twend limit 1) a "
+      "join "
+      "(select _twend te, min(c1) minv from stream_querydb.stream_t2 where ts >= _twstart and ts < _twend) b "
+      "on a.te = b.te");
+}
+
+TEST_F(ParserStreamTest, TestStreamExternalWindowInnerJoinBaseTableDisabled) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc(
+      [&](const SQuery* pQuery, ParserStage stage) { pstCheckCalcPlanExternalWindowCount(pQuery, stage, 0); });
+
+  run("create stream stream_streamdb.s1 interval(1s) sliding(1s) from stream_triggerdb.stream_t1 "
+      "into stream_outdb.stream_out as select a.ts, a.cnt, b.c1 from "
+      "(select _twstart ts, count(*) cnt from stream_querydb.stream_t1 where ts >= _twstart and ts < _twend) a "
+      "join stream_querydb.stream_t2 b on a.ts = b.ts");
+}
+
 TEST_F(ParserStreamTest, TestOutTagExprSpecialCases) {
   setAsyncFlag("-1");
   useDb("root", "testus");
 
-  ITableBuilder& builder = g_mockCatalogService->createTableBuilder("stream_triggerdb", "stn_tag_precision",
-                                                                    TSDB_SUPER_TABLE, 1, 1)
-                               .setPrecision(TSDB_TIME_PRECISION_NANO)
-                               .addColumn("ts", TSDB_DATA_TYPE_TIMESTAMP)
-                               .addTag("tag1", TSDB_DATA_TYPE_TIMESTAMP);
+  ITableBuilder& builder =
+      g_mockCatalogService->createTableBuilder("stream_triggerdb", "stn_tag_precision", TSDB_SUPER_TABLE, 1, 1)
+          .setPrecision(TSDB_TIME_PRECISION_NANO)
+          .addColumn("ts", TSDB_DATA_TYPE_TIMESTAMP)
+          .addTag("tag1", TSDB_DATA_TYPE_TIMESTAMP);
   builder.done();
   g_mockCatalogService->createSubTable("stream_triggerdb", "stn_tag_precision", "stn_tag_precision_s1", 2);
 

--- a/source/libs/parser/test/parTestUtil.cpp
+++ b/source/libs/parser/test/parTestUtil.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <array>
+#include <mutex>
 #include <thread>
 
 #include "catalog.h"
@@ -63,6 +64,14 @@ void setLogLevel(const char* pLogLevel) { g_logLevel = stoi(pLogLevel); }
 
 int32_t getLogLevel() { return g_logLevel; }
 
+static void initKeywordsTableOnce() {
+  static once_flag once;
+  call_once(once, []() {
+    int32_t code = qInitKeywordsTable();
+    TD_ALWAYS_ASSERT(TSDB_CODE_SUCCESS == code);
+  });
+}
+
 // Dummy catalog object for parser tests. Never dereferenced; only checked for NULL.
 static struct {
   char dummy;  // minimal non-empty struct to avoid UB
@@ -71,8 +80,7 @@ static struct {
 class ParserTestBaseImpl {
  public:
   ParserTestBaseImpl(ParserTestBase* pBase) : pBase_(pBase), sqlNo_(0), sqlNum_(0) {
-    int32_t code = qInitKeywordsTable();
-    TD_ALWAYS_ASSERT(TSDB_CODE_SUCCESS == code);
+    initKeywordsTableOnce();
     caseEnv_.numOfSkipSql_ = g_skipSql;
     caseEnv_.numOfLimitSql_ = g_limitSql;
   }

--- a/source/libs/planner/src/planLogicCreater.c
+++ b/source/libs/planner/src/planLogicCreater.c
@@ -32,7 +32,8 @@ typedef struct SLogicPlanContext {
   SPlanContext* pPlanCxt;
   SLogicNode*   pCurrRoot;
   SSHashObj*    pChildTables;
-  bool          containsOuterJoin;
+  bool          streamExtWindowTreeChecked;
+  bool          streamExtWindowTreeEnabled;
 } SLogicPlanContext;
 
 typedef int32_t (*FCreateLogicNode)(SLogicPlanContext*, void*, SLogicNode**);
@@ -740,6 +741,180 @@ int32_t collectJoinResColumns(SSelectStmt* pSelect, SJoinLogicNode* pJoin, SNode
   tSimpleHashCleanup(pTables);
 
   return code;
+}
+
+typedef enum EStreamExtJoinKey {
+  STREAM_EXT_JOIN_KEY_NONE = 0,
+  STREAM_EXT_JOIN_KEY_TWSTART,
+  STREAM_EXT_JOIN_KEY_TWEND,
+} EStreamExtJoinKey;
+
+static bool streamExtJoinSourceIsSafe(SNode* pTable);
+static bool streamExtJoinTableIsSafe(SJoinTableNode* pJoinTable);
+static EStreamExtJoinKey streamExtJoinTableKeyType(SJoinTableNode* pJoinTable);
+
+static bool streamExtJoinExprNameMatches(const SExprNode* pExpr, const char* pColName) {
+  if (NULL == pExpr || NULL == pColName) {
+    return false;
+  }
+
+  return ('\0' != pExpr->aliasName[0] && 0 == strcasecmp(pExpr->aliasName, pColName)) ||
+         ('\0' != pExpr->userAlias[0] && 0 == strcasecmp(pExpr->userAlias, pColName));
+}
+
+static EStreamExtJoinKey streamExtJoinExprKeyType(SNode* pNode) {
+  if (NULL == pNode) {
+    return STREAM_EXT_JOIN_KEY_NONE;
+  }
+
+  if (QUERY_NODE_FUNCTION == nodeType(pNode)) {
+    SFunctionNode* pFunc = (SFunctionNode*)pNode;
+    if (FUNCTION_TYPE_TWSTART == pFunc->funcType) {
+      return STREAM_EXT_JOIN_KEY_TWSTART;
+    }
+    if (FUNCTION_TYPE_TWEND == pFunc->funcType) {
+      return STREAM_EXT_JOIN_KEY_TWEND;
+    }
+  } else if (QUERY_NODE_COLUMN == nodeType(pNode)) {
+    SColumnNode* pCol = (SColumnNode*)pNode;
+    if (COLUMN_TYPE_WINDOW_START == pCol->colType) {
+      return STREAM_EXT_JOIN_KEY_TWSTART;
+    }
+    if (COLUMN_TYPE_WINDOW_END == pCol->colType) {
+      return STREAM_EXT_JOIN_KEY_TWEND;
+    }
+  }
+
+  return STREAM_EXT_JOIN_KEY_NONE;
+}
+
+static EStreamExtJoinKey streamExtJoinGetProjectedKey(SSelectStmt* pSelect, const char* pColName) {
+  if (NULL == pSelect || NULL == pColName) {
+    return STREAM_EXT_JOIN_KEY_NONE;
+  }
+
+  SNode* pProj = NULL;
+  FOREACH(pProj, pSelect->pProjectionList) {
+    if (streamExtJoinExprNameMatches((SExprNode*)pProj, pColName)) {
+      return streamExtJoinExprKeyType(pProj);
+    }
+  }
+
+  return STREAM_EXT_JOIN_KEY_NONE;
+}
+
+static bool streamExtJoinSubquerySourceIsSupported(STempTableNode* pTable) {
+  if (NULL == pTable || NULL == pTable->pSubquery || QUERY_NODE_SELECT_STMT != nodeType(pTable->pSubquery)) {
+    return false;
+  }
+
+  SSelectStmt* pSelect = (SSelectStmt*)pTable->pSubquery;
+  return pSelect->hasAggFuncs && !pSelect->joinContains && NULL != pSelect->pFromTable;
+}
+
+static EStreamExtJoinKey streamExtJoinFindKeyInSource(SNode* pTable, const SColumnNode* pCol) {
+  if (NULL == pTable || NULL == pCol) {
+    return STREAM_EXT_JOIN_KEY_NONE;
+  }
+
+  switch (nodeType(pTable)) {
+    case QUERY_NODE_TEMP_TABLE: {
+      STempTableNode* pTemp = (STempTableNode*)pTable;
+      if (!streamExtJoinSubquerySourceIsSupported(pTemp) || 0 != strcasecmp(pTemp->table.tableAlias, pCol->tableAlias)) {
+        return STREAM_EXT_JOIN_KEY_NONE;
+      }
+      return streamExtJoinGetProjectedKey((SSelectStmt*)pTemp->pSubquery, pCol->colName);
+    }
+    case QUERY_NODE_JOIN_TABLE: {
+      SJoinTableNode*   pJoin = (SJoinTableNode*)pTable;
+      EStreamExtJoinKey key = streamExtJoinFindKeyInSource(pJoin->pLeft, pCol);
+      if (STREAM_EXT_JOIN_KEY_NONE != key) {
+        return key;
+      }
+      return streamExtJoinFindKeyInSource(pJoin->pRight, pCol);
+    }
+    default:
+      return STREAM_EXT_JOIN_KEY_NONE;
+  }
+}
+
+static EStreamExtJoinKey streamExtJoinEqCondKeyType(SJoinTableNode* pJoinTable, SOperatorNode* pOp) {
+  if (NULL == pJoinTable || NULL == pOp || OP_TYPE_EQUAL != pOp->opType || QUERY_NODE_COLUMN != nodeType(pOp->pLeft) ||
+      QUERY_NODE_COLUMN != nodeType(pOp->pRight)) {
+    return STREAM_EXT_JOIN_KEY_NONE;
+  }
+
+  SColumnNode*      pLeftCol = (SColumnNode*)pOp->pLeft;
+  SColumnNode*      pRightCol = (SColumnNode*)pOp->pRight;
+  EStreamExtJoinKey leftKey = streamExtJoinFindKeyInSource(pJoinTable->pLeft, pLeftCol);
+  EStreamExtJoinKey rightKey = streamExtJoinFindKeyInSource(pJoinTable->pRight, pRightCol);
+  if (STREAM_EXT_JOIN_KEY_NONE != leftKey && leftKey == rightKey) {
+    return leftKey;
+  }
+
+  leftKey = streamExtJoinFindKeyInSource(pJoinTable->pRight, pLeftCol);
+  rightKey = streamExtJoinFindKeyInSource(pJoinTable->pLeft, pRightCol);
+  return STREAM_EXT_JOIN_KEY_NONE != leftKey && leftKey == rightKey ? leftKey : STREAM_EXT_JOIN_KEY_NONE;
+}
+
+static EStreamExtJoinKey streamExtJoinOnCondKeyType(SJoinTableNode* pJoinTable, SNode* pCond) {
+  if (NULL == pCond) {
+    return STREAM_EXT_JOIN_KEY_NONE;
+  }
+
+  if (QUERY_NODE_OPERATOR == nodeType(pCond)) {
+    return streamExtJoinEqCondKeyType(pJoinTable, (SOperatorNode*)pCond);
+  }
+
+  if (QUERY_NODE_LOGIC_CONDITION != nodeType(pCond)) {
+    return STREAM_EXT_JOIN_KEY_NONE;
+  }
+
+  SLogicConditionNode* pLogicCond = (SLogicConditionNode*)pCond;
+  if (LOGIC_COND_TYPE_AND != pLogicCond->condType || 0 == LIST_LENGTH(pLogicCond->pParameterList)) {
+    return STREAM_EXT_JOIN_KEY_NONE;
+  }
+
+  EStreamExtJoinKey joinKey = STREAM_EXT_JOIN_KEY_NONE;
+  SNode* pParam = NULL;
+  FOREACH(pParam, pLogicCond->pParameterList) {
+    EStreamExtJoinKey paramKey = streamExtJoinOnCondKeyType(pJoinTable, pParam);
+    if (STREAM_EXT_JOIN_KEY_NONE == paramKey ||
+        (STREAM_EXT_JOIN_KEY_NONE != joinKey && joinKey != paramKey)) {
+      return STREAM_EXT_JOIN_KEY_NONE;
+    }
+    joinKey = paramKey;
+  }
+
+  return joinKey;
+}
+
+static bool streamExtJoinSourceIsSafe(SNode* pTable) {
+  if (NULL == pTable) {
+    return false;
+  }
+
+  switch (nodeType(pTable)) {
+    case QUERY_NODE_TEMP_TABLE:
+      return streamExtJoinSubquerySourceIsSupported((STempTableNode*)pTable);
+    case QUERY_NODE_JOIN_TABLE:
+      return streamExtJoinTableIsSafe((SJoinTableNode*)pTable);
+    default:
+      return false;
+  }
+}
+
+static bool streamExtJoinTableIsSafe(SJoinTableNode* pJoinTable) {
+  return STREAM_EXT_JOIN_KEY_NONE != streamExtJoinTableKeyType(pJoinTable);
+}
+
+static EStreamExtJoinKey streamExtJoinTableKeyType(SJoinTableNode* pJoinTable) {
+  if (NULL == pJoinTable || JOIN_TYPE_INNER != pJoinTable->joinType || JOIN_STYPE_NONE != pJoinTable->subType ||
+      !streamExtJoinSourceIsSafe(pJoinTable->pLeft) || !streamExtJoinSourceIsSafe(pJoinTable->pRight)) {
+    return STREAM_EXT_JOIN_KEY_NONE;
+  }
+
+  return streamExtJoinOnCondKeyType(pJoinTable, pJoinTable->pOnCond);
 }
 
 static int32_t createJoinLogicNode(SLogicPlanContext* pCxt, SSelectStmt* pSelect, SJoinTableNode* pJoinTable,
@@ -2289,150 +2464,112 @@ static int32_t createWindowLogicNodeByAnomaly(SLogicPlanContext* pCxt, SAnomalyW
   return code;
 }
 
-static int32_t setColTableInfo(SNode* pFromTable, SColumnNode* pCol) {
-  if (NULL == pFromTable || NULL == pCol) {
-    return TSDB_CODE_SUCCESS;
+static int32_t makeStreamExtWindowTsCol(uint8_t precision, SNode** ppCol) {
+  SColumnNode* pCol = NULL;
+  int32_t      code = nodesMakeNode(QUERY_NODE_COLUMN, (SNode**)&pCol);
+  if (TSDB_CODE_SUCCESS != code || NULL == pCol) {
+    return code;
   }
 
-  // Default to a normal column
-  pCol->colType = COLUMN_TYPE_COLUMN;
-
-  switch (nodeType(pFromTable)) {
-    case QUERY_NODE_REAL_TABLE: {
-      SRealTableNode* pTable = (SRealTableNode*)pFromTable;
-      tstrncpy(pCol->dbName, pTable->table.dbName, TSDB_DB_NAME_LEN);
-      tstrncpy(pCol->tableName, pTable->table.tableName, TSDB_TABLE_NAME_LEN);
-      tstrncpy(pCol->tableAlias, pTable->table.tableAlias, TSDB_TABLE_NAME_LEN);
-      if (pTable->pMeta) {
-        pCol->tableId = pTable->pMeta->uid;
-        pCol->tableType = pTable->pMeta->tableType;
-      }
-      break;
-    }
-    case QUERY_NODE_VIRTUAL_TABLE: {
-      SVirtualTableNode* pTable = (SVirtualTableNode*)pFromTable;
-      tstrncpy(pCol->dbName, pTable->table.dbName, TSDB_DB_NAME_LEN);
-      tstrncpy(pCol->tableName, pTable->table.tableName, TSDB_TABLE_NAME_LEN);
-      tstrncpy(pCol->tableAlias, pTable->table.tableAlias, TSDB_TABLE_NAME_LEN);
-      if (pTable->pMeta) {
-        pCol->tableId = pTable->pMeta->uid;
-        pCol->tableType = pTable->pMeta->tableType;
-      }
-      break;
-    }
-    case QUERY_NODE_PLACE_HOLDER_TABLE: {
-      SPlaceHolderTableNode* pTable = (SPlaceHolderTableNode*)pFromTable;
-      tstrncpy(pCol->dbName, pTable->table.dbName, TSDB_DB_NAME_LEN);
-      tstrncpy(pCol->tableName, pTable->table.tableName, TSDB_TABLE_NAME_LEN);
-      tstrncpy(pCol->tableAlias, pTable->table.tableAlias, TSDB_TABLE_NAME_LEN);
-      if (pTable->pMeta) {
-        pCol->tableId = pTable->pMeta->uid;
-        pCol->tableType = pTable->pMeta->tableType;
-      }
-      break;
-    }
-    case QUERY_NODE_TEMP_TABLE: {
-      STempTableNode* pTable = (STempTableNode*)pFromTable;
-      tstrncpy(pCol->dbName, pTable->table.dbName, TSDB_DB_NAME_LEN);
-      tstrncpy(pCol->tableName, pTable->table.tableName, TSDB_TABLE_NAME_LEN);
-      tstrncpy(pCol->tableAlias, pTable->table.tableAlias, TSDB_TABLE_NAME_LEN);
-      // temp table may not have meta; leave tableId/tableType unset
-      break;
-    }
-    case QUERY_NODE_JOIN_TABLE: {
-      // External window does not apply to joins; minimal alias propagation
-      SJoinTableNode* pTable = (SJoinTableNode*)pFromTable;
-      tstrncpy(pCol->dbName, pTable->table.dbName, TSDB_DB_NAME_LEN);
-      tstrncpy(pCol->tableName, pTable->table.tableName, TSDB_TABLE_NAME_LEN);
-      tstrncpy(pCol->tableAlias, pTable->table.tableAlias, TSDB_TABLE_NAME_LEN);
-      break;
-    }
-    default: {
-      // Fallback: try to copy common table fields if layout matches STableNode
-      // No-op if not applicable
-      break;
-    }
-  }
-
+  pCol->colId = PRIMARYKEY_TIMESTAMP_COL_ID;
+  pCol->isPrimTs = true;
+  tstrncpy(pCol->colName, "_c0", TSDB_COL_NAME_LEN);
+  pCol->node.resType = (SDataType){.type = TSDB_DATA_TYPE_TIMESTAMP, .bytes = TSDB_KEYSIZE, .precision = precision};
+  *ppCol = (SNode*)pCol;
   return TSDB_CODE_SUCCESS;
 }
 
-// Helper: create a timestamp comparison operator with a placeholder function on the right
-static int32_t makeTsPlaceholderOp(SNode* pFromTable, EOperatorType opType, const char* funcName, const char* alias,
-                                   SOperatorNode** pOutOp) {
+static int32_t makeStreamExtWindowPseudoFunc(const char* pFuncName, int32_t funcType, int32_t funcId,
+                                             uint8_t precision, SNode** ppFunc) {
   int32_t        code = TSDB_CODE_SUCCESS;
   SFunctionNode* pFunc = NULL;
-  SOperatorNode* pOper = NULL;
+  SNode*         pParam = NULL;
+  bool           paramAppended = false;
 
-  code = nodesMakeNode(QUERY_NODE_FUNCTION, (SNode**)&pFunc);
-  if (TSDB_CODE_SUCCESS != code || NULL == pFunc) return code;
-  tstrncpy(pFunc->functionName, funcName, TSDB_FUNC_NAME_LEN);
-  tstrncpy(pFunc->node.userAlias, alias, TSDB_FUNC_NAME_LEN);
+  PLAN_ERR_JRET(nodesMakeNode(QUERY_NODE_FUNCTION, (SNode**)&pFunc));
+  tstrncpy(pFunc->functionName, pFuncName, TSDB_FUNC_NAME_LEN);
+  tstrncpy(pFunc->node.userAlias, pFuncName, TSDB_FUNC_NAME_LEN);
+  tstrncpy(pFunc->node.aliasName, pFuncName, TSDB_FUNC_NAME_LEN);
+  pFunc->funcType = funcType;
+  pFunc->funcId = funcId;
+  pFunc->node.resType = (SDataType){.type = TSDB_DATA_TYPE_TIMESTAMP, .bytes = TSDB_KEYSIZE, .precision = precision};
 
-  code = nodesMakeNode(QUERY_NODE_OPERATOR, (SNode**)&pOper);
-  if (TSDB_CODE_SUCCESS != code || NULL == pOper) {
-    nodesDestroyNode((SNode*)pFunc);
-    return code;
+  PLAN_ERR_JRET(nodesMakeValueNodeFromTimestamp(0, &pParam));
+  ((SValueNode*)pParam)->notReserved = true;
+  PLAN_ERR_JRET(nodesListMakePushFront(&pFunc->pParameterList, pParam));
+  paramAppended = true;
+
+  *ppFunc = (SNode*)pFunc;
+  return code;
+
+_return:
+  nodesDestroyNode((SNode*)pFunc);
+  if (!paramAppended) {
+    nodesDestroyNode(pParam);
   }
-
-  pOper->opType = opType;
-  code = nodesMakeNode(QUERY_NODE_COLUMN, (SNode**)&pOper->pLeft);
-  if (TSDB_CODE_SUCCESS != code || NULL == pOper->pLeft) {
-    nodesDestroyNode((SNode*)pOper);
-    nodesDestroyNode((SNode*)pFunc);
-    return code;
-  }
-  ((SColumnNode*)pOper->pLeft)->colId = PRIMARYKEY_TIMESTAMP_COL_ID;
-  ((SColumnNode*)pOper->pLeft)->isPrimTs = true;
-  snprintf(((SColumnNode*)pOper->pLeft)->colName, sizeof(((SColumnNode*)pOper->pLeft)->colName), "%s", "_c0");
-  setColTableInfo(pFromTable, (SColumnNode*)pOper->pLeft);
-
-
-  code = nodesCloneNode((SNode*)pFunc, &pOper->pRight);
-  nodesDestroyNode((SNode*)pFunc); // function node no longer needed after clone
-  if (TSDB_CODE_SUCCESS != code) {
-    nodesDestroyNode((SNode*)pOper);
-    return code;
-  }
-
-  *pOutOp = pOper;
-  return TSDB_CODE_SUCCESS;
+  return code;
 }
 
-static int32_t buildDefaultTimeRangeForExternalWindow(SLogicPlanContext* pCxt, SSelectStmt* pSelect) {
-  if (pSelect->pWindow == NULL || nodeType(pSelect->pWindow) != QUERY_NODE_EXTERNAL_WINDOW ||
-      pSelect->pTimeRange != NULL) {
+static int32_t makeStreamExtWindowTimeRangeOp(EOperatorType opType, const char* pFuncName, int32_t funcType,
+                                              int32_t funcId, uint8_t precision, SNode** ppOp) {
+  int32_t        code = TSDB_CODE_SUCCESS;
+  SOperatorNode* pOp = NULL;
+  SNode*         pTsCol = NULL;
+  SNode*         pFunc = NULL;
+
+  PLAN_ERR_JRET(nodesMakeNode(QUERY_NODE_OPERATOR, (SNode**)&pOp));
+  pOp->opType = opType;
+  pOp->node.resType = (SDataType){.type = TSDB_DATA_TYPE_BOOL, .bytes = sizeof(bool), .precision = precision};
+
+  PLAN_ERR_JRET(makeStreamExtWindowTsCol(precision, &pTsCol));
+  PLAN_ERR_JRET(makeStreamExtWindowPseudoFunc(pFuncName, funcType, funcId, precision, &pFunc));
+  pOp->pLeft = pTsCol;
+  pOp->pRight = pFunc;
+  pTsCol = NULL;
+  pFunc = NULL;
+
+  *ppOp = (SNode*)pOp;
+  return code;
+
+_return:
+  nodesDestroyNode((SNode*)pOp);
+  nodesDestroyNode(pTsCol);
+  nodesDestroyNode(pFunc);
+  return code;
+}
+
+static int32_t buildStreamExtJoinTwendTimeRange(SSelectStmt* pSelect) {
+  if (NULL == pSelect || NULL == pSelect->pFromTable || QUERY_NODE_JOIN_TABLE != nodeType(pSelect->pFromTable) ||
+      NULL != pSelect->pTimeRange ||
+      STREAM_EXT_JOIN_KEY_TWEND != streamExtJoinTableKeyType((SJoinTableNode*)pSelect->pFromTable)) {
     return TSDB_CODE_SUCCESS;
   }
+
   int32_t         code = TSDB_CODE_SUCCESS;
   STimeRangeNode* pTimeRange = NULL;
-  SOperatorNode*  pStartOp = NULL;
-  SOperatorNode*  pEndOp = NULL;
+  SNode*          pStartOp = NULL;
+  SNode*          pEndOp = NULL;
 
-  code = nodesMakeNode(QUERY_NODE_TIME_RANGE, (SNode**)&pTimeRange);
-  if (TSDB_CODE_SUCCESS != code || NULL == pTimeRange) return code;
+  PLAN_ERR_JRET(nodesMakeNode(QUERY_NODE_TIME_RANGE, (SNode**)&pTimeRange));
+  pTimeRange->needCalc = true;
 
-  pTimeRange->pStart = NULL;
-  pTimeRange->pEnd = NULL;
-  pTimeRange->needCalc = false;
+  PLAN_ERR_JRET(makeStreamExtWindowTimeRangeOp(OP_TYPE_GREATER_THAN, "_twstart", FUNCTION_TYPE_TWSTART,
+                                               fmGetTwstartFuncId(), pSelect->precision, &pStartOp));
+  PLAN_ERR_JRET(makeStreamExtWindowTimeRangeOp(OP_TYPE_LOWER_EQUAL, "_twend", FUNCTION_TYPE_TWEND,
+                                               fmGetTwendFuncId(), pSelect->precision, &pEndOp));
 
-  // ts >= _twstart, ts < _twend
-  code = makeTsPlaceholderOp(pSelect->pFromTable, OP_TYPE_GREATER_EQUAL, "_twstart", "_twstart", &pStartOp);
-  if (TSDB_CODE_SUCCESS != code || NULL == pStartOp) {
-    nodesDestroyNode((SNode*)pTimeRange);
-    return code;
-  }
-  code = makeTsPlaceholderOp(pSelect->pFromTable, OP_TYPE_LOWER_THAN, "_twend", "_twend", &pEndOp);
-  if (TSDB_CODE_SUCCESS != code || NULL == pEndOp) {
-    nodesDestroyNode((SNode*)pStartOp);
-    nodesDestroyNode((SNode*)pTimeRange);
-    return code;
-  }
-
-  pTimeRange->pStart = (SNode*)pStartOp;
-  pTimeRange->pEnd = (SNode*)pEndOp;
+  pTimeRange->pStart = pStartOp;
+  pTimeRange->pEnd = pEndOp;
+  pStartOp = NULL;
+  pEndOp = NULL;
   pSelect->pTimeRange = (SNode*)pTimeRange;
-  return TSDB_CODE_SUCCESS;
+  return code;
+
+_return:
+  nodesDestroyNode((SNode*)pTimeRange);
+  nodesDestroyNode(pStartOp);
+  nodesDestroyNode(pEndOp);
+  return code;
 }
 
 static int32_t createWindowLogicNodeByExternal(SLogicPlanContext* pCxt, SExternalWindowNode* pExternal,
@@ -2490,12 +2627,14 @@ _return:
 }
 
 static int32_t createWindowLogicNodeByStreamExternal(SLogicPlanContext* pCxt, SExternalWindowNode* pExternal,
-                                               SSelectStmt* pSelect, SLogicNode** pLogicNode) {
+                                                     SSelectStmt* pSelect, SLogicNode** pLogicNode) {
   SWindowLogicNode* pWindow = NULL;
   int32_t           code = nodesMakeNode(QUERY_NODE_LOGIC_PLAN_WINDOW, (SNode**)&pWindow);
   if (NULL == pWindow) {
     return code;
   }
+
+  pCxt->pPlanCxt->streamCxt.hasExtWindow = true;
 
   pWindow->winType = WINDOW_TYPE_EXTERNAL;
   pWindow->node.groupAction = GROUP_ACTION_NONE;
@@ -2753,6 +2892,81 @@ _return:
   return code;
 }
 
+static int32_t streamCurrentSelectSatisfyExternalWindow(SLogicPlanContext* pCxt, SSelectStmt* pSelect, bool* pSatisfy) {
+  *pSatisfy = false;
+  if (NULL == pSelect || NULL == pSelect->pFromTable) {
+    return TSDB_CODE_SUCCESS;
+  }
+
+  bool hasPlaceHolderCond = false;
+  PAR_ERR_RET(conditionHasPlaceHolder(pSelect->pWhere, &hasPlaceHolderCond));
+
+  ENodeType fromType = nodeType(pSelect->pFromTable);
+  bool      safeExtJoin =
+      QUERY_NODE_JOIN_TABLE == fromType && streamExtJoinTableIsSafe((SJoinTableNode*)pSelect->pFromTable);
+
+  if (NULL != pSelect->pWindow || NULL != pSelect->pPartitionByList || NULL != pSelect->pGroupByList ||
+      !inStreamCalcClause(pCxt->pPlanCxt) || hasPlaceHolderCond || QUERY_NODE_TEMP_TABLE == fromType ||
+      (QUERY_NODE_JOIN_TABLE == fromType && !safeExtJoin) || NULL != pSelect->pSlimit || NULL != pSelect->pLimit ||
+      pSelect->hasInterpFunc || pSelect->hasUniqueFunc || pSelect->hasTailFunc || pSelect->hasForecastFunc ||
+      (pSelect->pOrderByList != NULL && pCxt->pPlanCxt->streamCxt.hasForceOutput) ||
+      (!safeExtJoin && !timeRangeSatisfyExternalWindow((STimeRangeNode*)pSelect->pTimeRange))) {
+    return TSDB_CODE_SUCCESS;
+  }
+
+  if (pCxt->pPlanCxt->streamCxt.hasNotify || pCxt->pPlanCxt->streamCxt.hasForceOutput) {
+    // stream has notify or force output, external window node must be the root node, if not, do not use external window
+    if (pSelect->pFill || pSelect->hasInterpFunc || pSelect->hasForecastFunc || pSelect->hasGenericAnalysisFunc ||
+        pSelect->isDistinct || pSelect->pOrderByList) {
+      return TSDB_CODE_SUCCESS;
+    }
+  }
+
+  *pSatisfy = true;
+  return TSDB_CODE_SUCCESS;
+}
+
+static int32_t streamSelectTreeSatisfyExternalWindow(SLogicPlanContext* pCxt, SNode* pStmt, bool* pSatisfy);
+
+static int32_t streamTableTreeSatisfyExternalWindow(SLogicPlanContext* pCxt, SNode* pTable, bool* pSatisfy) {
+  if (NULL == pTable || !*pSatisfy) {
+    return TSDB_CODE_SUCCESS;
+  }
+
+  switch (nodeType(pTable)) {
+    case QUERY_NODE_TEMP_TABLE:
+      return streamSelectTreeSatisfyExternalWindow(pCxt, ((STempTableNode*)pTable)->pSubquery, pSatisfy);
+    case QUERY_NODE_JOIN_TABLE: {
+      SJoinTableNode* pJoin = (SJoinTableNode*)pTable;
+      PLAN_ERR_RET(streamTableTreeSatisfyExternalWindow(pCxt, pJoin->pLeft, pSatisfy));
+      if (!*pSatisfy) {
+        return TSDB_CODE_SUCCESS;
+      }
+      return streamTableTreeSatisfyExternalWindow(pCxt, pJoin->pRight, pSatisfy);
+    }
+    default:
+      return TSDB_CODE_SUCCESS;
+  }
+}
+
+static int32_t streamSelectTreeSatisfyExternalWindow(SLogicPlanContext* pCxt, SNode* pStmt, bool* pSatisfy) {
+  if (NULL == pStmt || !*pSatisfy) {
+    return TSDB_CODE_SUCCESS;
+  }
+  if (QUERY_NODE_SELECT_STMT != nodeType(pStmt)) {
+    *pSatisfy = false;
+    return TSDB_CODE_SUCCESS;
+  }
+
+  SSelectStmt* pSelect = (SSelectStmt*)pStmt;
+  PLAN_ERR_RET(streamCurrentSelectSatisfyExternalWindow(pCxt, pSelect, pSatisfy));
+  if (!*pSatisfy) {
+    return TSDB_CODE_SUCCESS;
+  }
+
+  return streamTableTreeSatisfyExternalWindow(pCxt, pSelect->pFromTable, pSatisfy);
+}
+
 /**
  * Determines whether the given external window is produced by a subquery
  * rather than by stream processing.
@@ -2795,29 +3009,17 @@ static int32_t checkExternalWindow(SLogicPlanContext* pCxt, SSelectStmt* pSelect
     return checkExprListForExternalWin(pCxt, pSelect);
   }
 
-  bool hasPlaceHolderCond = false;
-  PAR_ERR_RET(conditionHasPlaceHolder(pSelect->pWhere, &hasPlaceHolderCond));
-
-  pCxt->pPlanCxt->streamCxt.hasExtWindow = true;
-  if (NULL != pSelect->pWindow || NULL != pSelect->pPartitionByList || NULL != pSelect->pGroupByList ||
-      !inStreamCalcClause(pCxt->pPlanCxt) || pCxt->containsOuterJoin || hasPlaceHolderCond ||
-      nodeType(pSelect->pFromTable) == QUERY_NODE_TEMP_TABLE ||
-      nodeType(pSelect->pFromTable) == QUERY_NODE_JOIN_TABLE ||
-      NULL != pSelect->pSlimit || NULL != pSelect->pLimit || pSelect->hasInterpFunc ||
-      pSelect->hasUniqueFunc || pSelect->hasTailFunc || pSelect->hasForecastFunc ||
-      (pSelect->pOrderByList != NULL && pCxt->pPlanCxt->streamCxt.hasForceOutput) ||
-      !timeRangeSatisfyExternalWindow((STimeRangeNode*)pSelect->pTimeRange)) {
-    pCxt->pPlanCxt->streamCxt.hasExtWindow = false;
+  if (pCxt->streamExtWindowTreeChecked) {
+    return TSDB_CODE_SUCCESS;
   }
 
-  if (pCxt->pPlanCxt->streamCxt.hasNotify || pCxt->pPlanCxt->streamCxt.hasForceOutput) {
-    // stream has notify or force output, external window node must be the root node, if not, do not use external window
-    if (pSelect->pFill || pSelect->hasInterpFunc || pSelect->hasForecastFunc || pSelect->hasGenericAnalysisFunc ||
-        pSelect->isDistinct || pSelect->pOrderByList) {
-      pCxt->pPlanCxt->streamCxt.hasExtWindow = false;
-    }
+  bool satisfy = true;
+  PLAN_ERR_RET(streamSelectTreeSatisfyExternalWindow(pCxt, (SNode*)pSelect, &satisfy));
+  if (satisfy) {
+    PLAN_ERR_RET(buildStreamExtJoinTwendTimeRange(pSelect));
   }
-
+  pCxt->streamExtWindowTreeChecked = true;
+  pCxt->streamExtWindowTreeEnabled = satisfy;
   return TSDB_CODE_SUCCESS;
 }
 
@@ -2825,7 +3027,7 @@ static int32_t createExternalWindowLogicNode(SLogicPlanContext* pCxt, SSelectStm
   if (hasExternalWindowDerivedFromSubquery(pSelect)) {
     return createWindowLogicNodeByExternal(pCxt, (SExternalWindowNode*)pSelect->pWindow, pSelect, pLogicNode);
   }
-  if (!pCxt->pPlanCxt->streamCxt.hasExtWindow) {
+  if (!pCxt->streamExtWindowTreeEnabled) {
     return TSDB_CODE_SUCCESS;
   }
 
@@ -3146,7 +3348,7 @@ static int32_t createProjectLogicNode(SLogicPlanContext* pCxt, SSelectStmt* pSel
   TSWAP(pProject->node.pSlimit, pSelect->pSlimit);
   pProject->ignoreGroupId = pSelect->isSubquery ? true : (NULL == pSelect->pPartitionByList);
   pProject->node.groupAction = (hasExternalWindowDerivedFromSubquery(pSelect) ||
-                                (inStreamCalcClause(pCxt->pPlanCxt) && pCxt->pPlanCxt->streamCxt.hasExtWindow))
+                                (inStreamCalcClause(pCxt->pPlanCxt) && pCxt->streamExtWindowTreeEnabled))
                                    ? GROUP_ACTION_KEEP
                                    : GROUP_ACTION_CLEAR;
   pProject->node.requireDataOrder = DATA_ORDER_LEVEL_NONE;
@@ -3283,9 +3485,9 @@ static int32_t createSelectFromLogicNode(SLogicPlanContext* pCxt, SSelectStmt* p
   SLogicNode* pRoot = NULL;
   int32_t     code = TSDB_CODE_SUCCESS;
 
-  PLAN_ERR_JRET(createLogicNodeByTable(pCxt, pSelect, pSelect->pFromTable, &pRoot));
-
   PLAN_ERR_JRET(checkExternalWindow(pCxt, pSelect));
+
+  PLAN_ERR_JRET(createLogicNodeByTable(pCxt, pSelect, pSelect->pFromTable, &pRoot));
 
   PLAN_ERR_JRET(createSelectRootLogicNode(pCxt, pSelect, createPartitionLogicNode, &pRoot));
 
@@ -3322,8 +3524,6 @@ _return:
 
 static int32_t createSelectLogicNode(SLogicPlanContext* pCxt, SSelectStmt* pSelect, SLogicNode** pLogicNode) {
   int32_t code = TSDB_CODE_SUCCESS;
-  bool    oldContainsOuterJoin = pCxt->containsOuterJoin;
-  pCxt->containsOuterJoin = pCxt->containsOuterJoin || pSelect->joinContains;
 
   if (NULL == pSelect->pFromTable) {
     code = createSelectWithoutFromLogicNode(pCxt, pSelect, pLogicNode);
@@ -3335,7 +3535,6 @@ static int32_t createSelectLogicNode(SLogicPlanContext* pCxt, SSelectStmt* pSele
     TSWAP((*pLogicNode)->pHint, pSelect->pHint);
   }
 
-  pCxt->containsOuterJoin = oldContainsOuterJoin;
   return code;
 }
 

--- a/test/cases/18-StreamProcessing/07-SubQuery/test_subquery_external_window_join.py
+++ b/test/cases/18-StreamProcessing/07-SubQuery/test_subquery_external_window_join.py
@@ -1,0 +1,180 @@
+from new_test_framework.utils import tdLog, tdSql, tdStream, clusterComCheck
+
+
+class TestStreamSubqueryExternalWindowJoin:
+    def setup_class(cls):
+        tdLog.debug(f"start to execute {__file__}")
+
+    def _ensure_snode(self):
+        tdSql.query("show snodes")
+        if tdSql.getRows() == 0:
+            tdStream.createSnode(1)
+
+    def _prepare_databases(self):
+        for dbname in ("ewj_qdb", "ewj_tdb", "ewj_rdb"):
+            tdSql.prepare(dbname=dbname, vgroups=1)
+            clusterComCheck.checkDbReady(dbname)
+
+    def _prepare_query_tables(self):
+        tdSql.execute("create table ewj_qdb.left_src (ts timestamp, v int)")
+        tdSql.execute("create table ewj_qdb.right_src (ts timestamp, v int)")
+        tdSql.execute("create table ewj_qdb.extra_src (ts timestamp, v int)")
+        tdSql.execute("create table ewj_tdb.trigger_src (ts timestamp, v int)")
+
+        tdSql.execute(
+            "insert into ewj_qdb.left_src values "
+            "('2025-01-01 00:00:01.000', 1) "
+            "('2025-01-01 00:00:03.000', 2) "
+            "('2025-01-01 00:00:11.000', 3) "
+            "('2025-01-01 00:00:21.000', 5) "
+            "('2025-01-01 00:00:25.000', 7) "
+            "('2025-01-01 00:00:29.000', 9)"
+        )
+        tdSql.execute(
+            "insert into ewj_qdb.right_src values "
+            "('2025-01-01 00:00:02.000', 10) "
+            "('2025-01-01 00:00:06.000', 12) "
+            "('2025-01-01 00:00:12.000', 20) "
+            "('2025-01-01 00:00:18.000', 24) "
+            "('2025-01-01 00:00:24.000', 30)"
+        )
+        tdSql.execute(
+            "insert into ewj_qdb.extra_src values "
+            "('2025-01-01 00:00:04.000', 100) "
+            "('2025-01-01 00:00:14.000', 110) "
+            "('2025-01-01 00:00:16.000', 120) "
+            "('2025-01-01 00:00:22.000', 130) "
+            "('2025-01-01 00:00:28.000', 140)"
+        )
+
+    def _create_streams(self):
+        tdSql.execute(
+            "create stream ewj_rdb.s_start interval(10s) sliding(10s) "
+            "from ewj_tdb.trigger_src stream_options(fill_history) "
+            "into ewj_rdb.r_start as "
+            "select a.ts, a.cnt_l, a.sum_l, b.min_r, b.max_r, b.avg_r "
+            "from ("
+            "  select _twstart ts, count(*) cnt_l, sum(v) sum_l "
+            "  from ewj_qdb.left_src where ts >= _twstart and ts < _twend"
+            ") a "
+            "join ("
+            "  select _twstart ts, min(v) min_r, max(v) max_r, avg(v) avg_r "
+            "  from ewj_qdb.right_src where ts >= _twstart and ts < _twend"
+            ") b "
+            "on a.ts = b.ts"
+        )
+        tdSql.execute(
+            "create stream ewj_rdb.s_end interval(10s) sliding(10s) "
+            "from ewj_tdb.trigger_src stream_options(fill_history) "
+            "into ewj_rdb.r_end as "
+            "select a.ts, a.cnt_l, a.sum_l, b.cnt_r "
+            "from ("
+            "  select _twend ts, count(*) cnt_l, sum(v) sum_l "
+            "  from ewj_qdb.left_src where ts >= _twstart and ts < _twend"
+            ") a "
+            "join ("
+            "  select _twend ts, count(*) cnt_r "
+            "  from ewj_qdb.right_src where ts >= _twstart and ts < _twend"
+            ") b "
+            "on a.ts = b.ts"
+        )
+        tdSql.execute(
+            "create stream ewj_rdb.s_three interval(10s) sliding(10s) "
+            "from ewj_tdb.trigger_src stream_options(fill_history) "
+            "into ewj_rdb.r_three as "
+            "select a.ts, a.cnt_l, b.sum_r, c.max_e, c.cnt_e "
+            "from ("
+            "  select _twstart ts, count(*) cnt_l "
+            "  from ewj_qdb.left_src where ts >= _twstart and ts < _twend"
+            ") a "
+            "join ("
+            "  select _twstart ts, sum(v) sum_r "
+            "  from ewj_qdb.right_src where ts >= _twstart and ts < _twend"
+            ") b "
+            "on a.ts = b.ts "
+            "join ("
+            "  select _twstart ts, max(v) max_e, count(*) cnt_e "
+            "  from ewj_qdb.extra_src where ts >= _twstart and ts < _twend"
+            ") c "
+            "on b.ts = c.ts"
+        )
+
+    def _write_trigger_data(self):
+        tdSql.execute(
+            "insert into ewj_tdb.trigger_src values "
+            "('2025-01-01 00:00:00.000', 0) "
+            "('2025-01-01 00:00:10.000', 1) "
+            "('2025-01-01 00:00:20.000', 2)"
+        )
+
+    def _check_stream_results(self):
+        tdSql.checkResultsByFunc(
+            sql="select ts, cnt_l, sum_l, min_r, max_r, avg_r from ewj_rdb.r_start order by ts",
+            func=lambda: tdSql.getRows() == 2
+            and tdSql.compareData(0, 0, "2025-01-01 00:00:10.000")
+            and tdSql.compareData(0, 1, 1)
+            and tdSql.compareData(0, 2, 3)
+            and tdSql.compareData(0, 3, 20)
+            and tdSql.compareData(0, 4, 24)
+            and tdSql.compareData(0, 5, 22.0)
+            and tdSql.compareData(1, 0, "2025-01-01 00:00:20.000")
+            and tdSql.compareData(1, 1, 3)
+            and tdSql.compareData(1, 2, 21)
+            and tdSql.compareData(1, 3, 30)
+            and tdSql.compareData(1, 4, 30)
+            and tdSql.compareData(1, 5, 30.0),
+        )
+        tdSql.checkResultsByFunc(
+            sql="select ts, cnt_l, sum_l, cnt_r from ewj_rdb.r_end order by ts",
+            func=lambda: tdSql.getRows() == 2
+            and tdSql.compareData(0, 0, "2025-01-01 00:00:20.000")
+            and tdSql.compareData(0, 1, 1)
+            and tdSql.compareData(0, 2, 3)
+            and tdSql.compareData(0, 3, 2)
+            and tdSql.compareData(1, 0, "2025-01-01 00:00:30.000")
+            and tdSql.compareData(1, 1, 3)
+            and tdSql.compareData(1, 2, 21)
+            and tdSql.compareData(1, 3, 1),
+        )
+        tdSql.checkResultsByFunc(
+            sql="select ts, cnt_l, sum_r, max_e, cnt_e from ewj_rdb.r_three order by ts",
+            func=lambda: tdSql.getRows() == 2
+            and tdSql.compareData(0, 0, "2025-01-01 00:00:10.000")
+            and tdSql.compareData(0, 1, 1)
+            and tdSql.compareData(0, 2, 44)
+            and tdSql.compareData(0, 3, 120)
+            and tdSql.compareData(0, 4, 2)
+            and tdSql.compareData(1, 0, "2025-01-01 00:00:20.000")
+            and tdSql.compareData(1, 1, 3)
+            and tdSql.compareData(1, 2, 30)
+            and tdSql.compareData(1, 3, 140)
+            and tdSql.compareData(1, 4, 2),
+        )
+
+    def test_stream_subquery_external_window_join(self):
+        """Subquery: stream aggregate derived-table join result correctness
+
+        Verifies actual stream output for safe aggregate derived-table INNER JOIN
+        queries that use _twstart or _twend as the join key, including a
+        three-way INNER JOIN over aggregate derived tables.
+
+        Catalog:
+            - Streams:SubQuery
+
+        Since: v3.4.0.0
+
+        Labels: common, ci
+
+        Feishu: None
+
+        History:
+            - 2026-04-29 Codex Created
+        """
+
+        self._ensure_snode()
+        self._prepare_databases()
+        self._prepare_query_tables()
+        self._write_trigger_data()
+        self._create_streams()
+        tdStream.checkStreamStatus()
+        self._check_stream_results()

--- a/test/ci/cases.task
+++ b/test/ci/cases.task
@@ -795,6 +795,7 @@
 ,,y,.,./ci/pytest.sh pytest  cases/18-StreamProcessing/07-SubQuery/test_subquery_usage_restrict.py
 ,,y,.,./ci/pytest.sh pytest  cases/18-StreamProcessing/07-SubQuery/test_subquery_vtable_change.py
 ,,y,.,./ci/pytest.sh pytest cases/18-StreamProcessing/07-SubQuery/test_subquery_state_join_empty_result.py
+,,y,.,./ci/pytest.sh pytest cases/18-StreamProcessing/07-SubQuery/test_subquery_external_window_join.py
 ## 08-Recalc
 ,,y,.,./ci/pytest.sh pytest cases/18-StreamProcessing/08-Recalc/test_recalc_combined_options.py
 ,,y,.,./ci/pytest.sh pytest cases/18-StreamProcessing/08-Recalc/test_recalc_delete_recalc.py


### PR DESCRIPTION
# Description

- Allow stream external window planning for safe inner joins
- Restrict support to aggregate subqueries keyed by window time
- Add parser regression tests for supported and disabled cases

# Issue(s)

- Resolve: https://project.feishu.cn/taosdata_td/sub_task1/detail/6980647586

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
