### PR TITLE
docs(taosgen): support writing to TDengine in schemaless format and support writing data to Influxdb

### DIFF
--- a/docs/en/14-reference/02-tools/11-taosgen.md
+++ b/docs/en/14-reference/02-tools/11-taosgen.md
@@ -385,6 +385,7 @@ The `kafka/produce` action publishes data to the specified topic. It supports ob
 ### Format for Writing Data to InfluxDB Action
 
 The `influxdb/write` action writes data to the specified InfluxDB Bucket via the InfluxDB v2 Write API in line protocol format. It supports obtaining data from generator or CSV file sources and allows users to control timestamp attributes via various strategies. It also provides rich write control strategies for optimization.
+
 - schema: Uses global schema configuration by default; can be overridden for this action. The `name` field in the schema will be used as the InfluxDB measurement name.
 - concurrency (int): Number of concurrent write threads, default: 8.
 - failure_handling: For parameter details, see the description in [Format for Writing Data to TDengine Action](#format-for-writing-data-to-tdengine-action).

--- a/docs/en/14-reference/02-tools/11-taosgen.md
+++ b/docs/en/14-reference/02-tools/11-taosgen.md
@@ -168,7 +168,7 @@ These parameters can also be set via command line options (`--log-dir`, `--log-f
 #### InfluxDB Parameters
 
 - influxdb: Describes configuration parameters for the InfluxDB database, including:
-  - url (string): The HTTP address of the InfluxDB server, default: http://localhost:8086.
+  - url (string): The HTTP address of the InfluxDB server, default: `http://localhost:8086`.
   - token (string): API Token for authentication. Can also be set via the `INFLUXDB_TOKEN` environment variable.
   - org (string): InfluxDB organization name, default: default.
   - bucket (string): InfluxDB Bucket name, default: default.
@@ -384,12 +384,14 @@ The `kafka/produce` action publishes data to the specified topic. It supports ob
 
 ### Format for Writing Data to InfluxDB Action
 
-When `uses` is set to `influxdb/write`, the following format parameters are supported (configured under `with`):
-
-- concurrency (int): Number of concurrent write threads, default: 1.
+The `influxdb/write` action writes data to the specified InfluxDB Bucket via the InfluxDB v2 Write API in line protocol format. It supports obtaining data from generator or CSV file sources and allows users to control timestamp attributes via various strategies. It also provides rich write control strategies for optimization.
+- schema: Uses global schema configuration by default; can be overridden for this action. The `name` field in the schema will be used as the InfluxDB measurement name.
+- concurrency (int): Number of concurrent write threads, default: 8.
+- failure_handling: For parameter details, see the description in [Format for Writing Data to TDengine Action](#format-for-writing-data-to-tdengine-action).
+- time_interval: For parameter details, see the description in [Format for Writing Data to TDengine Action](#format-for-writing-data-to-tdengine-action).
 - precision (string): Timestamp precision for writing. Options: "ns", "us", "ms", "s". Default is "ns".
 - batch_size (int): Number of line protocol rows per HTTP request, default: 5000. InfluxDB officially recommends a value of 5000.
-- gzip (bool): Whether to enable gzip compression. Default is true. Enabling gzip significantly reduces bandwidth usage and is recommended for large-batch writes.
+- gzip (bool): Whether to enable gzip compression. Default is false. Enabling gzip significantly reduces bandwidth usage and is recommended for large-batch writes.
 
 ## Configuration File Examples
 

--- a/docs/en/14-reference/02-tools/11-taosgen.md
+++ b/docs/en/14-reference/02-tools/11-taosgen.md
@@ -13,7 +13,7 @@ taosgen currently supports Windows, Linux and macOS systems.
 Compared to taosBenchmark, taosgen offers the following advantages and improvements:
 
 - Provides job orchestration capabilities, with jobs supporting DAG dependencies to simulate real business processes.
-- Supports multiple targets/protocols (TDengine, MQTT, Kafka), enabling scenarios such as database writing and message publishing.
+- Supports multiple targets/protocols (TDengine, MQTT, Kafka, InfluxDB), enabling scenarios such as database writing and message publishing.
 - More diverse data generation methods, including support for Lua expressions to easily simulate real business data.
 - Supports real-time data generation, eliminating the need to pre-generate large data files, saving preparation time and better simulating real scenarios.
 - Supports various time interval strategies to control data writing operations, such as "playing" data according to its actual generation time.
@@ -67,11 +67,12 @@ Tip: If no parameters are specified when running taosgen, taosgen will create th
 
 ### Overall Structure
 
-The configuration file is divided into many parts: "tdengine", "mqtt", "kafka", "schema", "concurrency", and "jobs".
+The configuration file is divided into many parts: "tdengine", "mqtt", "kafka", "influxdb", "schema", "concurrency", and "jobs".
 
 - tdengine: Describes configuration parameters related to the TDengine database.
 - mqtt: Describes configuration parameters for the MQTT Broker.
 - kafka: Describes configuration parameters for the Kafka Broker.
+- influxdb: Describes configuration parameters for the InfluxDB database.
 - schema: Describes configuration parameters for data definition and generation.
 - concurrency: Describes job execution concurrency.
 - jobs: List structure, describes specific parameters for all jobs.
@@ -163,6 +164,14 @@ These parameters can also be set via command line options (`--log-dir`, `--log-f
     - sasl.password (string): The password for SASL authentication.
 
     For more parameters, refer to the [librdkafka configuration documentation](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md).
+
+#### InfluxDB Parameters
+
+- influxdb: Describes configuration parameters for the InfluxDB database, including:
+  - url (string): The HTTP address of the InfluxDB server, default: http://localhost:8086.
+  - token (string): API Token for authentication. Can also be set via the `INFLUXDB_TOKEN` environment variable.
+  - org (string): InfluxDB organization name, default: default.
+  - bucket (string): InfluxDB Bucket name, default: default.
 
 #### schema Parameters
 
@@ -267,6 +276,7 @@ Currently supported built-in actions:
 - `tdengine/insert`: Write data to TDengine database
 - `mqtt/publish`: Publish data to MQTT Broker
 - `kafka/produce`: Publish data to Kafka Broker
+- `influxdb/write`: Write data to InfluxDB database
 Each action can receive parameters via the with field, with content varying by action type.
 
 :::note
@@ -301,7 +311,10 @@ The `tdengine/create-child-table` action creates multiple child tables in the ta
 The `tdengine/insert` action writes data to specified child tables. Supports obtaining child table names and normal column data from generator or CSV file sources, and allows users to control timestamp attributes via various strategies. Also provides rich write control strategies for optimization.
 
 - schema: Uses global schema configuration by default; can be overridden for this action.
-- format (string): Format for writing data, options: sql, stmt, default: stmt.
+- format (string): Format for writing data, options: sql, stmt, schemaless, default: stmt.
+  - sql: Write data using SQL statements.
+  - stmt: Write data using parameterized write (Prepared Statement), suitable for high-performance batch writing.
+  - schemaless: Write data using Line Protocol format, without requiring pre-creation of super tables and child tables. Suitable for simulating data collection agents like Telegraf sending data to TDengine.
 - auto_create_table (bool): Whether to enable TDengine's auto-create-table feature to create tables on the fly when writing data; default: false.
 - concurrency (int): Number of threads for concurrent data writing, default: 8.
 - failure_handling (optional): Failure handling strategy:
@@ -368,6 +381,15 @@ The `kafka/produce` action publishes data to the specified topic. It supports ob
 - compression (string): Message compression type. Supported values: "none", "gzip", "snappy", "lz4", "zstd". Default is "none".
 - tbname_key (string): Specifies the field name for the table name in the JSON output. If set to an empty string (""), the table name is not included. Default is "table".
 - records_per_message (int): Number of records per message, default: 1.
+
+### Format for Writing Data to InfluxDB Action
+
+When `uses` is set to `influxdb/write`, the following format parameters are supported (configured under `with`):
+
+- concurrency (int): Number of concurrent write threads, default: 1.
+- precision (string): Timestamp precision for writing. Options: "ns", "us", "ms", "s". Default is "ns".
+- batch_size (int): Number of line protocol rows per HTTP request, default: 5000. InfluxDB officially recommends a value of 5000.
+- gzip (bool): Whether to enable gzip compression. Default is true. Enabling gzip significantly reduces bandwidth usage and is recommended for large-batch writes.
 
 ## Configuration File Examples
 
@@ -542,4 +564,36 @@ In a multi-broker cluster, use high-concurrency writes to test Kafka's replica s
 
 ```yaml
 {{#include docs/examples/taosgen/taosgen_config.yaml:kafka_produce_config}}
+```
+
+### Generator-Based Data Generation, Writing to InfluxDB Example
+
+This example demonstrates how to use taosgen to simulate CPU monitoring data from 10 servers, each generating a record every 10 seconds with CPU usage metrics. The generated data is written to InfluxDB via the InfluxDB v2 Write API in line protocol format.
+
+Configuration details:
+
+- InfluxDB configuration
+  - Connection info: The InfluxDB service address is specified via url, and authentication is performed via token.
+  - Target: Data is written to the specified Bucket within the organization.
+- schema configuration
+  - Name: Specifies the measurement name as cpu, consistent with the measurement name output by Telegraf's cpu input plugin.
+  - Table names: Defines naming rules for generating 10 logical tables, from host_0 to host_9, used to organize and identify the generated data.
+  - Table column structure: Defines 4 fields (usage_idle, usage_system, usage_user, usage_iowait) and 2 tags (host, cpu).
+    - Timestamp: Uses nanosecond precision with a 10-second step increment, simulating Telegraf's default 10-second collection interval.
+    - Time-series data: Each CPU metric uses random numbers within specified ranges.
+    - Tag data: The host tag uses 10 server names, and the cpu tag uses 5 CPU core identifiers.
+  - Data generation behavior: Uses interlace mode, 100 records per table, 500 rows per batch.
+- Data writing: Writes to InfluxDB using 2 concurrent threads in line protocol format, with gzip compression enabled to reduce bandwidth usage.
+
+Scenario description:
+
+This configuration is specifically designed to simulate Telegraf-collected system monitoring data writing to InfluxDB. It is suitable for the following scenarios:
+
+- InfluxDB Write Performance Testing: Simulate monitoring data writes from large-scale server clusters to test InfluxDB's throughput and latency under high-concurrency line protocol writes.
+- Telegraf Data Simulation: Generate data in a format fully consistent with Telegraf's cpu plugin output, for testing data pipelines in environments without real devices.
+- InfluxDB to TDengine Migration Validation: Write simulated data to InfluxDB first, then test the complete data migration process from InfluxDB to TDengine.
+- Monitoring Platform Integration Testing: Provide continuous simulated data streams for monitoring platforms like Grafana to validate dashboard configurations and alert rules.
+
+```yaml
+{{#include docs/examples/taosgen/taosgen_config.yaml:influxdb_write_config}}
 ```

--- a/docs/examples/taosgen/taosgen_config.yaml
+++ b/docs/examples/taosgen/taosgen_config.yaml
@@ -285,7 +285,7 @@ schema:
       type: timestamp
       start: now
       precision: ns
-      step: 10000000000
+      step: 10s
     - name: usage_idle
       type: float
       min: 50

--- a/docs/examples/taosgen/taosgen_config.yaml
+++ b/docs/examples/taosgen/taosgen_config.yaml
@@ -267,3 +267,60 @@ jobs:
           concurrency: 8
           acks: 1
 # ANCHOR_END: kafka_produce_config
+
+# ANCHOR: influxdb_write_config
+influxdb:
+  url: http://localhost:8086
+  token: "your-influxdb-api-token"
+  org: default
+  bucket: default
+
+schema:
+  name: cpu
+  tbname:
+    prefix: host_
+    count: 10
+  columns:
+    - name: ts
+      type: timestamp
+      start: now
+      precision: ns
+      step: 10000000000
+    - name: usage_idle
+      type: float
+      min: 50
+      max: 99
+    - name: usage_system
+      type: float
+      min: 0
+      max: 20
+    - name: usage_user
+      type: float
+      min: 0
+      max: 50
+    - name: usage_iowait
+      type: float
+      min: 0
+      max: 10
+  tags:
+    - name: host
+      type: binary(64)
+      values: [server01, server02, server03, server04, server05, server06, server07, server08, server09, server10]
+    - name: cpu
+      type: binary(16)
+      values: [cpu-total, cpu0, cpu1, cpu2, cpu3]
+  generation:
+    interlace: 1
+    rows_per_table: 100
+    rows_per_batch: 500
+
+jobs:
+  write-data:
+    steps:
+      - uses: influxdb/write
+        with:
+          concurrency: 2
+          precision: ns
+          batch_size: 500
+          gzip: true
+# ANCHOR_END: influxdb_write_config

--- a/docs/zh/14-reference/02-tools/11-taosgen.md
+++ b/docs/zh/14-reference/02-tools/11-taosgen.md
@@ -167,7 +167,7 @@ taosgen -h 127.0.0.1 -c config.yaml
 #### InfluxDB 参数
 
 - influxdb：描述 InfluxDB 数据库的相关配置参数，它包括以下属性：
-  - url（字符串）：InfluxDB 服务器的 HTTP 地址，默认值为 http://localhost:8086。
+  - url（字符串）：InfluxDB 服务器的 HTTP 地址，默认值为 `http://localhost:8086`。
   - token（字符串）：用于身份验证的 API Token。也可通过环境变量 `INFLUXDB_TOKEN` 设置。
   - org（字符串）：InfluxDB 组织名称，默认值为 default。
   - bucket（字符串）：InfluxDB Bucket 名称，默认值为 default。

--- a/docs/zh/14-reference/02-tools/11-taosgen.md
+++ b/docs/zh/14-reference/02-tools/11-taosgen.md
@@ -13,7 +13,7 @@ taosgen 目前支持 Windows、Linux 和 macOS 系统。
 taosgen 相比 taosBenchmark，具有以下优势和改进：
 
 - 提供作业编排能力，作业支持 DAG 依赖关系，能模拟真实业务流程。
-- 支持多种目标/协议（TDengine、MQTT、Kafka），可用于数据库写入、消息发布等多种场景。
+- 支持多种目标/协议（TDengine、MQTT、Kafka、InfluxDB），可用于数据库写入、消息发布等多种场景。
 - 更丰富的数据生成方式。支持 lua 表达式生成数据，便于模拟真实业务数据。
 - 支持即时数据生成，无需预先生成大批量数据文件，节省准备时间和模拟真实场景。
 - 支持使用多种时间间隔策略控制数据写入操作，如根据数据产生的真实时间“播放”数据。
@@ -67,11 +67,12 @@ taosgen -h 127.0.0.1 -c config.yaml
 
 ### 整体结构
 
-配置文件分为："tdengine"、"mqtt"、"kafka"、"schema"、"concurrency"、"jobs" 几部分。
+配置文件分为："tdengine"、"mqtt"、"kafka"、"influxdb"、"schema"、"concurrency"、"jobs" 几部分。
 
 - tdengine：描述 TDengine 数据库的相关配置参数。
 - mqtt：描述 MQTT Broker 的相关配置参数。
 - kafka：描述 Kafka Broker 的相关配置参数。
+- influxdb：描述 InfluxDB 数据库的相关配置参数。
 - schema：描述数据定义和生成的相关配置参数。
 - concurrency：描述作业执行的并发度。
 - jobs：列表结构，描述所有作业的具体相关参数。
@@ -162,6 +163,14 @@ taosgen -h 127.0.0.1 -c config.yaml
     - sasl.password (字符串)：SASL 身份验证的密码。
 
     更多参数请参考 [librdkafka 配置文档](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md)。
+
+#### InfluxDB 参数
+
+- influxdb：描述 InfluxDB 数据库的相关配置参数，它包括以下属性：
+  - url（字符串）：InfluxDB 服务器的 HTTP 地址，默认值为 http://localhost:8086。
+  - token（字符串）：用于身份验证的 API Token。也可通过环境变量 `INFLUXDB_TOKEN` 设置。
+  - org（字符串）：InfluxDB 组织名称，默认值为 default。
+  - bucket（字符串）：InfluxDB Bucket 名称，默认值为 default。
 
 #### schema 参数
 
@@ -275,6 +284,7 @@ taosgen -h 127.0.0.1 -c config.yaml
 - `tdengine/insert`：用于向指定的 TDengine 数据库中写入数据
 - `mqtt/publish`：用于向指定的 MQTT Broker 发布数据
 - `kafka/produce`：用于向指定的 Kafka Broker 发布数据
+- `influxdb/write`：用于向指定的 InfluxDB 数据库写入数据
 每个行动在调用时可通过 with 字段传入参数，具体参数内容因行动类型而异。
 
 :::note
@@ -310,7 +320,10 @@ taosgen -h 127.0.0.1 -c config.yaml
 `tdengine/insert` 行动用于将数据写入到指定的子表中。它支持从生成器或 CSV 文件两种来源获取子表名称、普通列数据，并允许用户通过多种时间戳策略控制数据的时间属性。此外，还提供了丰富的写入控制策略以优化数据写入过程，具备高度灵活性和可配置性。
 
 - schema：默认使用全局的 schema 配置信息，当需要差异化时可在此行动下单独定义。
-- format（字符串）：描述数据写入时使用的格式，可选值为：sql、stmt，默认使用 stmt。
+- format（字符串）：描述数据写入时使用的格式，可选值为：sql、stmt、schemaless，默认使用 stmt。
+  - sql：使用 SQL 语句写入数据。
+  - stmt：使用参数化写入（Prepared Statement）方式写入数据，适合高性能批量写入场景。
+  - schemaless：使用行协议（Line Protocol）方式写入数据，无需预先创建超级表和子表，适合模拟 Telegraf 等采集器向 TDengine 发送数据的场景。
 - auto_create_table（布尔）：表示是否使用 TDengine 自动建表功能在写入数据时动态创建表，默认值为 false。
 - concurrency（整数）：并发写入数据的线程数量，默认值为 8。
 - failure_handling：表示失败处理策略：
@@ -377,6 +390,18 @@ taosgen -h 127.0.0.1 -c config.yaml
 - compression (字符串)：消息压缩类型，支持 "none"、"gzip"、"snappy"、"lz4"、"zstd"，默认为 "none"。
 - tbname_key (字符串)：用于指定 json 格式输出中代表表名的字段名称。如果此参数被设置为空字符串 ("")，则不输出表名信息。默认值为 "table"。
 - records_per_message（整数）：每条消息包含的记录数，默认为 1。
+
+### 写入 InfluxDB 数据行动的格式
+
+`influxdb/write` 行动用于将数据通过 InfluxDB v2 Write API 以行协议（Line Protocol）格式写入到指定的 InfluxDB Bucket 中。它支持从生成器或 CSV 文件两种来源获取数据，并允许用户通过多种时间戳策略控制数据的时间属性。此外，还提供了丰富的写入控制策略以优化数据写入过程，具备高度灵活性和可配置性。
+
+- schema：默认使用全局的 schema 配置信息，当需要差异化时可在此行动下单独定义。schema 中的 `name` 字段将作为 InfluxDB 的 measurement 名称。
+- concurrency（整数）：并发写入数据的线程数量，默认值为 8。
+- failure_handling：参数说明请参考 [写入 TDengine 数据行动的格式](#写入-tdengine-数据行动的格式) 中的同名参数。
+- time_interval：参数说明请参考 [写入 TDengine 数据行动的格式](#写入-tdengine-数据行动的格式) 中的同名参数。
+- precision（字符串）：时间戳精度，可选值为 "ns"、"us"、"ms"、"s"，默认为 "ns"。
+- batch_size（整数）：每次 HTTP 请求包含的行协议行数，默认为 5000。InfluxDB 官方推荐值为 5000。
+- gzip（布尔）：是否对 HTTP 请求体启用 gzip 压缩，默认为 false。启用后可显著减少网络带宽占用。
 
 ## 配置文件示例
 
@@ -552,4 +577,36 @@ d1,1700000310000,4.98,220.9,147.9
 
 ```yaml
 {{#include docs/examples/taosgen/taosgen_config.yaml:kafka_produce_config}}
+```
+
+### 生成器方式生成数据并写入 InfluxDB 示例
+
+该示例展示了如何使用 taosgen 工具模拟 10 台服务器的 CPU 监控数据，每台服务器每隔 10 秒产生一条包含 CPU 使用率指标的记录，产生的数据通过 InfluxDB v2 Write API 以行协议格式写入 InfluxDB。
+
+配置详解：
+
+- InfluxDB 配置参数
+  - 连接信息：通过 url 指定 InfluxDB 服务地址，通过 token 进行身份验证。
+  - 目标：将数据写入指定组织的 Bucket 中。
+- schema 配置参数
+  - 名称：指定 measurement 名称为 cpu，与 Telegraf 的 cpu 采集插件输出的 measurement 名称一致。
+  - 表名称：定义生成 10 张逻辑表的名称规则，格式为 host_0 到 host_9，用于组织和标识生成的数据。
+  - 表字段结构信息：定义 4 个 field（usage_idle、usage_system、usage_user、usage_iowait）和 2 个 tag（host、cpu）。
+    - 时间戳：使用纳秒精度，以 10 秒为步长递增，模拟 Telegraf 默认的 10 秒采集间隔。
+    - 时序数据：各 CPU 指标使用指定范围的随机数模拟。
+    - 标签数据：host 标签使用 10 个服务器名称，cpu 标签使用 5 个 CPU 核心标识。
+  - 数据生成行为：使用交错模式，每张表 100 条记录，每批 500 行。
+- 数据写入：使用 2 线程并发以行协议格式写入 InfluxDB，启用 gzip 压缩以减少带宽占用。
+
+场景说明：
+
+此配置专为模拟 Telegraf 采集的系统监控数据写入 InfluxDB 而设计。它适用于以下场景：
+
+- InfluxDB 写入性能测试：模拟大规模服务器集群的监控数据写入，测试 InfluxDB 在高并发行协议写入下的吞吐量和延迟表现。
+- Telegraf 数据模拟：生成与 Telegraf cpu 插件输出格式完全一致的数据，用于在无真实设备的环境中测试数据管道。
+- InfluxDB 到 TDengine 迁移验证：先向 InfluxDB 写入模拟数据，再测试从 InfluxDB 迁移数据到 TDengine 的完整流程。
+- 监控平台集成测试：为 Grafana 等监控平台提供持续的模拟数据流，用于验证仪表盘配置和告警规则。
+
+```yaml
+{{#include docs/examples/taosgen/taosgen_config.yaml:influxdb_write_config}}
 ```


### PR DESCRIPTION
# Description

The modification is related to supporting writing to TDengine in schemaless format and supporting writing data to Influxdb for taosgen.

# Issue(s)

- Close https://project.feishu.cn/taosdata_td/feature/detail/6984939673

# Checklist

Please check the items in the checklist if applicable.

- [x] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
