### PR TITLE
chore: bump low-risk dependencies

### DIFF
--- a/docs/examples/JDBC/JDBCDemo/pom.xml
+++ b/docs/examples/JDBC/JDBCDemo/pom.xml
@@ -24,17 +24,17 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.18.4</version>
+        <version>2.18.6</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.18.4</version>
+        <version>2.18.6</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.18.4</version>
+        <version>2.18.6</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/docs/examples/JDBC/connectionPools/pom.xml
+++ b/docs/examples/JDBC/connectionPools/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.3</version>
+            <version>2.25.4</version>
         </dependency>
         <!-- proxool -->
         <dependency>

--- a/docs/examples/JDBC/highvolume/pom.xml
+++ b/docs/examples/JDBC/highvolume/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.9.1</version>
+            <version>3.9.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.lz4</groupId>
@@ -102,4 +102,3 @@
     </build>
 
 </project>
-

--- a/docs/examples/JDBC/mybatisplus-demo/pom.xml
+++ b/docs/examples/JDBC/mybatisplus-demo/pom.xml
@@ -18,7 +18,7 @@
         <java.version>17</java.version>
         <logback.version>1.5.25</logback.version>
         <netty.version>4.1.129.Final</netty.version>
-        <tomcat.version>10.1.47</tomcat.version>
+        <tomcat.version>10.1.49</tomcat.version>
         <spring-framework.version>6.2.11</spring-framework.version>
     </properties>
 
@@ -95,19 +95,19 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>10.1.47</version>
+            <version>10.1.49</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-el</artifactId>
-            <version>10.1.47</version>
+            <version>10.1.49</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-websocket</artifactId>
-            <version>10.1.47</version>
+            <version>10.1.49</version>
             <scope>provided</scope>
         </dependency>
 

--- a/docs/examples/JDBC/taosdemo/pom.xml
+++ b/docs/examples/JDBC/taosdemo/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.3</version>
+            <version>2.25.4</version>
         </dependency>
         <!-- junit -->
         <dependency>

--- a/tools/tdgpt/requirements_docker.txt
+++ b/tools/tdgpt/requirements_docker.txt
@@ -3,7 +3,7 @@ pandas==2.2.0 ; python_version >= "3.12"
 # install waitress on windows platform, since the gunicorn is not available for windows
 waitress==3.0.1; sys_platform == "win32"
 scipy==1.15.0
-wheel==0.35.0
+wheel==0.38.1
 scikit-learn==1.5.2
 outlier-utils==0.0.5
 statsmodels==0.14.4


### PR DESCRIPTION
# Description

bump low-risk dependencies：
wheel 0.35.0 -> 0.38.1
kafka-clients 3.9.1 -> 3.9.2  
log4j-core 2.25.3 -> 2.25.4  
Jackson core/databind/annotations -> 2.18.6      
Tomcat core/el/websocket -> 10.1.49   

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
