### PR TITLE
fix(stream): reduce trigger task running log noise

### DIFF
--- a/source/dnode/mnode/impl/src/mndConsumer.c
+++ b/source/dnode/mnode/impl/src/mndConsumer.c
@@ -248,7 +248,7 @@ static void storeOffsetRows(SMnode *pMnode, SMqHbReq *req, SMqConsumerObj *pCons
     if (data == NULL){
       continue;
     }
-    mInfo("heartbeat report offset rows.%s:%s", pConsumer->cgroup, data->topicName);
+    mDebug("heartbeat report offset rows.%s:%s", pConsumer->cgroup, data->topicName);
 
     SMqSubscribeObj *pSub = NULL;
     char  key[TSDB_SUBSCRIBE_KEY_LEN] = {0};

--- a/source/dnode/mnode/impl/src/mndStreamMgmt.c
+++ b/source/dnode/mnode/impl/src/mndStreamMgmt.c
@@ -3643,15 +3643,15 @@ int32_t msmNormalHandleStatusUpdate(SStmGrpCtx* pCtx) {
         
         STREAM_CLR_FLAG((*ppStatus)->flags, STREAM_FLAG_REDEPLOY_RUNNER);
       }
+
+      if (STREAM_TRIGGER_TASK == pTask->type && STREAM_STATUS_RUNNING == pTask->status) {
+        mstInfo("streamId:0x%" PRIx64 " trigger task status updated to Running in streamMap", (uint64_t)pTask->streamId);
+      }
     }
     
     (*ppStatus)->errCode = pTask->errorCode;
     (*ppStatus)->status = pTask->status;
     (*ppStatus)->lastUpTs = pCtx->currTs;
-    
-    if (STREAM_TRIGGER_TASK == pTask->type && STREAM_STATUS_RUNNING == pTask->status) {
-      mstInfo("streamId:0x%" PRIx64 " trigger task status updated to Running in streamMap", (uint64_t)pTask->streamId);
-    }
     
     if (STREAM_STATUS_RUNNING != pTask->status) {
       msmHandleTaskAbnormalStatus(pCtx, pTask, *ppStatus);


### PR DESCRIPTION
# Description

Log the trigger task Running transition only when the stored task status changes. This avoids repeated info logs from heartbeat status updates.

# Issue(s)

- Fix: https://project.feishu.cn/taosdata_td/defect/detail/6922828017

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
