### PR TITLE
fix(stream): align external window join indices

### DIFF
--- a/source/libs/executor/inc/mergejoin.h
+++ b/source/libs/executor/inc/mergejoin.h
@@ -133,6 +133,7 @@ typedef struct SMJoinTableCtx {
   bool               newBlk;
   SSDataBlock*       blk;
   int32_t            blkRowIdx;
+  SArray*            pBlkWinIdx;
 
   // merge join
   

--- a/source/libs/executor/src/mergejoinoperator.c
+++ b/source/libs/executor/src/mergejoinoperator.c
@@ -1130,6 +1130,71 @@ int32_t mJoinLaunchPrimExpr(SSDataBlock* pBlock, SMJoinTableCtx* pTable) {
   return TSDB_CODE_SUCCESS;
 }
 
+static int32_t mJoinGetExternalWinIdx(SMJoinTableCtx* pTable, int32_t rowIdx) {
+  if (NULL == pTable->pBlkWinIdx || taosArrayGetSize(pTable->pBlkWinIdx) <= 0) {
+    return -1;
+  }
+
+  int32_t size = taosArrayGetSize(pTable->pBlkWinIdx);
+  for (int32_t i = size - 1; i >= 0; --i) {
+    int64_t* pIdx = taosArrayGet(pTable->pBlkWinIdx, i);
+    if (NULL == pIdx) {
+      continue;
+    }
+
+    int32_t* pPair = (int32_t*)pIdx;
+    if (rowIdx >= pPair[1]) {
+      return pPair[0];
+    }
+  }
+
+  return -1;
+}
+
+static void mJoinSetExternalWinIdxFromPeer(SMJoinOperatorInfo* pJoin, SMJoinTableCtx* pTable) {
+  SExecTaskInfo* pTaskInfo = pJoin->pOperator->pTaskInfo;
+  if (NULL == pTaskInfo->pStreamRuntimeInfo || !pTaskInfo->pStreamRuntimeInfo->funcInfo.withExternalWindow) {
+    return;
+  }
+
+  SMJoinTableCtx* pPeer = (pTable == pJoin->build) ? pJoin->probe : pJoin->build;
+  if (NULL == pPeer || NULL == pPeer->blk || pPeer->blkRowIdx >= pPeer->blk->info.rows) {
+    return;
+  }
+
+  int32_t winIdx = mJoinGetExternalWinIdx(pPeer, pPeer->blkRowIdx);
+  if (winIdx >= 0) {
+    pTaskInfo->pStreamRuntimeInfo->funcInfo.curIdx = winIdx;
+  }
+}
+
+static int32_t mJoinSaveExternalWinIdx(SMJoinOperatorInfo* pJoin, SMJoinTableCtx* pTable) {
+  SExecTaskInfo* pTaskInfo = pJoin->pOperator->pTaskInfo;
+  if (NULL == pTaskInfo->pStreamRuntimeInfo || !pTaskInfo->pStreamRuntimeInfo->funcInfo.withExternalWindow) {
+    if (pTable->pBlkWinIdx) {
+      taosArrayClear(pTable->pBlkWinIdx);
+    }
+    return TSDB_CODE_SUCCESS;
+  }
+
+  SArray* pInputWinIdx = pTaskInfo->pStreamRuntimeInfo->funcInfo.pStreamBlkWinIdx;
+  int32_t size = (NULL == pInputWinIdx) ? 0 : taosArrayGetSize(pInputWinIdx);
+  if (NULL == pTable->pBlkWinIdx) {
+    pTable->pBlkWinIdx = taosArrayInit(TMAX(size, 1), sizeof(int64_t));
+    if (NULL == pTable->pBlkWinIdx) {
+      return terrno;
+    }
+  } else {
+    taosArrayClear(pTable->pBlkWinIdx);
+  }
+
+  if (size > 0 && NULL == taosArrayAddBatch(pTable->pBlkWinIdx, TARRAY_DATA(pInputWinIdx), size)) {
+    return terrno;
+  }
+
+  return TSDB_CODE_SUCCESS;
+}
+
 SSDataBlock* mJoinGrpRetrieveImpl(SMJoinOperatorInfo* pJoin, SMJoinTableCtx* pTable) {
   SSDataBlock* pTmp = NULL;
   int32_t      code = TSDB_CODE_SUCCESS;
@@ -1147,10 +1212,16 @@ SSDataBlock* mJoinGrpRetrieveImpl(SMJoinOperatorInfo* pJoin, SMJoinTableCtx* pTa
       return NULL;
     }
 
+    mJoinSetExternalWinIdxFromPeer(pJoin, pTable);
     pTmp = getNextBlockFromDownstreamRemain(pJoin->pOperator, dsIdx);
     if (NULL == pTmp) {
       pTable->dsFetchDone = true;
       return NULL;
+    }
+    code = mJoinSaveExternalWinIdx(pJoin, pTable);
+    if (code) {
+      pJoin->errCode = code;
+      T_LONG_JMP(pJoin->pOperator->pTaskInfo->env, pJoin->errCode);
     }
 
     if (0 == pTable->lastInGid) {
@@ -1188,10 +1259,16 @@ SSDataBlock* mJoinGrpRetrieveImpl(SMJoinOperatorInfo* pJoin, SMJoinTableCtx* pTa
       return NULL;
     }
 
+    mJoinSetExternalWinIdxFromPeer(pJoin, pTable);
     SSDataBlock* pTmp = getNextBlockFromDownstreamRemain(pJoin->pOperator, dsIdx);
     if (NULL == pTmp) {
       pTable->dsFetchDone = true;
       return NULL;
+    }
+    code = mJoinSaveExternalWinIdx(pJoin, pTable);
+    if (code) {
+      pJoin->errCode = code;
+      T_LONG_JMP(pJoin->pOperator->pTaskInfo->env, pJoin->errCode);
     }
 
     pTable->remainInBlk = pTmp;
@@ -1213,11 +1290,17 @@ static FORCE_INLINE SSDataBlock* mJoinRetrieveImpl(SMJoinOperatorInfo* pJoin, SM
     return NULL;
   }
 
+  mJoinSetExternalWinIdxFromPeer(pJoin, pTable);
   SSDataBlock* pTmp = getNextBlockFromDownstreamRemain(pJoin->pOperator, pTable->downStreamIdx);
   if (NULL == pTmp) {
     pTable->dsFetchDone = true;
   } else {
     int32_t code = mJoinLaunchPrimExpr(pTmp, pTable);
+    if (code) {
+      pJoin->errCode = code;
+      T_LONG_JMP(pJoin->pOperator->pTaskInfo->env, pJoin->errCode);
+    }
+    code = mJoinSaveExternalWinIdx(pJoin, pTable);
     if (code) {
       pJoin->errCode = code;
       T_LONG_JMP(pJoin->pOperator->pTaskInfo->env, pJoin->errCode);
@@ -1680,6 +1763,9 @@ void mJoinResetGroupTableCtx(SMJoinTableCtx* pCtx) {
   pCtx->blk = NULL;
   pCtx->blkRowIdx = 0;
   pCtx->newBlk = false;
+  if (pCtx->pBlkWinIdx) {
+    taosArrayClear(pCtx->pBlkWinIdx);
+  }
 
   mJoinDestroyCreatedBlks(pCtx->createdBlks);
   tSimpleHashClear(pCtx->pGrpHash);
@@ -1832,6 +1918,7 @@ void destroyMergeJoinTableCtx(SMJoinTableCtx* pTable) {
 
   taosArrayDestroy(pTable->eqGrps);
   taosArrayDestroyEx(pTable->pGrpArrays, destroyGrpArray);
+  taosArrayDestroy(pTable->pBlkWinIdx);
 }
 
 void destroyMergeJoinOperator(void* param) {

--- a/test/cases/18-StreamProcessing/07-SubQuery/test_subquery_external_window_join.py
+++ b/test/cases/18-StreamProcessing/07-SubQuery/test_subquery_external_window_join.py
@@ -110,45 +110,60 @@ class TestStreamSubqueryExternalWindowJoin:
     def _check_stream_results(self):
         tdSql.checkResultsByFunc(
             sql="select ts, cnt_l, sum_l, min_r, max_r, avg_r from ewj_rdb.r_start order by ts",
-            func=lambda: tdSql.getRows() == 2
-            and tdSql.compareData(0, 0, "2025-01-01 00:00:10.000")
-            and tdSql.compareData(0, 1, 1)
+            func=lambda: tdSql.getRows() == 3
+            and tdSql.compareData(0, 0, "2025-01-01 00:00:00.000")
+            and tdSql.compareData(0, 1, 2)
             and tdSql.compareData(0, 2, 3)
-            and tdSql.compareData(0, 3, 20)
-            and tdSql.compareData(0, 4, 24)
-            and tdSql.compareData(0, 5, 22.0)
-            and tdSql.compareData(1, 0, "2025-01-01 00:00:20.000")
-            and tdSql.compareData(1, 1, 3)
-            and tdSql.compareData(1, 2, 21)
-            and tdSql.compareData(1, 3, 30)
-            and tdSql.compareData(1, 4, 30)
-            and tdSql.compareData(1, 5, 30.0),
+            and tdSql.compareData(0, 3, 10)
+            and tdSql.compareData(0, 4, 12)
+            and tdSql.compareData(0, 5, 11.0)
+            and tdSql.compareData(1, 0, "2025-01-01 00:00:10.000")
+            and tdSql.compareData(1, 1, 1)
+            and tdSql.compareData(1, 2, 3)
+            and tdSql.compareData(1, 3, 20)
+            and tdSql.compareData(1, 4, 24)
+            and tdSql.compareData(1, 5, 22.0)
+            and tdSql.compareData(2, 0, "2025-01-01 00:00:20.000")
+            and tdSql.compareData(2, 1, 3)
+            and tdSql.compareData(2, 2, 21)
+            and tdSql.compareData(2, 3, 30)
+            and tdSql.compareData(2, 4, 30)
+            and tdSql.compareData(2, 5, 30.0),
         )
         tdSql.checkResultsByFunc(
             sql="select ts, cnt_l, sum_l, cnt_r from ewj_rdb.r_end order by ts",
-            func=lambda: tdSql.getRows() == 2
-            and tdSql.compareData(0, 0, "2025-01-01 00:00:20.000")
-            and tdSql.compareData(0, 1, 1)
+            func=lambda: tdSql.getRows() == 3
+            and tdSql.compareData(0, 0, "2025-01-01 00:00:10.000")
+            and tdSql.compareData(0, 1, 2)
             and tdSql.compareData(0, 2, 3)
             and tdSql.compareData(0, 3, 2)
-            and tdSql.compareData(1, 0, "2025-01-01 00:00:30.000")
-            and tdSql.compareData(1, 1, 3)
-            and tdSql.compareData(1, 2, 21)
-            and tdSql.compareData(1, 3, 1),
+            and tdSql.compareData(1, 0, "2025-01-01 00:00:20.000")
+            and tdSql.compareData(1, 1, 1)
+            and tdSql.compareData(1, 2, 3)
+            and tdSql.compareData(1, 3, 2)
+            and tdSql.compareData(2, 0, "2025-01-01 00:00:30.000")
+            and tdSql.compareData(2, 1, 3)
+            and tdSql.compareData(2, 2, 21)
+            and tdSql.compareData(2, 3, 1),
         )
         tdSql.checkResultsByFunc(
             sql="select ts, cnt_l, sum_r, max_e, cnt_e from ewj_rdb.r_three order by ts",
-            func=lambda: tdSql.getRows() == 2
-            and tdSql.compareData(0, 0, "2025-01-01 00:00:10.000")
-            and tdSql.compareData(0, 1, 1)
-            and tdSql.compareData(0, 2, 44)
-            and tdSql.compareData(0, 3, 120)
-            and tdSql.compareData(0, 4, 2)
-            and tdSql.compareData(1, 0, "2025-01-01 00:00:20.000")
-            and tdSql.compareData(1, 1, 3)
-            and tdSql.compareData(1, 2, 30)
-            and tdSql.compareData(1, 3, 140)
-            and tdSql.compareData(1, 4, 2),
+            func=lambda: tdSql.getRows() == 3
+            and tdSql.compareData(0, 0, "2025-01-01 00:00:00.000")
+            and tdSql.compareData(0, 1, 2)
+            and tdSql.compareData(0, 2, 22)
+            and tdSql.compareData(0, 3, 100)
+            and tdSql.compareData(0, 4, 1)
+            and tdSql.compareData(1, 0, "2025-01-01 00:00:10.000")
+            and tdSql.compareData(1, 1, 1)
+            and tdSql.compareData(1, 2, 44)
+            and tdSql.compareData(1, 3, 120)
+            and tdSql.compareData(1, 4, 2)
+            and tdSql.compareData(2, 0, "2025-01-01 00:00:20.000")
+            and tdSql.compareData(2, 1, 3)
+            and tdSql.compareData(2, 2, 30)
+            and tdSql.compareData(2, 3, 140)
+            and tdSql.compareData(2, 4, 2),
         )
 
     def test_stream_subquery_external_window_join(self):
@@ -161,14 +176,14 @@ class TestStreamSubqueryExternalWindowJoin:
         Catalog:
             - Streams:SubQuery
 
-        Since: v3.4.0.0
+        Since: v3.4.1.8
 
         Labels: common, ci
 
-        Feishu: None
+        Feishu: https://project.feishu.cn/taosdata_td/sub_task1/detail/6980647586
 
         History:
-            - 2026-04-29 Codex Created
+            - 2026-04-29 Jinqing Kuang Created
         """
 
         self._ensure_snode()


### PR DESCRIPTION
# Description

- Preserve external-window row mappings across merge join inputs
- Restore the peer window index before fetching the opposite input
- Correct stream external-window join result assertions

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
