### PR TITLE
fix: modify the endpoint tag length in the adapter_requests stable to 255

### DIFF
--- a/tools/keeper/api/adapter2.go
+++ b/tools/keeper/api/adapter2.go
@@ -228,8 +228,45 @@ func (a *Adapter) createTable() error {
 	if a.conn == nil {
 		return errNoConnection
 	}
-	_, err := a.conn.Exec(context.Background(), adapterTableSql, util.GetQidOwn(config.Conf.InstanceID))
-	return err
+	if _, err := a.conn.ExecWithRetryForever(context.Background(), adapterTableSql, util.GetQidOwn(config.Conf.InstanceID)); err != nil {
+		return err
+	}
+	return a.alterSTable()
+}
+
+func (a *Adapter) alterSTable() error {
+	qid := util.GetQidOwn(config.Conf.InstanceID)
+	result, err := a.conn.QueryWithRetryForever(context.Background(), "desc adapter_requests", qid)
+	if err != nil {
+		adapterLog.Errorf("desc stable adapter_requests error, msg:%v", err)
+		return err
+	}
+
+	needAlterEndpoint := false
+	for _, row := range result.Data {
+		if row[0] == "endpoint" {
+			if colLen, ok := row[2].(int32); ok {
+				if colLen < 255 {
+					needAlterEndpoint = true
+				}
+			} else {
+				adapterLog.Errorf("unexpected type for endpoint length: %T", row[2])
+				return fmt.Errorf("failed to get endpoint tag length")
+			}
+			break
+		}
+	}
+
+	if needAlterEndpoint {
+		alterSql := "alter stable adapter_requests modify tag endpoint varchar(255)"
+		adapterLog.Info("alter endpoint tag to varchar(255)")
+		if _, err := a.conn.ExecWithRetryForever(context.Background(), alterSql, qid); err != nil {
+			adapterLog.Errorf("alter stable adapter_requests error, sql:%s, msg:%s", alterSql, err)
+			return err
+		}
+	}
+
+	return nil
 }
 
 type AdapterReport struct {

--- a/tools/keeper/api/adapter2.go
+++ b/tools/keeper/api/adapter2.go
@@ -251,7 +251,7 @@ func (a *Adapter) alterSTable() error {
 				}
 			} else {
 				adapterLog.Errorf("unexpected type for endpoint length: %T", row[2])
-				return fmt.Errorf("failed to get endpoint tag length")
+				return fmt.Errorf("failed to get endpoint tag length: unexpected type/value %T (%v)", row[2], row[2])
 			}
 			break
 		}

--- a/tools/keeper/api/adapter2_test.go
+++ b/tools/keeper/api/adapter2_test.go
@@ -322,16 +322,7 @@ func TestAdapter_createTable_UpgradeEndpointTagLengthTo255(t *testing.T) {
 	for _, row := range result.Data {
 		if row[0] == "endpoint" {
 			foundEndpoint = true
-			switch v := row[2].(type) {
-			case int32:
-				endpointLen = v
-			case int64:
-				endpointLen = int32(v)
-			case float64:
-				endpointLen = int32(v)
-			default:
-				t.Fatalf("unexpected type for endpoint length: %T", row[2])
-			}
+			endpointLen, _ = row[2].(int32)
 			break
 		}
 	}

--- a/tools/keeper/api/adapter2_test.go
+++ b/tools/keeper/api/adapter2_test.go
@@ -286,6 +286,60 @@ func TestAdapter_handleFunc_ParseError_ReturnsBadRequest(t *testing.T) {
 	}
 }
 
+func TestAdapter_createTable_UpgradeEndpointTagLengthTo255(t *testing.T) {
+	cfg := config.GetCfg()
+	qid := util.GetQidOwn(cfg.InstanceID)
+
+	conn1, err := db.NewConnector(cfg.TDengine.Username, cfg.TDengine.Password, cfg.TDengine.Host, cfg.TDengine.Port, cfg.TDengine.Usessl)
+	assert.NoError(t, err)
+	defer conn1.Close()
+
+	_, err = conn1.Query(context.Background(), "drop database if exists test_1777449664", qid)
+	assert.NoError(t, err)
+	_, err = conn1.Query(context.Background(), "create database test_1777449664", qid)
+	assert.NoError(t, err)
+	defer func() {
+		_, _ = conn1.Query(context.Background(), "drop database if exists test_1777449664", qid)
+	}()
+
+	conn2, err := db.NewConnectorWithDb(cfg.TDengine.Username, cfg.TDengine.Password, cfg.TDengine.Host, cfg.TDengine.Port, "test_1777449664", cfg.TDengine.Usessl)
+	assert.NoError(t, err)
+	defer conn2.Close()
+
+	oldAdapterTableSql := strings.Replace(adapterTableSql, "varchar(255)", "varchar(32)", 1)
+	_, err = conn2.Query(context.Background(), oldAdapterTableSql, qid)
+	assert.NoError(t, err)
+
+	a := &Adapter{conn: conn2}
+	err = a.createTable()
+	assert.NoError(t, err)
+
+	result, err := conn2.Query(context.Background(), "desc adapter_requests", qid)
+	assert.NoError(t, err)
+
+	foundEndpoint := false
+	endpointLen := int32(0)
+	for _, row := range result.Data {
+		if row[0] == "endpoint" {
+			foundEndpoint = true
+			switch v := row[2].(type) {
+			case int32:
+				endpointLen = v
+			case int64:
+				endpointLen = int32(v)
+			case float64:
+				endpointLen = int32(v)
+			default:
+				t.Fatalf("unexpected type for endpoint length: %T", row[2])
+			}
+			break
+		}
+	}
+
+	assert.True(t, foundEndpoint)
+	assert.Equal(t, int32(255), endpointLen)
+}
+
 func TestAdapter_createTable_NoConnection_ReturnsErrNoConnection(t *testing.T) {
 	a := &Adapter{conn: nil}
 


### PR DESCRIPTION
# Description

<!-- Please briefly describe the code changes in this pull request. -->

fix: modify the endpoint tag length in the adapter_requests stable to 255

# Issue(s)

- close: https://project.feishu.cn/taosdata_td/defect/detail/6980900460

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
