### PR TITLE
docs(taosgen): keep deprecated -f as alias for --log-file with warning and migrate short option to -o

### DIFF
--- a/docs/en/14-reference/02-tools/11-taosgen.md
+++ b/docs/en/14-reference/02-tools/11-taosgen.md
@@ -57,7 +57,7 @@ taosgen -h 127.0.0.1 -c config.yaml
 | -p/--password          | Password for connecting to the server, default is taosdata |
 | -c/--config-file       | Path to the YAML configuration file |
 | -d/--log-dir           | Specify log output directory, default is ./log |
-| -f/--log-file          | Specify complete log file path (overrides --log-dir) |
+| -o/--log-file          | Specify complete log file path (overrides --log-dir) |
 | -?/--help              | Show help information and exit |
 | -V/--version           | Show version information and exit. Cannot be used with other parameters |
 

--- a/docs/en/14-reference/02-tools/11-taosgen.md
+++ b/docs/en/14-reference/02-tools/11-taosgen.md
@@ -57,7 +57,7 @@ taosgen -h 127.0.0.1 -c config.yaml
 | -p/--password          | Password for connecting to the server, default is taosdata |
 | -c/--config-file       | Path to the YAML configuration file |
 | -d/--log-dir           | Specify log output directory, default is ./log |
-| -o/--log-file          | Specify complete log file path (overrides --log-dir) |
+| -o/--log-file          | Specify complete log file path (overrides --log-dir), -f is deprecated |
 | -?/--help              | Show help information and exit |
 | -V/--version           | Show version information and exit. Cannot be used with other parameters |
 

--- a/docs/zh/14-reference/02-tools/11-taosgen.md
+++ b/docs/zh/14-reference/02-tools/11-taosgen.md
@@ -57,7 +57,7 @@ taosgen -h 127.0.0.1 -c config.yaml
 | -p/--password         | 指定用于连接服务器的密码，默认值为 taosdata |
 | -c/--config-file      | 指定 yaml 格式配置文件的路径 |
 | -d/--log-dir          | 指定日志输出目录，默认值为 ./log |
-| -o/--log-file         | 指定完整的日志文件路径（优先级高于 --log-dir） |
+| -o/--log-file         | 指定完整的日志文件路径（优先级高于 --log-dir），-f 已弃用 |
 | -?/--help             | 显示帮助信息并退出|
 | -V/--version          | 显示版本信息并退出，不能与其它参数混用 |
 

--- a/docs/zh/14-reference/02-tools/11-taosgen.md
+++ b/docs/zh/14-reference/02-tools/11-taosgen.md
@@ -57,7 +57,7 @@ taosgen -h 127.0.0.1 -c config.yaml
 | -p/--password         | 指定用于连接服务器的密码，默认值为 taosdata |
 | -c/--config-file      | 指定 yaml 格式配置文件的路径 |
 | -d/--log-dir          | 指定日志输出目录，默认值为 ./log |
-| -f/--log-file         | 指定完整的日志文件路径（优先级高于 --log-dir） |
+| -o/--log-file         | 指定完整的日志文件路径（优先级高于 --log-dir） |
 | -?/--help             | 显示帮助信息并退出|
 | -V/--version          | 显示版本信息并退出，不能与其它参数混用 |
 


### PR DESCRIPTION
# Description

Keep deprecated -f as alias for --log-file with warning and migrate short option to -o for taosgen.

# Issue(s)

- Close https://project.feishu.cn/taosdata_td/feature/detail/6984257331

# Checklist

Please check the items in the checklist if applicable.

- [x] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
