### PR TITLE
feat(stream): support nested event start conditions and leaf true_for

### DIFF
--- a/docs/en/06-advanced/03-stream.md
+++ b/docs/en/06-advanced/03-stream.md
@@ -33,9 +33,11 @@ trigger_type: {
   | INTERVAL(interval_val[, interval_offset]) SLIDING(sliding_val[, offset_time])
   | SESSION(ts_col, session_val)
   | STATE_WINDOW(expr [, extend[, zeroth_state]]) [TRUE_FOR(true_for_expr)]
-  | EVENT_WINDOW(START WITH start_condition END WITH end_condition) [TRUE_FOR(true_for_expr)]
+  | EVENT_WINDOW(START WITH start_event_item [END WITH end_condition]) [TRUE_FOR(true_for_expr)]
   | COUNT_WINDOW(count_val[, sliding_val][, col1[, ...]])
 }
+
+start_event_item: start_condition | (start_event_item, start_event_item [, ...])
 
 true_for_expr: {
     duration_time
@@ -59,6 +61,8 @@ event_type: {WINDOW_OPEN | WINDOW_CLOSE | IDLE | RESUME}
 tag_definition:
     tag_name type_name [COMMENT 'string_value'] AS expr
 ```
+
+For `EVENT_WINDOW`, `start_event_item` supports multi-level nested sub-events. For example, `START WITH ((cond_1a, cond_1b), cond_2)`. When a stream calculation uses a sub-event structure, the `_event_condition_path` placeholder can be used in the query part to obtain the static path of the currently matched node in the start-condition tree.
 
 ### Trigger Methods
 

--- a/docs/en/14-reference/03-taos-sql/41-stream.md
+++ b/docs/en/14-reference/03-taos-sql/41-stream.md
@@ -30,10 +30,11 @@ trigger_type: {
   | INTERVAL(interval_val[, interval_offset]) SLIDING(sliding_val[, offset_time]) 
   | SESSION(ts_col, session_val)
   | STATE_WINDOW(expr[, extend[, zeroth_state]]) [TRUE_FOR(true_for_expr)]
-  | EVENT_WINDOW(START WITH start_condition END WITH end_condition) [TRUE_FOR(true_for_expr)]
-  | EVENT_WINDOW(START WITH (start_condition_1, start_condition_2 [,...]) [END WITH end_condition]) [TRUE_FOR(true_for_expr)]
+  | EVENT_WINDOW(START WITH start_event_item [END WITH end_condition]) [TRUE_FOR(true_for_expr)]
   | COUNT_WINDOW(count_val[, sliding_val][, col1[, ...]]) 
 }
+
+start_event_item: start_condition | (start_event_item, start_event_item [, ...])
 
 true_for_expr: {
     duration_time
@@ -192,13 +193,13 @@ Applicable Scenarios: Suitable for use cases where computations and/or notificat
 ##### Event Window Trigger
 
 ```sql
-EVENT_WINDOW(START WITH start_condition END WITH end_condition) [TRUE_FOR(true_for_expr)]
+EVENT_WINDOW(START WITH start_condition [END WITH end_condition]) [TRUE_FOR(true_for_expr)]
 ```
 
 An event window trigger partitions the incoming data of the trigger table into windows based on defined event start and end conditions, and triggers when the window opens and/or closes. Parameter definitions are as follows:
 
 - start_condition: Definition of the event start condition. It can be any valid conditional expression.
-- end_condition: Definition of the event end condition. It can be any valid conditional expression.
+- end_condition: Optional. Definition of the event end condition. It can be any valid conditional expression.
 - true_for_expr (optional): Specifies the filtering condition for windows. Only windows that meet the condition will generate a trigger. Supports the following four modes:
   - `TRUE_FOR(duration_time)`: Filters based on duration only. The window duration must be greater than or equal to `duration_time`.
   - `TRUE_FOR(COUNT n)`: Filters based on row count only. The window row count must be greater than or equal to `n`.
@@ -225,16 +226,18 @@ CREATE STREAM s_tag_event
 
 Applicable Scenarios: Suitable for use cases where computations and/or notifications need to be driven by event windows.
 
-##### Event Window Trigger (with Sub-Event Window Support)
+##### Event Window Trigger (with Multi-Level Sub-Event Support)
 
 ```sql
-EVENT_WINDOW(START WITH (start_condition_1, start_condition_2 [,...] [END WITH end_condition]) [TRUE_FOR(true_for_expr)]
+EVENT_WINDOW(START WITH start_event_item [END WITH end_condition]) [TRUE_FOR(true_for_expr)]
+
+start_event_item: start_condition | (start_event_item, start_event_item [, ...])
 ```
 
-An event window trigger partitions the incoming data of the trigger table into windows based on event windows. It now supports specifying multiple start conditions and can further subdivide and manage sub-event windows within the original event window based on changes in the effective trigger condition, while introducing the concept of a parent event window to aggregate related sub-event windows. Parameter definitions are as follows:
+An event window trigger now supports recursively nested start-event groups. A start item can be a single valid condition expression or a group made of multiple `start_event_item` entries, and groups can be nested further. The engine evaluates the entire start-condition tree in SQL order and preserves the hierarchy of parent groups and leaf conditions in notifications and stream calculations.
 
-- start_condition_1, start_condition_2 [, ...]: Defines multiple event start conditions. The event window opens when any one of these conditions is satisfied. The system evaluates these conditions in order from first to last, and the first satisfied condition becomes the "effective trigger condition". When all start_conditions are not satisfied, both the parent window and the last sub-window close.
-- end_condition: Definition of the event end condition. When this condition is satisfied, both the current parent window and the last sub-window close. This parameter is now optional.
+- start_event_item: A start-event item. It can be a single start condition or a grouped list. Group items can themselves contain nested groups.
+- end_condition: Optional. When it is satisfied, the active leaf window and all affected ancestor group windows are closed in hierarchical order. If only a start trigger is required, `END WITH` can be omitted.
 - true_for_expr (optional): Specifies the filtering condition for windows. Only windows that meet the condition will generate a trigger. Supports the following four modes:
   - `TRUE_FOR(duration_time)`: Filters based on duration only. The window duration must be greater than or equal to `duration_time`.
   - `TRUE_FOR(COUNT n)`: Filters based on row count only. The window row count must be greater than or equal to `n`.
@@ -248,17 +251,24 @@ Usage Notes:
 - A trigger table must be specified. When the trigger table is a supertable, grouping by tags or subtables is supported, as well as no grouping.
 - When used with a supertable, it must be combined with PARTITION BY tbname.
 - Supports conditional window triggering after filtering the written data.
-- The multiple `start_condition` expressions and the optional `end_condition` can also reference tag columns visible in the trigger-table context.
-- Parent and sub-window behavior:
-  - No parent/sub-windows: During the event window opening period, if the effective trigger condition does not change, only one window is produced. The system treats it as a regular event window, without generating the concept of parent/sub-windows.
-  - Sub-windows: When a specific start_condition becomes the effective trigger condition, a sub-window opens. If the effective trigger condition changes, or when the end_condition is satisfied, the current sub-window closes. Sub-windows do not overlap with each other.
-  - Parent window: A parent window only opens when the second sub-window opens. The parent window's start time is the start time of the first sub-window, and its end time is the end time of the last sub-window. It closes when all start_conditions are not satisfied, or when the end_condition is satisfied.
-- Notification message extensions: In the window open (WINDOW_OPEN) notification message, two new fields are added:
-  - conditionIndex: The index number of the start condition that triggered the current window opening, counting from 0. For a parent window, its value is the same as the first sub-window's value.
-  - windowIndex: The index number of the sub-event window within the parent window, counting from 0. If it is not a sub-window (i.e., a regular event window or parent window), this field value is -1.
+- `start_event_item` and the optional `end_condition` can reference tag columns visible in the trigger-table context.
+- A leaf start condition inside a sub-event group can specify a local `TRUE_FOR(true_for_expr)` to override the outer `TRUE_FOR` default for that leaf only. For example: `START WITH (current >= 12 TRUE_FOR(1s), voltage < 215)`. A single plain start condition is not a sub-event structure and cannot use local `TRUE_FOR`; `START WITH current >= 12 TRUE_FOR(1s) END WITH current < 8` is invalid. Use the outer `EVENT_WINDOW(...) TRUE_FOR(1s)` form in that case.
+- Each node in the start-condition tree is assigned a stable static path named `conditionPath`. Paths are generated in SQL order, and sibling nodes are numbered from `0`. For `START WITH ((a, b, c), d)`:
+  - Group `(a, b, c)` has `conditionPath = "0"`
+  - `a` has `conditionPath = "0.0"`
+  - `b` has `conditionPath = "0.1"`
+  - `c` has `conditionPath = "0.2"`
+  - `d` has `conditionPath = "1"`
+- `conditionIndex` is redefined as the local index of the current node under its parent, which is always the last segment of `conditionPath`.
+- When the active branch switches from one subtree to another, the engine closes the current leaf window first, then closes the affected ancestor group windows, and finally opens the windows for the new branch.
+- Notification payloads no longer include `windowIndex`. Event-window node identification is now expressed with `conditionPath + conditionIndex`.
+- A new placeholder, `_event_condition_path`, is available in stream calculations:
+  - It is only valid in `EVENT_WINDOW` stream calculations.
+  - `START WITH` must use a sub-event structure, either single-level or nested.
+  - The value is the static path string of the currently triggered node, such as `0` or `0.1`.
 - The TRUE_FOR option applies to both sub-windows and parent windows, meaning windows (whether sub-windows or parent windows) shorter than the duration limit will be directly ignored. When some sub-windows under a parent window do not meet the TRUE_FOR condition, the valid sub-windows may not be consecutive. If only 1 sub-window under a parent window meets the TRUE_FOR condition, the parent/sub-window structure is still retained and triggers notifications and computations.
 
-Applicable Scenarios: Suitable for use cases where computations and/or notifications need to be driven by event windows, especially in IoT and industrial data management fields where fine-grained monitoring and analysis of events based on multiple dynamically changing conditions is required. For example, in equipment fault alarms, multiple alarm level conditions (such as "load above 90" and "load above 60") can be defined, and when alarm levels change, the escalation or de-escalation of alarm states can be clearly tracked.
+Applicable Scenarios: Suitable for use cases where computations and/or notifications need to be driven by event windows, especially when multiple dynamic conditions must be modeled with explicit hierarchy. For example, an alarm stream can first define a high-level alarm group and then subdivide it into nested severity levels, while `conditionPath` or `_event_condition_path` identifies the exact branch that matched.
 
 ##### Count Window Trigger
 
@@ -373,6 +383,7 @@ When performing calculations, you may need to use contextual information from th
 | Window Trigger    | _twrownum        | Number of rows in currently open window. Used only with WINDOW_CLOSE trigger. |
 | Idle Trigger      | _tidlestart      | The time (processing time) of the last data received by the group before it entered idle state. Nanosecond precision Unix epoch. Applicable only for IDLE/RESUME triggers. Cannot be mixed with `_twstart/_twend`. Since output tables are usually millisecond-precision, use `cast(_tidlestart/1000000 as timestamp)` to convert. |
 | Idle Trigger      | _tidleend        | The trigger time of the IDLE or RESUME event. Nanosecond precision Unix epoch. Applicable only for IDLE/RESUME triggers. Cannot be mixed with `_twstart/_twend`. Since output tables are usually millisecond-precision, use `cast(_tidleend/1000000 as timestamp)` to convert.|
+| Event Window Trigger | _event_condition_path | Static path of the currently triggered node in the event-window start-condition tree. Valid only for `EVENT_WINDOW` stream calculations that use a sub-event structure. Returns a string such as `0` or `0.1`. |
 | All               | _tgrpid          | ID of trigger group (data type BIGINT)                       |
 | All               | _tlocaltime      | System time of current trigger (nanosecond precision)        |
 | All               | %%n              | Reference to trigger group column<br/>n is the column number in `[PARTITION BY col1[, ...]]`, starting with 1 |
@@ -384,6 +395,7 @@ Usage Restrictions:
 - %%trows: Can only be used in the FROM clause. Queries that use %%trows do not support WHERE condition filtering or join operations on %%trows.
 - %%tbname: Can be used in the FROM, SELECT, and WHERE clauses.
 - Other placeholders: Can only be used in the SELECT and WHERE clauses.
+- `_event_condition_path`: Only valid in `EVENT_WINDOW` stream calculations where `START WITH` uses a sub-event structure. It is illegal for a single plain start condition.
 
 ### Stream Processing Control Options
 
@@ -504,8 +516,9 @@ An example structure of a notification message is shown below:
           "groupId": "7533998559487590581",
           "windowStart": 1733284800000,
           "triggerCondition": {
+            "conditionPath": "0.0",
             "conditionIndex": 0,
-            "fieldValue": {
+            "fieldValues": {
               "c1": 10,
               "c2": 15
             }
@@ -521,8 +534,9 @@ An example structure of a notification message is shown below:
           "windowStart": 1733284800000,
           "windowEnd": 1733284810000,
           "triggerCondition": {
+            "conditionPath": "0.1",
             "conditionIndex": 1,
-            "fieldValue": {
+            "fieldValues": {
               "c1": 20,
               "c2": 3
             }
@@ -621,14 +635,16 @@ These fields apply only when triggerType is Event.
 - If eventType = WINDOW_OPEN, the event object includes:
 - windowStart: Long integer timestamp indicating the window’s start time. Precision matches the time precision of the result table.
 - triggerCondition: Information about the condition that opened the window, including:
-  - conditionIndex: Integer. The index of the condition that triggered the window open, starting from 0.
-  - fieldValue: Key–value pairs containing the condition column names and their corresponding values.
+  - conditionPath: String. The static path of the current node in the start-condition tree.
+  - conditionIndex: Integer. The local index of the current node under its parent, equal to the last segment of `conditionPath`.
+  - fieldValues: Key–value pairs containing the columns referenced by the event-window start-condition tree and their values.
 - If eventType = WINDOW_CLOSE, the event object includes:
   - windowStart: Long integer timestamp indicating the window’s start time. Precision matches the time precision of the result table.
   - windowEnd: Long integer timestamp indicating the window’s end time. Precision matches the time precision of the result table.
   - triggerCondition: Information about the condition that closed the window, including:
-    - conditionIndex: Integer. The index of the condition that triggered the window close, starting from 0.
-    - fieldValue: Key–value pairs containing the condition column names and their corresponding values.
+    - conditionPath: String. The static path of the current node in the start-condition tree.
+    - conditionIndex: Integer. The local index of the current node under its parent, equal to the last segment of `conditionPath`.
+    - fieldValues: Key–value pairs containing the condition-related column values carried by the close notification.
   - result: The computation result, expressed as key–value pairs containing the names of the result columns and their corresponding values.
 
 ##### Fields for Count Windows
@@ -998,6 +1014,22 @@ CREATE STREAM `idmp`.`ana_temp` EVENT_WINDOW(start with `temp` > 80 end with `te
   INTO `idmp`.`ana_temp` 
   AS 
     SELECT _twstart+0s as output_timestamp, avg(`temp`) as `avgtemp` FROM idmp.`vt_engsens02_471544` where ts >= _twstart and ts <= _twend;
+```
+
+- Create a stream with multi-level sub-events for device alarms, and output the path of the matched start condition. The outer `TRUE_FOR(10s)` is the default filter; leaf conditions can override it with local `TRUE_FOR`.
+
+```SQL
+CREATE STREAM power.s_event_alarm
+  EVENT_WINDOW(
+    START WITH ((current >= 12 TRUE_FOR(1s), current >= 10), voltage < 215 TRUE_FOR(COUNT 3))
+    END WITH current < 8 AND voltage >= 215
+  ) TRUE_FOR(10s)
+  FROM power.meters
+  PARTITION BY tbname
+  INTO power.event_alarm_out
+  AS
+    SELECT _twstart AS ts, _twend AS te, _event_condition_path AS path, COUNT(*) AS cnt
+    FROM %%trows;
 ```
 
 #### Sliding Trigger

--- a/docs/zh/06-advanced/03-stream.md
+++ b/docs/zh/06-advanced/03-stream.md
@@ -35,9 +35,11 @@ trigger_type: {
   | INTERVAL(interval_val[, interval_offset]) SLIDING(sliding_val[, offset_time])
   | SESSION(ts_col, session_val)
   | STATE_WINDOW(expr [, extend[, zeroth_state]]) [TRUE_FOR(true_for_expr)]
-  | EVENT_WINDOW(START WITH start_condition END WITH end_condition) [TRUE_FOR(true_for_expr)]
+  | EVENT_WINDOW(START WITH start_event_item [END WITH end_condition]) [TRUE_FOR(true_for_expr)]
   | COUNT_WINDOW(count_val[, sliding_val][, col1[, ...]])
 }
+
+start_event_item: start_condition | (start_event_item, start_event_item [, ...])
 
 true_for_expr: {
     duration_time
@@ -61,6 +63,8 @@ event_type: {WINDOW_OPEN | WINDOW_CLOSE | IDLE | RESUME}
 tag_definition:
     tag_name type_name [COMMENT 'string_value'] AS expr
 ```
+
+其中 `EVENT_WINDOW` 的 `start_event_item` 支持多级子事件嵌套。例如 `START WITH ((cond_1a, cond_1b), cond_2)`。当流计算使用了子事件结构时，可在查询部分使用 `_event_condition_path` 获取当前命中节点在开始条件树中的静态路径。
 
 ### 触发方式
 

--- a/docs/zh/14-reference/03-taos-sql/41-stream.md
+++ b/docs/zh/14-reference/03-taos-sql/41-stream.md
@@ -27,13 +27,14 @@ options: {
 trigger_type: {
     PERIOD(period_time[, offset_time])
   | SLIDING(sliding_val[, offset_time]) 
-  | INTERVAL(interval_val[, interval_offset]) SLIDING(sliding_val[, offset_time]) 
+  | INTERVAL(interval_val[, interval_offset]) SLIDING(sliding_val[, offset_time])
   | SESSION(ts_col, session_val)
   | STATE_WINDOW(expr [, extend[, zeroth_state]]) [TRUE_FOR(true_for_expr)]
-  | EVENT_WINDOW(START WITH start_condition END WITH end_condition) [TRUE_FOR(true_for_expr)]
-  | EVENT_WINDOW(START WITH (start_condition_1, start_condition_2 [,...]) [END WITH end_condition]) [TRUE_FOR(true_for_expr)]
-  | COUNT_WINDOW(count_val[, sliding_val][, col1[, ...]]) 
+  | EVENT_WINDOW(START WITH start_event_item [END WITH end_condition]) [TRUE_FOR(true_for_expr)]
+  | COUNT_WINDOW(count_val[, sliding_val][, col1[, ...]])
 }
+
+start_event_item: start_condition | (start_event_item, start_event_item [, ...])
 
 true_for_expr: {
     duration_time
@@ -192,13 +193,13 @@ CREATE STREAM s_tag_state
 ##### 事件窗口触发
 
 ```sql
-EVENT_WINDOW(START WITH start_condition END WITH end_condition) [TRUE_FOR(true_for_expr)]
+EVENT_WINDOW(START WITH start_condition [END WITH end_condition]) [TRUE_FOR(true_for_expr)]
 ```
 
 事件窗口触发是指对触发表的写入数据按照事件窗口的方式进行窗口划分，当窗口启动和（或）关闭时进行的触发。各参数含义如下：
 
 - start_condition：事件开始条件的定义，可以是任意合法条件表达式。
-- end_condition：事件结束条件的定义，可以是任意合法条件表达式。
+- end_condition：可选，事件结束条件的定义，可以是任意合法条件表达式。
 - true_for_expr：可选，指定窗口的过滤条件，只有满足条件的窗口才会产生触发。支持以下四种模式：
   - `TRUE_FOR(duration_time)`：仅基于持续时长过滤，窗口持续时长必须大于等于 `duration_time`。
   - `TRUE_FOR(COUNT n)`：仅基于数据行数过滤，窗口数据行数必须大于等于 `n`。
@@ -225,16 +226,18 @@ CREATE STREAM s_tag_event
 
 适用场景：需要通过事件窗口驱动计算和（或）通知的场景。
 
-##### 事件窗口触发 (支持子事件窗口)
+##### 事件窗口触发（支持多级子事件）
 
 ```sql
-EVENT_WINDOW(START WITH (start_condition_1, start_condition_2 [,...] [END WITH end_condition]) [TRUE_FOR(true_for_expr)]
+EVENT_WINDOW(START WITH start_event_item [END WITH end_condition]) [TRUE_FOR(true_for_expr)]
+
+start_event_item: start_condition | (start_event_item, start_event_item [, ...])
 ```
 
-事件窗口触发是指对触发表的写入数据按照事件窗口的方式进行窗口划分，它现在支持指定多个开始条件，并能根据有效触发条件的变化，在原有的事件窗口内进一步划分和管理子事件窗口，同时引入父事件窗口的概念来聚合相关的子事件窗口。各参数含义如下：
+事件窗口触发支持将开始事件递归拆分为多级子事件。开始条件既可以是单个合法条件表达式，也可以是由多个 `start_event_item` 组成的分组；分组内部仍然可以继续嵌套分组。系统会按 SQL 书写顺序递归评估整棵开始条件树，并在窗口通知与流计算中保留父分组和叶子条件的层级语义。各参数含义如下：
 
-- start_condition_1, start_condition_2 [,...]：定义多个事件开始条件。当任何一个条件满足时，事件窗口开启。系统会从前往后依次评估这些条件，第一个满足的条件即为“有效触发条件”。当所有 start_condition 都不满足时，父窗口和最后一个子窗口关闭。
-- end_condition：事件结束条件的定义。当该条件满足时，当前父窗口和最后一个子窗口均关闭。该参数现在是可选的。
+- start_event_item：开始事件项。可以是单个开始条件，也可以是分组。分组中的子项支持继续嵌套。
+- end_condition：可选，事件结束条件的定义。当该条件满足时，当前活动叶子窗口和受影响的父分组窗口会按层级顺序关闭。如果只需要定义开始触发条件，可以省略 `END WITH`。
 - true_for_expr：可选，指定窗口的过滤条件，只有满足条件的窗口才会产生触发。支持以下四种模式：
   - `TRUE_FOR(duration_time)`：仅基于持续时长过滤，窗口持续时长必须大于等于 `duration_time`。
   - `TRUE_FOR(COUNT n)`：仅基于数据行数过滤，窗口数据行数必须大于等于 `n`。
@@ -248,17 +251,24 @@ EVENT_WINDOW(START WITH (start_condition_1, start_condition_2 [,...] [END WITH e
 - 必须指定触发表，触发表为超级表时支持按标签、子表分组，支持不分组。
 - 搭配超级表时，必须与 `partition by tbname` 一起使用。
 - 支持对写入数据进行处理过滤后（有条件）的窗口触发。
-- 多个 `start_condition` 以及可选的 `end_condition` 同样可以引用触发表上下文中可见的 tag 列。
-- 父子窗口行为：
-  - 没有父/子窗口：在事件窗口开启期间，如果有效触发条件没有变化，则只产生一个窗口，系统将其视为常规事件窗口，不产生父/子窗口的概念。
-  - 子窗口：当某一个具体的 start_condition 成为有效触发条件时，会开启一个子窗口。如果有效触发条件发生变化，或者 end_condition 满足时，当前子窗口关闭。子窗口之间不重叠。
-  - 父窗口：仅当第二个子窗口开启时，才会开启父窗口。父窗口的起始时间为第一个子窗口的起始时间，结束时间为最后一个子窗口的结束时间，当所有 start_condition 都不满足，或者 end_condition 满足时关闭。
-- 通知消息扩展：在窗口开启（WINDOW_OPEN）的通知消息中，新增两个字段：
-  - conditionIndex：触发当前窗口开启的开始条件的序号，从 0 开始计数。对于父窗口，其值与第一个子窗口的值相同。
-  - windowIndex：子事件窗口在父窗口中的序号，从 0 开始计数。如果不是子窗口（即常规事件窗口或父窗口），该字段值为 -1。
+- `start_event_item` 与可选的 `end_condition` 同样可以引用触发表上下文中可见的 tag 列。
+- 子事件分组中的叶子开始条件可以指定局部 `TRUE_FOR(true_for_expr)`，用于覆盖该叶子自身的外层 `TRUE_FOR` 默认值。例如 `START WITH (current >= 12 TRUE_FOR(1s), voltage < 215)`。单个普通开始条件不是子事件结构，不能写局部 `TRUE_FOR`，例如 `START WITH current >= 12 TRUE_FOR(1s) END WITH current < 8` 非法；这种场景应使用外层 `EVENT_WINDOW(...) TRUE_FOR(1s)`。
+- 系统会为开始条件树中的每个节点分配一个稳定的静态路径 `conditionPath`。路径按 SQL 书写顺序生成，兄弟节点从 `0` 开始编号。例如 `START WITH ((a, b, c), d)` 中：
+  - 分组 `(a, b, c)` 的 `conditionPath` 为 `0`
+  - `a` 的 `conditionPath` 为 `0.0`
+  - `b` 的 `conditionPath` 为 `0.1`
+  - `c` 的 `conditionPath` 为 `0.2`
+  - `d` 的 `conditionPath` 为 `1`
+- `conditionIndex` 的含义调整为“当前节点在父节点下的本地索引”，其值恒等于 `conditionPath` 最后一段。
+- 当活动分支从一棵子树切换到另一棵子树时，会先关闭当前叶子窗口，再关闭受影响的祖先分组窗口，最后打开新分支对应的分组和叶子窗口。
+- 通知消息不再输出 `windowIndex`。事件窗口相关的节点定位统一使用 `conditionPath + conditionIndex`。
+- 在流计算 SQL 中新增占位符 `_event_condition_path`：
+  - 仅可用于 `EVENT_WINDOW` 流计算。
+  - 且要求 `START WITH` 使用了子事件结构（无论是一层还是多级嵌套）。
+  - 其值为当前触发节点的静态路径字符串，例如 `0`、`0.1`。
 - TRUE_FOR 选项对子窗口和父窗口均生效，即小于该时长限制的窗口（无论是子窗口还是父窗口）将直接被忽略。当父窗口下有部分子窗口不满足 TRUE_FOR 条件时，有效的子窗口可能不是连续的。如果父窗口下仅有 1 个子窗口满足 TRUE_FOR 条件，父/子窗口仍保留并触发通知和计算。
 
-适用场景：需要通过事件窗口驱动计算和（或）通知的场景，尤其适用于需要根据多个动态变化的条件来精细化监控和分析事件的物联网、工业数据管理等领域。例如，设备故障告警，可以定义多个告警级别条件（如“负载高于 90”、“负载高于 60”），并在告警级别变化时，清晰地追踪告警状态的升级或降级。
+适用场景：需要通过事件窗口驱动计算和（或）通知的场景，尤其适用于需要根据多个动态变化条件、并且需要保留条件层级关系来精细化监控和分析事件的物联网、工业数据管理等领域。例如，设备告警可以先定义“高优先级告警组”，再在组内细分不同告警等级，并通过 `conditionPath` 或 `_event_condition_path` 明确区分当前命中的告警分支。
 
 ##### 计数窗口触发
 
@@ -373,6 +383,7 @@ tag_definition:
 | 窗口触发 | _twrownum        | 本次触发窗口的记录条数，只适用于 `WINDOW_CLOSE` 触发使用   |
 | 空闲触发 | _tidlestart      | 分组进入空闲前最后一次收到数据的时间（processing time，精度：ns）。只适用于 `IDLE`/`RESUME` 触发使用，不可与 `_twstart/_twend` 混用。由于输出表通常为 ms 精度，建议使用 `cast(_tidlestart/1000000 as timestamp)` 进行转换。 |
 | 空闲触发 | _tidleend        | IDLE 或 RESUME 事件的触发时间（精度：ns）。只适用于 `IDLE`/`RESUME` 触发使用，不可与 `_twstart/_twend` 混用。由于输出表通常为 ms 精度，建议使用 `cast(_tidleend/1000000 as timestamp)` 进行转换。 |
+| 事件窗口触发 | _event_condition_path | 当前事件窗口触发节点在开始条件树中的静态路径。只适用于使用了子事件结构的 `EVENT_WINDOW` 流计算，返回值类型为字符串，例如 `0`、`0.1`。 |
 | 通用     | _tgrpid     | 触发分组的 ID 值，类型为 BIGINT         |
 | 通用     | _tlocaltime | 本次触发时刻的系统时间（精度：ns）       |
 | 通用     | %%n         | 触发分组列的引用<br/>n 为分组列（来自 `[PARTITION BY col1[, ...]]`）的下标（从 1 开始）       |
@@ -384,6 +395,7 @@ tag_definition:
 - %%trows：只能用于 FROM 子句，在使用 %%trows 的语句中不支持 where 条件过滤，不支持对 %%trows 进行关联查询。
 - %%tbname：可以用于 FROM、SELECT 和 WHERE 子句。
 - 其他占位符：只能用于 SELECT 和 WHERE 子句。
+- `_event_condition_path`：仅可用于 `EVENT_WINDOW` 流计算，且 `START WITH` 必须使用子事件结构。对于单个普通开始条件的事件窗口，该占位符非法。
 
 ### 流式计算的控制选项
 
@@ -504,8 +516,9 @@ event_type: {WINDOW_OPEN | WINDOW_CLOSE | ON_TIME | IDLE | RESUME}
           "groupId": "7533998559487590581",
           "windowStart": 1733284800000,
           "triggerCondition": {
+            "conditionPath": "0.0",
             "conditionIndex": 0,
-            "fieldValue": {
+            "fieldValues": {
               "c1": 10,
               "c2": 15
             }
@@ -521,8 +534,9 @@ event_type: {WINDOW_OPEN | WINDOW_CLOSE | ON_TIME | IDLE | RESUME}
           "windowStart": 1733284800000,
           "windowEnd": 1733284810000,
           "triggerCondition": {
+            "conditionPath": "0.1",
             "conditionIndex": 1,
-            "fieldValue": {
+            "fieldValues": {
               "c1": 20,
               "c2": 3
             }
@@ -621,14 +635,16 @@ event_type: {WINDOW_OPEN | WINDOW_CLOSE | ON_TIME | IDLE | RESUME}
 - 如果 eventType 为 WINDOW_OPEN，则包含如下字段：
 - windowStart：长整型时间戳，表示窗口的开始时间，精度与结果表的时间精度一致。
 - triggerCondition：触发窗口开始的条件信息，包括以下字段：
-  - conditionIndex：整型，表示满足的触发窗口开始的条件的索引，从 0 开始编号。
-  - fieldValue：键值对形式，包含条件列列名及其对应的值。
+  - conditionPath：字符串，表示当前触发节点在开始条件树中的静态路径。
+  - conditionIndex：整型，表示当前节点在父节点下的本地索引，等于 `conditionPath` 的最后一段。
+  - fieldValues：键值对形式，包含事件窗口开始条件树引用到的列及其对应的值。
 - 如果 eventType 为 WINDOW_CLOSE，则包含如下字段：
   - windowStart：长整型时间戳，表示窗口的开始时间，精度与结果表的时间精度一致。
   - windowEnd：长整型时间戳，表示窗口的结束时间，精度与结果表的时间精度一致。
   - triggerCondition：触发窗口关闭的条件信息，包括以下字段：
-    - conditionIndex：整型，表示满足的触发窗口关闭的条件的索引，从 0 开始编号。
-    - fieldValue：键值对形式，包含条件列列名及其对应的值。
+    - conditionPath：字符串，表示当前关闭节点在开始条件树中的静态路径。
+    - conditionIndex：整型，表示当前节点在父节点下的本地索引，等于 `conditionPath` 的最后一段。
+    - fieldValues：键值对形式，包含事件窗口结束时通知所携带的条件列值。
   - result：计算结果，为键值对形式，包含窗口计算的结果列列名及其对应的值。
 
 ###### 计数窗口相关字段
@@ -997,6 +1013,22 @@ CREATE STREAM `idmp`.`ana_temp` EVENT_WINDOW(start with `环境温度` > 80 end 
   INTO `idmp`.`ana_temp` 
   AS 
     SELECT _twstart+0s as output_timestamp, avg(`环境温度`) as `平均环境温度` FROM idmp.`vt_气象传感器02_471544` where ts >= _twstart and ts <= _twend;
+```
+
+- 对设备告警使用多级子事件建流，输出当前命中的开始条件路径。外层 `TRUE_FOR(10s)` 是默认过滤条件，叶子条件可以用局部 `TRUE_FOR` 覆盖自身。
+
+```SQL
+CREATE STREAM power.s_event_alarm
+  EVENT_WINDOW(
+    START WITH ((current >= 12 TRUE_FOR(1s), current >= 10), voltage < 215 TRUE_FOR(COUNT 3))
+    END WITH current < 8 AND voltage >= 215
+  ) TRUE_FOR(10s)
+  FROM power.meters
+  PARTITION BY tbname
+  INTO power.event_alarm_out
+  AS
+    SELECT _twstart AS ts, _twend AS te, _event_condition_path AS path, COUNT(*) AS cnt
+    FROM %%trows;
 ```
 
 ##### 滑动触发

--- a/include/common/streamMsg.h
+++ b/include/common/streamMsg.h
@@ -60,6 +60,7 @@ typedef struct STokenBucket       STokenBucket;
 #define PLACE_HOLDER_GRPID            BIT_FLAG_MASK(13)
 #define PLACE_HOLDER_IDLE_START       BIT_FLAG_MASK(14)
 #define PLACE_HOLDER_IDLE_END         BIT_FLAG_MASK(15)
+#define PLACE_HOLDER_EVENT_CONDITION_PATH BIT_FLAG_MASK(16)
 
 #define CREATE_STREAM_FLAG_NONE                     0
 #define CREATE_STREAM_FLAG_TRIGGER_VIRTUAL_STB      BIT_FLAG_MASK(0)
@@ -904,6 +905,7 @@ typedef struct SSTriggerCalcParam {
   int64_t triggerTime;  // _tlocaltime
 
   int32_t notifyType;           // See also: ESTriggerEventType
+  char*   conditionPath;        // _event_condition_path
   char*   extraNotifyContent;   // NULL if not available
   char*   resultNotifyContent;  // does not serialize
   SArray* pExternalWindowData;

--- a/include/common/tmsg.h
+++ b/include/common/tmsg.h
@@ -371,6 +371,7 @@ typedef enum ENodeType {
   QUERY_NODE_UPDATE_TAG_VALUE,
   QUERY_NODE_ALTER_TABLE_UPDATE_TAG_VAL_CLAUSE,
   QUERY_NODE_REMOTE_TABLE,
+  QUERY_NODE_EVENT_START_LEAF,
 
   // Statement nodes are used in parser and planner module.
   QUERY_NODE_SET_OPERATOR = 100,

--- a/include/libs/function/functionMgt.h
+++ b/include/libs/function/functionMgt.h
@@ -208,8 +208,9 @@ typedef enum EFunctionType {
   FUNCTION_TYPE_IMPUTATION_ROWTS,
   FUNCTION_TYPE_IMPUTATION_MARK,
   FUNCTION_TYPE_ANOMALY_MARK,
-  FUNCTION_TYPE_TIDLESTART,          // _tidlestart
-  FUNCTION_TYPE_TIDLEEND,            // _tidleend
+  FUNCTION_TYPE_TIDLESTART,            // _tidlestart
+  FUNCTION_TYPE_TIDLEEND,              // _tidleend
+  FUNCTION_TYPE_EVENT_CONDITION_PATH,  // _event_condition_path
 
   // internal function
   FUNCTION_TYPE_SELECT_VALUE = 3750,

--- a/include/libs/nodes/querynodes.h
+++ b/include/libs/nodes/querynodes.h
@@ -463,6 +463,12 @@ typedef struct SEventWindowNode {
   SNode*    pTrueForLimit;
 } SEventWindowNode;
 
+typedef struct SEventStartLeafNode {
+  ENodeType type;  // QUERY_NODE_EVENT_START_LEAF
+  SNode*    pCond;
+  SNode*    pTrueForLimit;
+} SEventStartLeafNode;
+
 typedef enum ETrueForType {
   TRUE_FOR_DURATION_ONLY = 0,
   TRUE_FOR_COUNT_ONLY = 1,

--- a/include/util/tdef.h
+++ b/include/util/tdef.h
@@ -296,6 +296,8 @@ typedef enum {
 #define TSDB_STREAM_NAME_LEN          193                                // it is a null-terminated string
 #define TSDB_STREAM_NOTIFY_URL_LEN    128                                // it includes the terminating '\0'
 #define TSDB_STREAM_NOTIFY_STAT_LEN   350                                // it includes the terminating '\0'
+#define TSDB_MAX_EVENT_CONDITION_LEAF_NUM 64
+#define TSDB_MAX_EVENT_CONDITION_PATH_LEN 256                            // max chars stored in _event_condition_path
 #define TSDB_OBJ_NAME_LEN             193                                // it is a null-terminated string
 #define TSDB_OBJ_FNAME_LEN            (TSDB_ACCT_ID_LEN + TSDB_OBJ_NAME_LEN + TSDB_NAME_DELIMITER_LEN)
 #define TSDB_DB_NAME_LEN              65

--- a/source/common/src/msg/streamMsg.c
+++ b/source/common/src/msg/streamMsg.c
@@ -3592,10 +3592,12 @@ static int32_t tSerializeSTriggerCalcParam(SEncoder* pEncoder, SArray* pParams, 
       TAOS_MEMCPY(pEncoder->data + pEncoder->pos, param, plainFieldSize);
     }
     pEncoder->pos += plainFieldSize;
+    uint64_t len = (param->conditionPath != NULL) ? strlen(param->conditionPath) + 1 : 0;
+    TAOS_CHECK_EXIT(tEncodeBinary(pEncoder, (uint8_t*)param->conditionPath, len));
 
     if (!ignoreNotificationInfo) {
       TAOS_CHECK_EXIT(tEncodeI32(pEncoder, param->notifyType));
-      uint64_t len = (param->extraNotifyContent != NULL) ? strlen(param->extraNotifyContent) + 1 : 0;
+      len = (param->extraNotifyContent != NULL) ? strlen(param->extraNotifyContent) + 1 : 0;
       TAOS_CHECK_EXIT(tEncodeBinary(pEncoder, (uint8_t*)param->extraNotifyContent, len));
     }
   }
@@ -3605,6 +3607,9 @@ _exit:
 
 void tDestroySSTriggerCalcParam(void* ptr) {
   SSTriggerCalcParam* pParam = ptr;
+  if (pParam && pParam->conditionPath != NULL) {
+    taosMemoryFreeClear(pParam->conditionPath);
+  }
   if (pParam && pParam->extraNotifyContent != NULL) {
     taosMemoryFreeClear(pParam->extraNotifyContent);
   }
@@ -3672,10 +3677,11 @@ static int32_t tDeserializeSTriggerCalcParam(SDecoder* pDecoder, SArray**ppParam
     int64_t plainFieldSize = offsetof(SSTriggerCalcParam, notifyType);
     TAOS_MEMCPY(param, pDecoder->data + pDecoder->pos, plainFieldSize);
     pDecoder->pos += plainFieldSize;
+    uint64_t len = 0;
+    TAOS_CHECK_EXIT(tDecodeBinaryAlloc(pDecoder, (void**)&param->conditionPath, &len));
 
     if (!ignoreNotificationInfo) {
       TAOS_CHECK_EXIT(tDecodeI32(pDecoder, &param->notifyType));
-      uint64_t len = 0;
       TAOS_CHECK_EXIT(tDecodeBinaryAlloc(pDecoder, (void**)&param->extraNotifyContent, &len));
     }
   }

--- a/source/libs/function/src/builtins.c
+++ b/source/libs/function/src/builtins.c
@@ -1145,6 +1145,11 @@ static int32_t translatePlaceHolderPseudoColumn(SFunctionNode* pFunc, char* pErr
           (SDataType){.bytes = TSDB_TABLE_FNAME_LEN - 1 + VARSTR_HEADER_SIZE, .type = TSDB_DATA_TYPE_BINARY};
       break;
     }
+    case FUNCTION_TYPE_EVENT_CONDITION_PATH: {
+      pFunc->node.resType =
+          (SDataType){.bytes = TSDB_MAX_EVENT_CONDITION_PATH_LEN + VARSTR_HEADER_SIZE, .type = TSDB_DATA_TYPE_BINARY};
+      break;
+    }
     case FUNCTION_TYPE_PLACEHOLDER_COLUMN: {
       break;
     }
@@ -6426,6 +6431,20 @@ const SBuiltinFuncDefinition funcMgtBuiltins[] = {
                    .outputParaInfo = {.validDataType = FUNC_PARAM_SUPPORT_TIMESTAMP_TYPE}},
     .translateFunc = translatePlaceHolderPseudoColumn,
     .getEnvFunc   = getTimePseudoFuncEnv,
+    .initFunc     = NULL,
+    .sprocessFunc = streamPseudoScalarFunction,
+    .finalizeFunc = NULL,
+  },
+  {
+    .name = "_event_condition_path",
+    .type = FUNCTION_TYPE_EVENT_CONDITION_PATH,
+    .classification = FUNC_MGT_PSEUDO_COLUMN_FUNC | FUNC_MGT_PLACE_HOLDER_FUNC | FUNC_MGT_SKIP_SCAN_CHECK_FUNC,
+    .parameters = {.minParamNum = 0,
+                   .maxParamNum = 0,
+                   .paramInfoPattern = 0,
+                   .outputParaInfo = {.validDataType = FUNC_PARAM_SUPPORT_VARCHAR_TYPE}},
+    .translateFunc = translatePlaceHolderPseudoColumn,
+    .getEnvFunc   = NULL,
     .initFunc     = NULL,
     .sprocessFunc = streamPseudoScalarFunction,
     .finalizeFunc = NULL,

--- a/source/libs/function/src/functionMgt.c
+++ b/source/libs/function/src/functionMgt.c
@@ -872,6 +872,8 @@ const void* fmGetStreamPesudoFuncVal(int32_t funcId, const SStreamRuntimeFuncInf
       return pStreamRuntimeFuncInfo->pStreamPartColVals;
     case FUNCTION_TYPE_PLACEHOLDER_TBNAME:
       return pStreamRuntimeFuncInfo->pStreamPartColVals;
+    case FUNCTION_TYPE_EVENT_CONDITION_PATH:
+      return pParams->conditionPath;
     case FUNCTION_TYPE_TIDLESTART:
       return &pParams->idlestart;
     case FUNCTION_TYPE_TIDLEEND:
@@ -986,6 +988,24 @@ int32_t fmSetStreamPseudoFuncParamVal(int32_t funcId, SNodeList* pParamNodes, co
         break;
       }
     }
+  } else if (FUNCTION_TYPE_EVENT_CONDITION_PATH == t) {
+    const char* pVal = (const char*)fmGetStreamPesudoFuncVal(funcId, pStreamRuntimeInfo);
+    taosMemoryFreeClear(((SValueNode*)pFirstParam)->datum.p);
+    if (pVal == NULL) {
+      ((SValueNode*)pFirstParam)->isNull = true;
+    } else {
+      size_t maxLen = ((SValueNode*)pFirstParam)->node.resType.bytes > VARSTR_HEADER_SIZE
+                          ? (size_t)((SValueNode*)pFirstParam)->node.resType.bytes - VARSTR_HEADER_SIZE
+                          : 0;
+      size_t len = strnlen(pVal, maxLen);
+      ((SValueNode*)pFirstParam)->datum.p = taosMemoryCalloc(len + VARSTR_HEADER_SIZE, 1);
+      if (NULL == ((SValueNode*)pFirstParam)->datum.p) {
+        return terrno;
+      }
+      (void)memcpy(varDataVal(((SValueNode*)pFirstParam)->datum.p), pVal, len);
+      varDataLen(((SValueNode*)pFirstParam)->datum.p) = len;
+      ((SValueNode*)pFirstParam)->isNull = false;
+    }
   } else if(FUNCTION_TYPE_EXTERNAL_WINDOW_COLUMN == t) {
     if (NULL == pParamNodes || LIST_LENGTH(pParamNodes) < 2) {
       uError("invalid stream external window column param list %p, len: %d", pParamNodes,
@@ -1047,4 +1067,3 @@ int32_t fmSetStreamPseudoFuncParamVal(int32_t funcId, SNodeList* pParamNodes, co
   
   return code;
 }
-

--- a/source/libs/new-stream/inc/streamInt.h
+++ b/source/libs/new-stream/inc/streamInt.h
@@ -120,7 +120,7 @@ int32_t streamBuildStateNotifyContent(ESTriggerEventType eventType, SColumnInfo*
                                       const char* pToState, char** ppContent);
 int32_t streamBuildIdleNotifyContent(ESTriggerEventType eventType, int64_t idleDurationMs, char** ppContent);
 int32_t streamBuildEventNotifyContent(const SSDataBlock* pInputBlock, const SNodeList* pCondCols, int32_t rowIdx,
-                                      int32_t condIdx, int32_t winIdx, int64_t groupId, int64_t windowStart,
+                                      const char* conditionPath, int64_t groupId, int64_t windowStart,
                                       int64_t parentWindowStart, char** ppContent);
 int32_t streamBuildBlockResultNotifyContent(const SStreamRunnerTask* pTask, const SSDataBlock* pBlock, char** ppContent,
                                             const SArray* pFields, const int32_t startRow, const int32_t endRow);

--- a/source/libs/new-stream/inc/streamTriggerTask.h
+++ b/source/libs/new-stream/inc/streamTriggerTask.h
@@ -194,9 +194,9 @@ typedef struct SSTriggerVTablePatchItem {
 } SSTriggerVTablePatchItem;
 
 typedef struct SSTriggerVTablePatchContext {
-  SSHashObj *pPatchItems;          // SSHashObj<vtbUid, SSTriggerVTablePatchItem>
-  SArray    *pVirTableInfoRsp;     // SArray<VTableInfo>
-  SSHashObj *pOrigTableCols;       // SSHashObj<dbname, SSHashObj<tbname, SSTriggerOrigColumnInfo>*>
+  SSHashObj *pPatchItems;       // SSHashObj<vtbUid, SSTriggerVTablePatchItem>
+  SArray    *pVirTableInfoRsp;  // SArray<VTableInfo>
+  SSHashObj *pOrigTableCols;    // SSHashObj<dbname, SSHashObj<tbname, SSTriggerOrigColumnInfo>*>
 } SSTriggerVTablePatchContext;
 
 typedef struct SSTriggerRealtimeContext {
@@ -227,7 +227,7 @@ typedef struct SSTriggerRealtimeContext {
 
   // these fields need to be cleared each round
   bool       needCheckAgain;
-  SSHashObj *pSlices;  // SSHashObj<uid, SSTriggerDataSlice>
+  SSHashObj *pSlices;        // SSHashObj<uid, SSTriggerDataSlice>
   SObjList   dumpTableUids;  // SObjList<{uid, vgId}>, backup ids for repeated check in one round
   // these fields are shared by all groups and need to reset for each group
   bool                         needPseudoCols;

--- a/source/libs/new-stream/inc/streamTriggerTask.h
+++ b/source/libs/new-stream/inc/streamTriggerTask.h
@@ -51,6 +51,11 @@ typedef struct SSTriggerOrigTableInfo {
 typedef struct SSTriggerWindow {
   STimeWindow range;
   int64_t     wrownum;
+  int64_t     calcStartTs;
+  int64_t     calcWrownum;
+  int32_t     eventNodeId;
+  int32_t     parentEventNodeId;
+  int64_t     parentWindowStart;
   int64_t     prevProcTime;  // only used in realtime group for max_delay check
 } SSTriggerWindow;
 
@@ -58,9 +63,62 @@ typedef struct SSTriggerNotifyWindow {
   STimeWindow range;
   int64_t     wrownum;
   bool        forceWinOpen;
+  int64_t     calcStartTs;
+  int64_t     calcWrownum;
+  int32_t     eventNodeId;
+  int32_t     parentEventNodeId;
+  int64_t     parentWindowStart;
   char       *pWinOpenNotify;
   char       *pWinCloseNotify;
 } SSTriggerNotifyWindow;
+
+typedef struct SSTriggerEventNodeMeta {
+  int32_t      nodeId;
+  int32_t      parentNodeId;
+  int32_t      localIndex;
+  int32_t      leafIndex;
+  int32_t      priority;
+  bool         isLeaf;
+  bool         hasLocalTrueFor;
+  SNode       *pCond;
+  SNode       *pHistCond;
+  STrueForInfo localTrueForInfo;
+  STrueForInfo effectiveTrueForInfo;
+  char        *path;
+} SSTriggerEventNodeMeta;
+
+typedef enum ESTriggerEventNodeState {
+  STRIGGER_EVENT_NODE_IDLE = 0,
+  STRIGGER_EVENT_NODE_TRACKING,
+  STRIGGER_EVENT_NODE_SATISFIED,
+} ESTriggerEventNodeState;
+
+typedef struct SSTriggerEventInterval {
+  STimeWindow range;
+  int64_t     wrownum;
+  int64_t     calcStartTs;
+  int64_t     calcWrownum;
+} SSTriggerEventInterval;
+
+typedef struct SSTriggerLeafRuntimeState {
+  int32_t                 nodeId;
+  ESTriggerEventNodeState state;
+  int64_t                 curStartTs;
+  int64_t                 curLastTs;
+  int64_t                 curRowCount;
+  int64_t                 calcStartTs;
+  int64_t                 calcRowCount;
+  SArray                 *pQualifiedHistory;  // SArray<SSTriggerEventInterval>
+} SSTriggerLeafRuntimeState;
+
+typedef struct SSTriggerParentRuntimeState {
+  int32_t                 nodeId;
+  ESTriggerEventNodeState state;
+  int64_t                 curStartTs;
+  int64_t                 curLastTs;
+  int64_t                 curRowCount;
+  char                   *pWinOpenNotify;
+} SSTriggerParentRuntimeState;
 
 typedef TRINGBUF(SSTriggerWindow) TriggerWindowBuf;
 
@@ -88,6 +146,8 @@ typedef struct SSTriggerRealtimeGroup {
       char                 *pFirstSubWinOpenNotify;
       int32_t               numSubWindows;
       int32_t               conditionIdx;
+      SArray               *pLeafStates;    // SArray<SSTriggerLeafRuntimeState>
+      SArray               *pParentStates;  // SArray<SSTriggerParentRuntimeState>
     };
     int64_t totalCount;  // for count window trigger
   };
@@ -131,6 +191,8 @@ typedef struct SSTriggerHistoryGroup {
       SSTriggerNotifyWindow parentWindow;
       int32_t               numSubWindows;
       int32_t               conditionIdx;
+      SArray               *pLeafStates;    // SArray<SSTriggerLeafRuntimeState>
+      SArray               *pParentStates;  // SArray<SSTriggerParentRuntimeState>
     };
   };
 
@@ -398,7 +460,9 @@ typedef struct SStreamTriggerTask {
       SNode       *pEndCond;
       SNodeList   *pStartCondCols;
       SNodeList   *pEndCondCols;
+      SArray      *pStartCondMeta;  // SArray<SSTriggerEventNodeMeta>
       STrueForInfo eventTrueForInfo;
+      bool         startCondHasSubEvents;
     };
   };
   int32_t trigTsIndex;

--- a/source/libs/new-stream/src/streamTriggerTask.c
+++ b/source/libs/new-stream/src/streamTriggerTask.c
@@ -2576,7 +2576,8 @@ int32_t stTriggerTaskDeploy(SStreamTriggerTask *pTask, SStreamTriggerDeployMsg *
   pTask->ignoreNoDataTrigger = pMsg->igNoDataTrigger;
   pTask->hasTriggerFilter = pMsg->triggerHasPF;
   pTask->multiGroupBatch = pMsg->enableMultiGroupCalc;
-  QUERY_CHECK_CONDITION(!pTask->multiGroupBatch, code, lino, _end, TSDB_CODE_INTERNAL_ERROR); // todo(kjq): enable multi group calc
+  QUERY_CHECK_CONDITION(!pTask->multiGroupBatch, code, lino, _end,
+                        TSDB_CODE_INTERNAL_ERROR);  // todo(kjq): enable multi group calc
   if (pTask->multiGroupBatch) {
     QUERY_CHECK_CONDITION((pTask->placeHolderBitmap & PLACE_HOLDER_PARTITION_ROWS) == 0, code, lino, _end,
                           TSDB_CODE_INVALID_PARA);
@@ -4344,12 +4345,12 @@ _end:
 // send STRIGGER_PULL_GROUP_COL_VALUE for given (pProgress, gid); used when pulling groupInfo for pending create-table
 static int32_t stRealtimeContextSendPullReqForGid(SSTriggerRealtimeContext *pContext, SSTriggerWalProgress *pProgress,
                                                   int64_t gid) {
-  SStreamTriggerTask       *pTask = pContext->pTask;
-  SSTriggerPullRequest      *pReq = &pProgress->pullReq.base;
-  SStreamTaskAddr           *pReader = pProgress->pTaskAddr;
-  SRpcMsg                    msg = {.msgType = TDMT_STREAM_TRIGGER_PULL};
-  int32_t                    code = TSDB_CODE_SUCCESS;
-  int32_t                    lino = 0;
+  SStreamTriggerTask   *pTask = pContext->pTask;
+  SSTriggerPullRequest *pReq = &pProgress->pullReq.base;
+  SStreamTaskAddr      *pReader = pProgress->pTaskAddr;
+  SRpcMsg               msg = {.msgType = TDMT_STREAM_TRIGGER_PULL};
+  int32_t               code = TSDB_CODE_SUCCESS;
+  int32_t               lino = 0;
 
   pReq->type = STRIGGER_PULL_GROUP_COL_VALUE;
   pReq->readerTaskId = pReader->taskId;
@@ -4410,7 +4411,8 @@ static int32_t stTriggerTaskSendCreateTableReq(SStreamTriggerTask *pTask, SSTrig
       (pTask->placeHolderBitmap & PLACE_HOLDER_PARTITION_TBNAME)) {
     needTagValue = true;
   }
-  if (needTagValue && pContext != NULL && pContext->pGroupColVals != NULL && taosArrayGetSize(pCalcReq->groupColVals) == 0) {
+  if (needTagValue && pContext != NULL && pContext->pGroupColVals != NULL &&
+      taosArrayGetSize(pCalcReq->groupColVals) == 0) {
     void *px = tSimpleHashGet(pContext->pGroupColVals, &gid, sizeof(int64_t));
     if (px != NULL) {
       SArray *pGroupColVals = *(SArray **)px;
@@ -4512,7 +4514,6 @@ _end:
 }
 
 static int32_t stRealtimeContextSendCalcReq(SSTriggerRealtimeContext *pContext, bool sendOnly) {
-
   int32_t               code = TSDB_CODE_SUCCESS;
   int32_t               lino = 0;
   SStreamTriggerTask   *pTask = pContext->pTask;
@@ -4747,8 +4748,8 @@ static int32_t stRealtimeContextSendCalcReq(SSTriggerRealtimeContext *pContext, 
     TAOS_MEMCPY(&readInfo.lastParam, pLastParam, plainFieldSize);
     // todo(kjq): fill in ptables in readInfo
     SSTriggerRealtimeGroup *pGroup = stRealtimeContextGetCurrentGroup(pContext);
-    SArray *pInfos = NULL;
-    void *px = tSimpleHashGet(pCalcReq->pGroupReadInfos, &pGroup->vgId, sizeof(int32_t));
+    SArray                 *pInfos = NULL;
+    void                   *px = tSimpleHashGet(pCalcReq->pGroupReadInfos, &pGroup->vgId, sizeof(int32_t));
     if (px == NULL) {
       pInfos = taosArrayInit(0, sizeof(SSTriggerGroupReadInfo));
       QUERY_CHECK_NULL(pInfos, code, lino, _end, terrno);
@@ -5992,9 +5993,9 @@ static int32_t stRealtimeContextProcPullRsp(SSTriggerRealtimeContext *pContext, 
       pProgress->doneVer = pProgress->startVer;
       pProgress->lastScanVer = pProgress->startVer;
 
-      int32_t nrows = blockDataGetNumOfRows(pDataBlock);
-      int64_t         *pGidData = NULL;
-      int64_t         *pTsData = NULL;
+      int32_t  nrows = blockDataGetNumOfRows(pDataBlock);
+      int64_t *pGidData = NULL;
+      int64_t *pTsData = NULL;
 
       if (nrows > 0) {
         int32_t          iCol = 0;
@@ -6052,8 +6053,7 @@ static int32_t stRealtimeContextProcPullRsp(SSTriggerRealtimeContext *pContext, 
 
       if (pTask->nodelayCreateSubtable && nrows > 0 && pGidData != NULL) {
         if (pContext->pPendingCreateTableGids == NULL) {
-          pContext->pPendingCreateTableGids =
-              taosArrayInit(0, sizeof(SSTriggerPendingCreateTableEntry));
+          pContext->pPendingCreateTableGids = taosArrayInit(0, sizeof(SSTriggerPendingCreateTableEntry));
           QUERY_CHECK_NULL(pContext->pPendingCreateTableGids, code, lino, _end, terrno);
         }
         if (pTask->isVirtualTable) {
@@ -6063,8 +6063,7 @@ static int32_t stRealtimeContextProcPullRsp(SSTriggerRealtimeContext *pContext, 
             if (pOrigTableInfo == NULL) continue;
             for (int32_t j = 0; j < TARRAY_SIZE(pOrigTableInfo->pVtbUids); j++) {
               int64_t                 vtbUid = *(int64_t *)TARRAY_GET_ELEM(pOrigTableInfo->pVtbUids, j);
-              SSTriggerVirtTableInfo *pVirtTableInfo =
-                  tSimpleHashGet(pTask->pVirtTableInfos, &vtbUid, sizeof(int64_t));
+              SSTriggerVirtTableInfo *pVirtTableInfo = tSimpleHashGet(pTask->pVirtTableInfos, &vtbUid, sizeof(int64_t));
               if (pVirtTableInfo == NULL) continue;
               SSTriggerPendingCreateTableEntry entry = {
                   .gid = pVirtTableInfo->tbGid, .pProgress = pProgress, .attemptCount = 1};
@@ -6075,7 +6074,7 @@ static int32_t stRealtimeContextProcPullRsp(SSTriggerRealtimeContext *pContext, 
         } else {
           for (int32_t i = 0; i < nrows; i++) {
             SSTriggerPendingCreateTableEntry entry = {.gid = pGidData[i], .pProgress = pProgress, .attemptCount = 1};
-            void *px = taosArrayPush(pContext->pPendingCreateTableGids, &entry);
+            void                            *px = taosArrayPush(pContext->pPendingCreateTableGids, &entry);
             QUERY_CHECK_NULL(px, code, lino, _end, terrno);
           }
         }
@@ -6087,8 +6086,7 @@ static int32_t stRealtimeContextProcPullRsp(SSTriggerRealtimeContext *pContext, 
       }
 
       // all readers responded; send first GROUP_COL_VALUE pull for nodelay create-table if any
-      if (pContext->pPendingCreateTableGids != NULL &&
-          taosArrayGetSize(pContext->pPendingCreateTableGids) > 0) {
+      if (pContext->pPendingCreateTableGids != NULL && taosArrayGetSize(pContext->pPendingCreateTableGids) > 0) {
         SSTriggerPendingCreateTableEntry *pFirst =
             (SSTriggerPendingCreateTableEntry *)taosArrayGet(pContext->pPendingCreateTableGids, 0);
         QUERY_CHECK_NULL(pFirst, code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
@@ -6531,13 +6529,15 @@ static int32_t stRealtimeContextProcPullRsp(SSTriggerRealtimeContext *pContext, 
           code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
       SSTriggerGroupColValueRequest *pRequest = (SSTriggerGroupColValueRequest *)pReq;
       if (pContext->status == STRIGGER_CONTEXT_DETERMINE_BOUND && pContext->pPendingCreateTableGids != NULL) {
-        // pending create-table: LAST_TS needed tag, we pulled groupInfo for one gid; create table then continue or finish
+        // pending create-table: LAST_TS needed tag, we pulled groupInfo for one gid; create table then continue or
+        // finish
         SStreamGroupInfo groupInfo = {0};
         if (pRsp->contLen > 0) {
           code = tDeserializeSStreamGroupInfo(pRsp->pCont, pRsp->contLen, &groupInfo);
           QUERY_CHECK_CODE(code, lino, _end);
         }
-        code = tSimpleHashPut(pContext->pGroupColVals, &pRequest->gid, sizeof(int64_t), &groupInfo.gInfo, POINTER_BYTES);
+        code =
+            tSimpleHashPut(pContext->pGroupColVals, &pRequest->gid, sizeof(int64_t), &groupInfo.gInfo, POINTER_BYTES);
         if (code != TSDB_CODE_SUCCESS) {
           taosArrayClearEx(groupInfo.gInfo, tDestroySStreamGroupValue);
           QUERY_CHECK_CODE(code, lino, _end);
@@ -6560,8 +6560,7 @@ static int32_t stRealtimeContextProcPullRsp(SSTriggerRealtimeContext *pContext, 
           SSTriggerPendingCreateTableEntry *pNext =
               (SSTriggerPendingCreateTableEntry *)taosArrayGet(pContext->pPendingCreateTableGids, 0);
           QUERY_CHECK_NULL(pNext, code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
-          code =
-              stRealtimeContextSendPullReqForGid(pContext, pNext->pProgress, pNext->gid);
+          code = stRealtimeContextSendPullReqForGid(pContext, pNext->pProgress, pNext->gid);
           QUERY_CHECK_CODE(code, lino, _end);
         } else {
           taosArrayDestroy(pContext->pPendingCreateTableGids);
@@ -10323,9 +10322,9 @@ static int32_t stRealtimeGroupGenCalcParams(SSTriggerRealtimeGroup *pGroup, int3
                                           pWin->range.ekey & (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK), pWin->wrownum);
     bool ignore = (pWin->range.skey <= pGroup->prevParentWinStart) || !meetTrueFor;
     if ((calcOpen || notifyOpen) && !ignore && !pContext->recovering) {
-      SSTriggerCalcParam    param = {.triggerTime = now,
-                                     .notifyType = (notifyOpen ? STRIGGER_EVENT_WINDOW_OPEN : STRIGGER_EVENT_WINDOW_NONE),
-                                     .extraNotifyContent = pWin->pWinOpenNotify};
+      SSTriggerCalcParam param = {.triggerTime = now,
+                                  .notifyType = (notifyOpen ? STRIGGER_EVENT_WINDOW_OPEN : STRIGGER_EVENT_WINDOW_NONE),
+                                  .extraNotifyContent = pWin->pWinOpenNotify};
       SSTriggerNotifyWindow win = *pWin;
       if (pTask->triggerType != STREAM_TRIGGER_SLIDING) {
         win.range.ekey = win.range.skey;
@@ -10373,9 +10372,9 @@ static int32_t stRealtimeGroupGenCalcParams(SSTriggerRealtimeGroup *pGroup, int3
                                           pWin->range.ekey & (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK), pWin->wrownum);
     bool ignore = (pWin->range.skey <= pGroup->prevParentWinStart) || !meetTrueFor;
     if ((calcOpen || notifyOpen) && !ignore && !pContext->recovering) {
-      SSTriggerCalcParam    param = {.triggerTime = now,
-                                     .notifyType = (notifyOpen ? STRIGGER_EVENT_WINDOW_OPEN : STRIGGER_EVENT_WINDOW_NONE),
-                                     .extraNotifyContent = pWin->pWinOpenNotify};
+      SSTriggerCalcParam param = {.triggerTime = now,
+                                  .notifyType = (notifyOpen ? STRIGGER_EVENT_WINDOW_OPEN : STRIGGER_EVENT_WINDOW_NONE),
+                                  .extraNotifyContent = pWin->pWinOpenNotify};
       SSTriggerNotifyWindow win = *pWin;
       if (pTask->triggerType != STREAM_TRIGGER_SLIDING) {
         win.range.ekey = win.range.skey;

--- a/source/libs/new-stream/src/streamTriggerTask.c
+++ b/source/libs/new-stream/src/streamTriggerTask.c
@@ -139,6 +139,604 @@ static SRWLatch gStreamTriggerWaitLatch;
 static SList    gStreamTriggerWaitList;
 static tmr_h    gStreamTriggerTimerId = NULL;
 
+static SSTriggerEventNodeMeta *stTriggerTaskGetEventMeta(const SStreamTriggerTask *pTask, int32_t nodeId) {
+  if (pTask == NULL || pTask->triggerType != STREAM_TRIGGER_EVENT || pTask->pStartCondMeta == NULL || nodeId < 0 ||
+      nodeId >= taosArrayGetSize(pTask->pStartCondMeta)) {
+    return NULL;
+  }
+
+  return taosArrayGet(pTask->pStartCondMeta, nodeId);
+}
+
+static bool stTriggerTaskParseTrueForNode(const SNode *pNode, STrueForInfo *pInfo) {
+  if (pNode == NULL || pInfo == NULL) {
+    return false;
+  }
+
+  TAOS_MEMSET(pInfo, 0, sizeof(*pInfo));
+  if (nodeType((SNode *)pNode) == QUERY_NODE_TRUE_FOR) {
+    const STrueForNode *pTrueFor = (const STrueForNode *)pNode;
+    pInfo->trueForType = pTrueFor->trueForType;
+    pInfo->count = pTrueFor->count;
+    if (pTrueFor->pDuration != NULL && nodeType(pTrueFor->pDuration) == QUERY_NODE_VALUE) {
+      pInfo->duration = ((const SValueNode *)pTrueFor->pDuration)->datum.i;
+    }
+    return true;
+  }
+
+  if (nodeType((SNode *)pNode) == QUERY_NODE_VALUE) {
+    pInfo->trueForType = TRUE_FOR_DURATION_ONLY;
+    pInfo->duration = ((const SValueNode *)pNode)->datum.i;
+    return true;
+  }
+
+  return false;
+}
+
+static SNode *stTriggerTaskUnwrapEventStartLeaf(SNode *pNode, bool *pHasLocalTrueFor, STrueForInfo *pInfo) {
+  if (pHasLocalTrueFor != NULL) {
+    *pHasLocalTrueFor = false;
+  }
+  if (pInfo != NULL) {
+    TAOS_MEMSET(pInfo, 0, sizeof(*pInfo));
+  }
+  if (pNode == NULL || nodeType(pNode) != QUERY_NODE_EVENT_START_LEAF) {
+    return pNode;
+  }
+
+  SEventStartLeafNode *pLeaf = (SEventStartLeafNode *)pNode;
+  if (pHasLocalTrueFor != NULL) {
+    *pHasLocalTrueFor = stTriggerTaskParseTrueForNode(pLeaf->pTrueForLimit, pInfo);
+  }
+  return pLeaf->pCond;
+}
+
+static SNode *stTriggerTaskGetEventMetaCond(const SSTriggerEventNodeMeta *pMeta, bool useHistCond) {
+  if (pMeta == NULL) {
+    return NULL;
+  }
+
+  return (useHistCond && pMeta->pHistCond != NULL) ? pMeta->pHistCond : pMeta->pCond;
+}
+
+static const STrueForInfo *stTriggerTaskGetEffectiveEventTrueForInfo(const SStreamTriggerTask *pTask, int32_t nodeId,
+                                                                     STrueForInfo *pBuf) {
+  SSTriggerEventNodeMeta *pMeta = stTriggerTaskGetEventMeta(pTask, nodeId);
+  if (pMeta != NULL && pMeta->isLeaf) {
+    if (pBuf != NULL) {
+      *pBuf = pMeta->effectiveTrueForInfo;
+      return pBuf;
+    }
+    return &pMeta->effectiveTrueForInfo;
+  }
+
+  if (pTask == NULL || pTask->triggerType != STREAM_TRIGGER_EVENT) {
+    return NULL;
+  }
+
+  if (pBuf != NULL) {
+    *pBuf = pTask->eventTrueForInfo;
+    return pBuf;
+  }
+  return &pTask->eventTrueForInfo;
+}
+
+static bool stTriggerTaskIsTrueForSatisfied(const STrueForInfo *pTrueForInfo, int64_t skey, int64_t ekey,
+                                            int64_t wrownum) {
+  if (pTrueForInfo == NULL || (pTrueForInfo->duration == 0 && pTrueForInfo->count == 0)) {
+    return true;
+  }
+
+  return isTrueForSatisfied((STrueForInfo *)pTrueForInfo, skey, ekey, wrownum);
+}
+
+static bool stTriggerTaskNeedRawEventNodeWindows(const SStreamTriggerTask *pTask) {
+  return pTask != NULL && pTask->triggerType == STREAM_TRIGGER_EVENT && pTask->startCondHasSubEvents &&
+         (pTask->placeHolderBitmap & PLACE_HOLDER_EVENT_CONDITION_PATH) &&
+         (pTask->placeHolderBitmap & PLACE_HOLDER_PARTITION_ROWS) == 0;
+}
+
+static bool stTriggerTaskShouldDelayEventCalcStart(const SStreamTriggerTask *pTask, int32_t nodeId) {
+  SSTriggerEventNodeMeta *pMeta = stTriggerTaskGetEventMeta(pTask, nodeId);
+  return !stTriggerTaskNeedRawEventNodeWindows(pTask) && pMeta != NULL && pMeta->isLeaf && pMeta->hasLocalTrueFor &&
+         (pMeta->localTrueForInfo.duration > 0 || pMeta->localTrueForInfo.count > 0);
+}
+
+static void stTriggerTaskInitEventWindowCalcState(const SStreamTriggerTask *pTask, int32_t nodeId, int64_t rawStartTs,
+                                                  int64_t rawRows, int64_t *pCalcStartTs, int64_t *pCalcWrownum) {
+  if (pCalcStartTs == NULL || pCalcWrownum == NULL) {
+    return;
+  }
+
+  *pCalcStartTs = rawStartTs;
+  *pCalcWrownum = stTriggerTaskShouldDelayEventCalcStart(pTask, nodeId) ? 0 : rawRows;
+}
+
+static void stTriggerTaskAdvanceEventWindowCalcState(const SStreamTriggerTask *pTask, int32_t nodeId,
+                                                     int64_t rawStartTs, int64_t rawEndTs, int64_t rawRows,
+                                                     int64_t rowTs, int64_t *pCalcStartTs, int64_t *pCalcWrownum) {
+  if (pCalcStartTs == NULL || pCalcWrownum == NULL) {
+    return;
+  }
+  (void)rowTs;
+
+  if (!stTriggerTaskShouldDelayEventCalcStart(pTask, nodeId)) {
+    *pCalcStartTs = rawStartTs;
+    *pCalcWrownum = rawRows;
+    return;
+  }
+
+  STrueForInfo        trueForInfo = {0};
+  const STrueForInfo *pTrueForInfo = stTriggerTaskGetEffectiveEventTrueForInfo(pTask, nodeId, &trueForInfo);
+  const bool          satisfied = stTriggerTaskIsTrueForSatisfied(pTrueForInfo, rawStartTs, rawEndTs, rawRows);
+  if (!satisfied) {
+    *pCalcStartTs = rawStartTs;
+    *pCalcWrownum = 0;
+    return;
+  }
+
+  if (*pCalcWrownum == 0) {
+    *pCalcStartTs = rowTs;
+    *pCalcWrownum = 1;
+  } else {
+    ++(*pCalcWrownum);
+  }
+}
+
+static int32_t stTriggerTaskSetEventConditionPath(const SStreamTriggerTask *pTask, int32_t nodeId, char **ppPath) {
+  if (ppPath == NULL) {
+    return TSDB_CODE_INVALID_PARA;
+  }
+
+  *ppPath = NULL;
+  SSTriggerEventNodeMeta *pMeta = stTriggerTaskGetEventMeta(pTask, nodeId);
+  const char             *path = (pMeta != NULL && pMeta->path != NULL) ? pMeta->path : "";
+  *ppPath = taosStrdup(path);
+  return (*ppPath != NULL) ? TSDB_CODE_SUCCESS : terrno;
+}
+
+static int64_t stTriggerTaskGetParentEventWindowStart(const SStreamTriggerTask *pTask, const SArray *pParentStates,
+                                                      int32_t nodeId) {
+  SSTriggerEventNodeMeta *pMeta = stTriggerTaskGetEventMeta(pTask, nodeId);
+  if (pMeta == NULL || pMeta->parentNodeId < 0 || pParentStates == NULL) {
+    return 0;
+  }
+
+  for (int32_t i = 0; i < taosArrayGetSize((SArray *)pParentStates); ++i) {
+    SSTriggerParentRuntimeState *pState = taosArrayGet((SArray *)pParentStates, i);
+    if (pState != NULL && pState->nodeId == pMeta->parentNodeId && pState->state != STRIGGER_EVENT_NODE_IDLE) {
+      return pState->curStartTs;
+    }
+  }
+
+  return 0;
+}
+
+static void stTriggerTaskSetEventParentWindowInfo(const SStreamTriggerTask *pTask, const SArray *pParentStates,
+                                                  SSTriggerNotifyWindow *pWin) {
+  if (pWin == NULL) {
+    return;
+  }
+
+  pWin->parentEventNodeId = -1;
+  SSTriggerEventNodeMeta *pMeta = stTriggerTaskGetEventMeta(pTask, pWin->eventNodeId);
+  if (pMeta == NULL || pMeta->parentNodeId < 0) {
+    pWin->parentWindowStart = 0;
+    return;
+  }
+
+  pWin->parentEventNodeId = pMeta->parentNodeId;
+  pWin->parentWindowStart = stTriggerTaskGetParentEventWindowStart(pTask, pParentStates, pWin->eventNodeId);
+}
+
+static bool stTriggerTaskShouldDeferSingleEventSubWindow(const SStreamTriggerTask *pTask, const SArray *pWindows,
+                                                         const SSTriggerNotifyWindow *pWin, bool needRawNodeWindow) {
+  if (needRawNodeWindow || pTask == NULL || pWindows == NULL || pWin == NULL) {
+    return false;
+  }
+
+  SSTriggerEventNodeMeta *pMeta = stTriggerTaskGetEventMeta(pTask, pWin->eventNodeId);
+  if (pMeta == NULL || !pMeta->isLeaf || pMeta->parentNodeId < 0) {
+    return false;
+  }
+
+  int32_t nSiblingWindows = 0;
+  for (int32_t i = 0; i < TARRAY_SIZE((SArray *)pWindows); ++i) {
+    SSTriggerNotifyWindow *pSibling = TARRAY_GET_ELEM((SArray *)pWindows, i);
+    if (pSibling == NULL || pSibling->parentEventNodeId != pMeta->parentNodeId ||
+        pSibling->parentWindowStart != pWin->parentWindowStart) {
+      continue;
+    }
+    ++nSiblingWindows;
+    if (nSiblingWindows > 1) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static int32_t stTriggerTaskBuildEventNotify(const SStreamTriggerTask *pTask, const SSDataBlock *pInputBlock,
+                                             const SNodeList *pCondCols, int32_t rowIdx, int32_t nodeId,
+                                             int64_t groupId, int64_t windowStart, int64_t parentWindowStart,
+                                             char **ppContent) {
+  SSTriggerEventNodeMeta *pMeta = stTriggerTaskGetEventMeta(pTask, nodeId);
+  const char             *path = (pMeta != NULL && pMeta->path != NULL) ? pMeta->path : "";
+  return streamBuildEventNotifyContent(pInputBlock, pCondCols, rowIdx, path, groupId, windowStart, parentWindowStart,
+                                       ppContent);
+}
+
+static uint64_t stTriggerTaskGetEventStartMask(const SColumnInfoData *pStartCol, int32_t rowIdx) {
+  if (pStartCol == NULL || pStartCol->pData == NULL || rowIdx < 0) {
+    return 0;
+  }
+
+  if (pStartCol->info.type == TSDB_DATA_TYPE_BIGINT) {
+    return ((uint64_t *)pStartCol->pData)[rowIdx];
+  }
+
+  int32_t idx = 0;
+  if (pStartCol->info.type == TSDB_DATA_TYPE_INT) {
+    idx = ((int32_t *)pStartCol->pData)[rowIdx];
+  } else {
+    idx = ((uint8_t *)pStartCol->pData)[rowIdx];
+  }
+
+  return (idx > 0 && idx <= 64) ? (1ULL << (idx - 1)) : 0;
+}
+
+static int32_t stTriggerTaskGetFirstMatchedEventLeaf(const SStreamTriggerTask *pTask, uint64_t mask) {
+  if (pTask == NULL || pTask->pStartCondMeta == NULL || mask == 0) {
+    return -1;
+  }
+
+  int32_t nMetas = taosArrayGetSize(pTask->pStartCondMeta);
+  for (int32_t priority = 0; priority < nMetas && priority < 64; ++priority) {
+    for (int32_t i = 0; i < nMetas; ++i) {
+      SSTriggerEventNodeMeta *pMeta = taosArrayGet(pTask->pStartCondMeta, i);
+      if (pMeta != NULL && pMeta->isLeaf && pMeta->priority == priority && pMeta->leafIndex >= 0 &&
+          (mask & (1ULL << pMeta->leafIndex))) {
+        return pMeta->nodeId;
+      }
+    }
+  }
+
+  return -1;
+}
+
+static bool stTriggerTaskEventNodeTruth(const SStreamTriggerTask *pTask, int32_t nodeId, uint64_t mask) {
+  SSTriggerEventNodeMeta *pMeta = stTriggerTaskGetEventMeta(pTask, nodeId);
+  if (pMeta == NULL) {
+    return false;
+  }
+
+  if (pMeta->isLeaf) {
+    return pMeta->leafIndex >= 0 && (mask & (1ULL << pMeta->leafIndex));
+  }
+
+  int32_t nMetas = taosArrayGetSize(pTask->pStartCondMeta);
+  for (int32_t i = 0; i < nMetas; ++i) {
+    SSTriggerEventNodeMeta *pChild = taosArrayGet(pTask->pStartCondMeta, i);
+    if (pChild != NULL && pChild->parentNodeId == nodeId && stTriggerTaskEventNodeTruth(pTask, pChild->nodeId, mask)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static SSTriggerLeafRuntimeState *stTriggerTaskGetLeafRuntimeState(SArray *pLeafStates, int32_t nodeId) {
+  if (pLeafStates == NULL) {
+    return NULL;
+  }
+
+  for (int32_t i = 0; i < taosArrayGetSize(pLeafStates); ++i) {
+    SSTriggerLeafRuntimeState *pState = taosArrayGet(pLeafStates, i);
+    if (pState != NULL && pState->nodeId == nodeId) {
+      return pState;
+    }
+  }
+  return NULL;
+}
+
+static void stTriggerTaskResetLeafRuntimeState(SSTriggerLeafRuntimeState *pState) {
+  if (pState == NULL) {
+    return;
+  }
+
+  pState->state = STRIGGER_EVENT_NODE_IDLE;
+  pState->curStartTs = 0;
+  pState->curLastTs = 0;
+  pState->curRowCount = 0;
+  pState->calcStartTs = 0;
+  pState->calcRowCount = 0;
+}
+
+static void stTriggerTaskUpdateLeafRuntimeStates(const SStreamTriggerTask *pTask, SArray *pLeafStates,
+                                                 uint64_t startMask, int64_t rowTs) {
+  if (pTask == NULL || pTask->pStartCondMeta == NULL || pLeafStates == NULL) {
+    return;
+  }
+
+  int32_t nMetas = taosArrayGetSize(pTask->pStartCondMeta);
+  for (int32_t i = 0; i < nMetas; ++i) {
+    SSTriggerEventNodeMeta *pMeta = taosArrayGet(pTask->pStartCondMeta, i);
+    if (pMeta == NULL || !pMeta->isLeaf || pMeta->leafIndex < 0) {
+      continue;
+    }
+
+    SSTriggerLeafRuntimeState *pState = stTriggerTaskGetLeafRuntimeState(pLeafStates, pMeta->nodeId);
+    if (pState == NULL) {
+      continue;
+    }
+
+    bool leafTrue = (startMask & (1ULL << pMeta->leafIndex)) != 0;
+    if (!leafTrue) {
+      stTriggerTaskResetLeafRuntimeState(pState);
+      continue;
+    }
+
+    if (pState->state == STRIGGER_EVENT_NODE_IDLE) {
+      pState->state = STRIGGER_EVENT_NODE_TRACKING;
+      pState->curStartTs = rowTs;
+      pState->curLastTs = rowTs;
+      pState->curRowCount = 1;
+    } else {
+      pState->curLastTs = rowTs;
+      ++pState->curRowCount;
+    }
+
+    if (stTriggerTaskIsTrueForSatisfied(&pMeta->effectiveTrueForInfo, pState->curStartTs, pState->curLastTs,
+                                        pState->curRowCount)) {
+      pState->state = STRIGGER_EVENT_NODE_SATISFIED;
+    }
+  }
+}
+
+static bool stTriggerTaskLeafNeedsLocalTrueFor(const SSTriggerEventNodeMeta *pMeta) {
+  return pMeta != NULL && pMeta->hasLocalTrueFor &&
+         (pMeta->localTrueForInfo.duration > 0 || pMeta->localTrueForInfo.count > 0);
+}
+
+static int32_t stTriggerTaskGetFirstEligibleEventLeaf(const SStreamTriggerTask *pTask, SArray *pLeafStates,
+                                                      uint64_t mask) {
+  if (pTask == NULL || pTask->pStartCondMeta == NULL || pLeafStates == NULL || mask == 0) {
+    return -1;
+  }
+
+  if (stTriggerTaskNeedRawEventNodeWindows(pTask)) {
+    return stTriggerTaskGetFirstMatchedEventLeaf(pTask, mask);
+  }
+
+  int32_t nMetas = taosArrayGetSize(pTask->pStartCondMeta);
+  for (int32_t priority = 0; priority < nMetas && priority < 64; ++priority) {
+    for (int32_t i = 0; i < nMetas; ++i) {
+      SSTriggerEventNodeMeta *pMeta = taosArrayGet(pTask->pStartCondMeta, i);
+      if (pMeta == NULL || !pMeta->isLeaf || pMeta->priority != priority || pMeta->leafIndex < 0 ||
+          (mask & (1ULL << pMeta->leafIndex)) == 0) {
+        continue;
+      }
+
+      SSTriggerLeafRuntimeState *pState = stTriggerTaskGetLeafRuntimeState(pLeafStates, pMeta->nodeId);
+      if (!stTriggerTaskLeafNeedsLocalTrueFor(pMeta) ||
+          (pState != NULL && pState->state == STRIGGER_EVENT_NODE_SATISFIED)) {
+        return pMeta->nodeId;
+      }
+    }
+  }
+
+  return -1;
+}
+
+static bool stTriggerTaskGetLocalTrueForOpenState(const SStreamTriggerTask *pTask, SArray *pLeafStates, int32_t nodeId,
+                                                  SSTriggerLeafRuntimeState **ppState) {
+  SSTriggerEventNodeMeta *pMeta = stTriggerTaskGetEventMeta(pTask, nodeId);
+  if (!stTriggerTaskLeafNeedsLocalTrueFor(pMeta)) {
+    return false;
+  }
+
+  SSTriggerLeafRuntimeState *pState = stTriggerTaskGetLeafRuntimeState(pLeafStates, nodeId);
+  if (pState == NULL || pState->state != STRIGGER_EVENT_NODE_SATISFIED || pState->curRowCount <= 0) {
+    return false;
+  }
+
+  if (ppState != NULL) {
+    *ppState = pState;
+  }
+  return true;
+}
+
+static void stTriggerTaskReleaseCalcParamOwnership(SSTriggerCalcParam *pParam) {
+  if (pParam == NULL) {
+    return;
+  }
+
+  pParam->conditionPath = NULL;
+  pParam->extraNotifyContent = NULL;
+  pParam->resultNotifyContent = NULL;
+  pParam->pExternalWindowData = NULL;
+}
+
+static bool stTriggerTaskUseParentCalcParam(const SObjList *pParentParams, const SObjList *pCalcParams) {
+  if (pParentParams == NULL || pParentParams->neles == 0) {
+    return false;
+  }
+  if (pCalcParams == NULL || pCalcParams->neles == 0) {
+    return true;
+  }
+
+  SSTriggerCalcParam *pParent = taosObjListGetHead((SObjList *)pParentParams);
+  SSTriggerCalcParam *pCalc = taosObjListGetHead((SObjList *)pCalcParams);
+  if (pParent == NULL) {
+    return false;
+  }
+  if (pCalc == NULL) {
+    return true;
+  }
+
+  if (pParent->wstart != pCalc->wstart) {
+    return pParent->wstart < pCalc->wstart;
+  }
+
+  return false;
+}
+
+static int32_t stTriggerTaskTakePendingCalcParam(SObjList *pPendingParams, SArray *pParams) {
+  if (pPendingParams == NULL || pParams == NULL || pPendingParams->neles == 0) {
+    return TSDB_CODE_SUCCESS;
+  }
+
+  SSTriggerCalcParam *pParam = taosObjListGetHead(pPendingParams);
+  if (pParam == NULL) {
+    return TSDB_CODE_INTERNAL_ERROR;
+  }
+
+  void *px = taosArrayPush(pParams, pParam);
+  if (px == NULL) {
+    return terrno;
+  }
+
+  stTriggerTaskReleaseCalcParamOwnership(pParam);
+  taosObjListPopHead(pPendingParams);
+  return TSDB_CODE_SUCCESS;
+}
+
+static bool stTriggerTaskNeedOverlapSafeCalcRange(const SStreamTriggerTask *pTask) {
+  return stTriggerTaskNeedRawEventNodeWindows(pTask);
+}
+
+static int64_t stTriggerTaskGetCalcParamFetchStart(const SStreamTriggerTask *pTask, const SArray *pParams,
+                                                   const SSTriggerCalcParam *pParam) {
+  if (pParam == NULL) {
+    return INT64_MIN;
+  }
+
+  // Parent/child event windows can overlap on the same source rows. Reusing the previous
+  // window's end as the next fetch start drops those rows and turns aggregates into zero.
+  if (stTriggerTaskNeedOverlapSafeCalcRange(pTask)) {
+    return pParam->wstart;
+  }
+
+  if (pParams == NULL) {
+    return pParam->wstart;
+  }
+
+  int32_t paramIdx = TARRAY_ELEM_IDX((SArray *)pParams, (SSTriggerCalcParam *)pParam);
+  if (paramIdx <= 0) {
+    return pParam->wstart;
+  }
+
+  int64_t prevMaxEnd = INT64_MIN;
+  for (int32_t i = 0; i < paramIdx; ++i) {
+    SSTriggerCalcParam *pPrevParam = taosArrayGet((SArray *)pParams, i);
+    if (pPrevParam != NULL) {
+      prevMaxEnd = TMAX(prevMaxEnd, pPrevParam->wend);
+    }
+  }
+
+  return (prevMaxEnd == INT64_MIN) ? pParam->wstart : TMAX(pParam->wstart, prevMaxEnd + 1);
+}
+
+static void stTriggerTaskDestroyLeafRuntimeState(void *ptr) {
+  SSTriggerLeafRuntimeState *pState = ptr;
+  if (pState == NULL) {
+    return;
+  }
+  taosArrayDestroy(pState->pQualifiedHistory);
+  pState->pQualifiedHistory = NULL;
+}
+
+static void stTriggerTaskDestroyParentRuntimeState(void *ptr) {
+  SSTriggerParentRuntimeState *pState = ptr;
+  if (pState == NULL) {
+    return;
+  }
+  taosMemoryFreeClear(pState->pWinOpenNotify);
+}
+
+static int32_t stTriggerTaskInitEventRuntimeStates(const SStreamTriggerTask *pTask, SArray **ppLeafStates,
+                                                   SArray **ppParentStates) {
+  int32_t code = TSDB_CODE_SUCCESS;
+  int32_t lino = 0;
+  SArray *pLeafStates = NULL;
+  SArray *pParentStates = NULL;
+
+  QUERY_CHECK_CONDITION(pTask != NULL && pTask->triggerType == STREAM_TRIGGER_EVENT && pTask->pStartCondMeta != NULL,
+                        code, lino, _end, TSDB_CODE_INVALID_PARA);
+
+  pLeafStates = taosArrayInit(0, sizeof(SSTriggerLeafRuntimeState));
+  QUERY_CHECK_NULL(pLeafStates, code, lino, _end, terrno);
+  pParentStates = taosArrayInit(0, sizeof(SSTriggerParentRuntimeState));
+  QUERY_CHECK_NULL(pParentStates, code, lino, _end, terrno);
+
+  for (int32_t i = 0; i < taosArrayGetSize(pTask->pStartCondMeta); ++i) {
+    SSTriggerEventNodeMeta *pMeta = taosArrayGet(pTask->pStartCondMeta, i);
+    if (pMeta == NULL) {
+      continue;
+    }
+    if (pMeta->isLeaf) {
+      SSTriggerLeafRuntimeState state = {.nodeId = pMeta->nodeId, .state = STRIGGER_EVENT_NODE_IDLE};
+      state.pQualifiedHistory = taosArrayInit(0, sizeof(SSTriggerEventInterval));
+      QUERY_CHECK_NULL(state.pQualifiedHistory, code, lino, _end, terrno);
+      void *px = taosArrayPush(pLeafStates, &state);
+      QUERY_CHECK_NULL(px, code, lino, _end, terrno);
+    } else {
+      SSTriggerParentRuntimeState state = {.nodeId = pMeta->nodeId, .state = STRIGGER_EVENT_NODE_IDLE};
+      void                       *px = taosArrayPush(pParentStates, &state);
+      QUERY_CHECK_NULL(px, code, lino, _end, terrno);
+    }
+  }
+
+  *ppLeafStates = pLeafStates;
+  *ppParentStates = pParentStates;
+  pLeafStates = NULL;
+  pParentStates = NULL;
+
+_end:
+  if (pLeafStates != NULL) {
+    taosArrayDestroyEx(pLeafStates, stTriggerTaskDestroyLeafRuntimeState);
+  }
+  if (pParentStates != NULL) {
+    taosArrayDestroyEx(pParentStates, stTriggerTaskDestroyParentRuntimeState);
+  }
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
+static void stTriggerTaskResetEventRuntimeStates(SArray *pLeafStates, SArray *pParentStates) {
+  if (pLeafStates != NULL) {
+    for (int32_t i = 0; i < taosArrayGetSize(pLeafStates); ++i) {
+      SSTriggerLeafRuntimeState *pState = taosArrayGet(pLeafStates, i);
+      if (pState == NULL) {
+        continue;
+      }
+      pState->state = STRIGGER_EVENT_NODE_IDLE;
+      pState->curStartTs = 0;
+      pState->curLastTs = 0;
+      pState->curRowCount = 0;
+      pState->calcStartTs = 0;
+      pState->calcRowCount = 0;
+      if (pState->pQualifiedHistory != NULL) {
+        taosArrayClear(pState->pQualifiedHistory);
+      }
+    }
+  }
+  if (pParentStates != NULL) {
+    for (int32_t i = 0; i < taosArrayGetSize(pParentStates); ++i) {
+      SSTriggerParentRuntimeState *pState = taosArrayGet(pParentStates, i);
+      if (pState == NULL) {
+        continue;
+      }
+      pState->state = STRIGGER_EVENT_NODE_IDLE;
+      pState->curStartTs = 0;
+      pState->curLastTs = 0;
+      pState->curRowCount = 0;
+      taosMemoryFreeClear(pState->pWinOpenNotify);
+    }
+  }
+}
+
 static int32_t stTriggerTaskAddWaitSession(SStreamTriggerTask *pTask, int64_t sessionId, int64_t resumeTime) {
   int32_t code = TSDB_CODE_SUCCESS;
   int32_t lino = 0;
@@ -2436,6 +3034,141 @@ _end:
   return code;
 }
 
+static void stTriggerTaskDestroyEventNodeMeta(void *ptr) {
+  SSTriggerEventNodeMeta *pMeta = ptr;
+  if (pMeta == NULL) {
+    return;
+  }
+
+  taosMemoryFreeClear(pMeta->path);
+}
+
+static int32_t stTriggerTaskBuildEventMetaItem(SStreamTriggerTask *pTask, SNode *pNode, int32_t parentNodeId,
+                                               int32_t localIndex, const char *pParentPath, SArray *pMetas,
+                                               int32_t *pLeafCounter) {
+  int32_t                code = TSDB_CODE_SUCCESS;
+  int32_t                lino = 0;
+  char                   pathBuf[TSDB_MAX_EVENT_CONDITION_PATH_LEN] = {0};
+  int32_t                pathLen = 0;
+  bool                   hasLocalTrueFor = false;
+  STrueForInfo           localTrueForInfo = {0};
+  SNode                 *pActualNode = stTriggerTaskUnwrapEventStartLeaf(pNode, &hasLocalTrueFor, &localTrueForInfo);
+  SSTriggerEventNodeMeta meta = {0};
+
+  if (pParentPath == NULL) {
+    pathLen = 0;
+  } else if (pParentPath[0] == '\0') {
+    pathLen = snprintf(pathBuf, sizeof(pathBuf), "%d", localIndex);
+  } else {
+    pathLen = snprintf(pathBuf, sizeof(pathBuf), "%s.%d", pParentPath, localIndex);
+  }
+  QUERY_CHECK_CONDITION(pathLen >= 0 && pathLen < TSDB_MAX_EVENT_CONDITION_PATH_LEN, code, lino, _end,
+                        TSDB_CODE_INTERNAL_ERROR);
+
+  meta.nodeId = taosArrayGetSize(pMetas);
+  meta.parentNodeId = parentNodeId;
+  meta.localIndex = localIndex;
+  meta.leafIndex = -1;
+  meta.priority = -1;
+  meta.isLeaf = (pActualNode != NULL && nodeType(pActualNode) != QUERY_NODE_NODE_LIST);
+  meta.hasLocalTrueFor = hasLocalTrueFor;
+  meta.localTrueForInfo = localTrueForInfo;
+  if (meta.isLeaf) {
+    meta.pCond = pActualNode;
+    meta.leafIndex = *pLeafCounter;
+    meta.priority = *pLeafCounter;
+    ++(*pLeafCounter);
+    meta.effectiveTrueForInfo = meta.hasLocalTrueFor ? meta.localTrueForInfo : pTask->eventTrueForInfo;
+  }
+  QUERY_CHECK_CONDITION(meta.pCond == NULL || ((SExprNode *)meta.pCond)->resType.type == TSDB_DATA_TYPE_BOOL, code,
+                        lino, _end, TSDB_CODE_INVALID_PARA);
+
+  meta.path = taosStrdup(pathBuf);
+  QUERY_CHECK_NULL(meta.path, code, lino, _end, terrno);
+  void *px = taosArrayPush(pMetas, &meta);
+  QUERY_CHECK_NULL(px, code, lino, _end, terrno);
+  meta.path = NULL;
+  int32_t nodeId = taosArrayGetSize(pMetas) - 1;
+
+  if (pActualNode != NULL && nodeType(pActualNode) == QUERY_NODE_NODE_LIST) {
+    SNodeList *pNodeList = ((SNodeListNode *)pActualNode)->pNodeList;
+    SNode     *pChild = NULL;
+    int32_t    childIndex = 0;
+    FOREACH(pChild, pNodeList) {
+      code = stTriggerTaskBuildEventMetaItem(pTask, pChild, nodeId, childIndex++, pathBuf, pMetas, pLeafCounter);
+      QUERY_CHECK_CODE(code, lino, _end);
+    }
+  }
+
+_end:
+  stTriggerTaskDestroyEventNodeMeta(&meta);
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
+static int32_t stTriggerTaskBuildEventMetas(SStreamTriggerTask *pTask, SNode *pStartCond, SArray **ppMetas) {
+  int32_t code = TSDB_CODE_SUCCESS;
+  int32_t lino = 0;
+  SArray *pMetas = NULL;
+  int32_t leafCounter = 0;
+
+  QUERY_CHECK_NULL(pStartCond, code, lino, _end, TSDB_CODE_INVALID_PARA);
+  pMetas = taosArrayInit(0, sizeof(SSTriggerEventNodeMeta));
+  QUERY_CHECK_NULL(pMetas, code, lino, _end, terrno);
+
+  code = stTriggerTaskBuildEventMetaItem(pTask, pStartCond, -1, 0, NULL, pMetas, &leafCounter);
+  QUERY_CHECK_CODE(code, lino, _end);
+  QUERY_CHECK_CONDITION(leafCounter <= 64, code, lino, _end, TSDB_CODE_INVALID_PARA);
+
+  *ppMetas = pMetas;
+  pMetas = NULL;
+
+_end:
+  if (pMetas != NULL) {
+    taosArrayDestroyEx(pMetas, stTriggerTaskDestroyEventNodeMeta);
+  }
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
+static int32_t stTriggerTaskBindHistEventConds(SStreamTriggerTask *pTask) {
+  int32_t code = TSDB_CODE_SUCCESS;
+  int32_t lino = 0;
+  SArray *pHistMetas = NULL;
+
+  QUERY_CHECK_CONDITION(pTask != NULL && pTask->triggerType == STREAM_TRIGGER_EVENT && pTask->pStartCondMeta != NULL &&
+                            pTask->histStartCond != NULL,
+                        code, lino, _end, TSDB_CODE_INVALID_PARA);
+
+  code = stTriggerTaskBuildEventMetas(pTask, pTask->histStartCond, &pHistMetas);
+  QUERY_CHECK_CODE(code, lino, _end);
+  QUERY_CHECK_CONDITION(taosArrayGetSize(pTask->pStartCondMeta) == taosArrayGetSize(pHistMetas), code, lino, _end,
+                        TSDB_CODE_INTERNAL_ERROR);
+
+  for (int32_t i = 0; i < taosArrayGetSize(pTask->pStartCondMeta); ++i) {
+    SSTriggerEventNodeMeta *pMeta = taosArrayGet(pTask->pStartCondMeta, i);
+    SSTriggerEventNodeMeta *pHistMeta = taosArrayGet(pHistMetas, i);
+    QUERY_CHECK_CONDITION(pMeta != NULL && pHistMeta != NULL && pMeta->isLeaf == pHistMeta->isLeaf &&
+                              pMeta->path != NULL && pHistMeta->path != NULL &&
+                              strcmp(pMeta->path, pHistMeta->path) == 0,
+                          code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
+    pMeta->pHistCond = pHistMeta->pCond;
+  }
+
+_end:
+  if (pHistMetas != NULL) {
+    taosArrayDestroyEx(pHistMetas, stTriggerTaskDestroyEventNodeMeta);
+  }
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
 int32_t stTriggerTaskDeploy(SStreamTriggerTask *pTask, SStreamTriggerDeployMsg *pMsg) {
   int32_t    code = TSDB_CODE_SUCCESS;
   int32_t    lino = 0;
@@ -2495,6 +3228,9 @@ int32_t stTriggerTaskDeploy(SStreamTriggerTask *pTask, SStreamTriggerDeployMsg *
       pTask->eventTrueForInfo.trueForType = pEvent->trueForType;
       pTask->eventTrueForInfo.count = pEvent->trueForCount;
       pTask->eventTrueForInfo.duration = pEvent->trueForDuration;
+      pTask->startCondHasSubEvents = nodeType(pTask->pStartCond) == QUERY_NODE_NODE_LIST;
+      code = stTriggerTaskBuildEventMetas(pTask, pTask->pStartCond, &pTask->pStartCondMeta);
+      QUERY_CHECK_CODE(code, lino, _end);
       code = nodesCollectColumnsFromNode(pTask->pStartCond, NULL, COLLECT_COL_TYPE_ALL, &pTask->pStartCondCols);
       QUERY_CHECK_CODE(code, lino, _end);
       if (nodeType(pTask->pStartCond) == QUERY_NODE_NODE_LIST) {
@@ -2618,6 +3354,8 @@ int32_t stTriggerTaskDeploy(SStreamTriggerTask *pTask, SStreamTriggerDeployMsg *
     code = nodesCloneList(pTask->pStartCondCols, &pTask->histStartCondCols);
     QUERY_CHECK_CODE(code, lino, _end);
     code = nodesCloneList(pTask->pEndCondCols, &pTask->histEndCondCols);
+    QUERY_CHECK_CODE(code, lino, _end);
+    code = stTriggerTaskBindHistEventConds(pTask);
     QUERY_CHECK_CODE(code, lino, _end);
   }
 
@@ -2768,6 +3506,10 @@ int32_t stTriggerTaskUndeployImpl(SStreamTriggerTask **ppTask, const SStreamUnde
     if (pTask->pEndCondCols != NULL) {
       nodesDestroyList(pTask->pEndCondCols);
       pTask->pEndCondCols = NULL;
+    }
+    if (pTask->pStartCondMeta != NULL) {
+      taosArrayDestroyEx(pTask->pStartCondMeta, stTriggerTaskDestroyEventNodeMeta);
+      pTask->pStartCondMeta = NULL;
     }
   }
 
@@ -3447,7 +4189,56 @@ static int32_t stRealtimeContextCalcExpr(SSTriggerRealtimeContext *pContext, SSD
   void *px = taosArrayPush(pList, &pDataBlock);
   QUERY_CHECK_NULL(px, code, lino, _end, terrno);
 
-  if (pExpr == NULL || nodeType(pExpr) == QUERY_NODE_NODE_LIST) {
+  if (pExpr == NULL) {
+    pResCol->info.type = TSDB_DATA_TYPE_UINT;
+    pResCol->info.bytes = 1;
+    pResCol->info.scale = 0;
+    pResCol->info.precision = 0;
+
+    code = colInfoDataEnsureCapacity(pResCol, pDataBlock->info.capacity, false);
+    QUERY_CHECK_CODE(code, lino, _end);
+    TAOS_MEMSET(pResCol->nullbitmap, 0, BitmapLen(pDataBlock->info.capacity));
+    TAOS_MEMSET(pResCol->pData, 0, pDataBlock->info.capacity);
+  } else if (pTask->triggerType == STREAM_TRIGGER_EVENT && pTask->startCondHasSubEvents && pExpr == pTask->pStartCond) {
+    pResCol->info.type = TSDB_DATA_TYPE_BIGINT;
+    pResCol->info.bytes = 8;
+    pResCol->info.scale = 0;
+    pResCol->info.precision = 0;
+    int32_t nrows = blockDataGetNumOfRows(pDataBlock);
+    code = colInfoDataEnsureCapacity(pResCol, pDataBlock->info.capacity, false);
+    QUERY_CHECK_CODE(code, lino, _end);
+    TAOS_MEMSET(pResCol->nullbitmap, 0, BitmapLen(pDataBlock->info.capacity));
+    TAOS_MEMSET(pResCol->pData, 0, pDataBlock->info.capacity * sizeof(uint64_t));
+
+    int32_t nMetas = taosArrayGetSize(pTask->pStartCondMeta);
+    for (int32_t i = 0; i < nMetas; ++i) {
+      SSTriggerEventNodeMeta *pMeta = taosArrayGet(pTask->pStartCondMeta, i);
+      SNode                  *pCond = stTriggerTaskGetEventMetaCond(pMeta, false);
+      if (pMeta == NULL || !pMeta->isLeaf || pCond == NULL) {
+        continue;
+      }
+      if (pTmpCol == NULL) {
+        pTmpCol = taosMemoryCalloc(1, sizeof(SColumnInfoData));
+        QUERY_CHECK_NULL(pTmpCol, code, lino, _end, terrno);
+      }
+      SDataType *pType = &((SExprNode *)pCond)->resType;
+      pTmpCol->info.type = pType->type;
+      pTmpCol->info.bytes = pType->bytes;
+      pTmpCol->info.scale = pType->scale;
+      pTmpCol->info.precision = pType->precision;
+
+      SScalarParam output = {.columnData = pTmpCol};
+      code = scalarCalculate(pCond, pList, &output, NULL);
+      QUERY_CHECK_CODE(code, lino, _end);
+      uint8_t  *pTmpData = (uint8_t *)pTmpCol->pData;
+      uint64_t *pResData = (uint64_t *)pResCol->pData;
+      for (int32_t r = 0; r < nrows; ++r) {
+        if (pTmpData[r]) {
+          pResData[r] |= (1ULL << pMeta->leafIndex);
+        }
+      }
+    }
+  } else if (nodeType(pExpr) == QUERY_NODE_NODE_LIST) {
     pResCol->info.type = TSDB_DATA_TYPE_UINT;
     pResCol->info.bytes = 1;
     pResCol->info.scale = 0;
@@ -3458,7 +4249,6 @@ static int32_t stRealtimeContextCalcExpr(SSTriggerRealtimeContext *pContext, SSD
     QUERY_CHECK_CODE(code, lino, _end);
     TAOS_MEMSET(pResCol->nullbitmap, 0, BitmapLen(pDataBlock->info.capacity));
     TAOS_MEMSET(pResCol->pData, 0, pDataBlock->info.capacity);
-
     uint8_t        idx = 1;
     SNode         *pNode = NULL;
     SNodeListNode *pListNode = (SNodeListNode *)pExpr;
@@ -4586,6 +5376,8 @@ static int32_t stRealtimeContextSendCalcReq(SSTriggerRealtimeContext *pContext, 
         if ((pTask->windowSliding > 0) && (pTask->windowSliding < pTask->windowCount)) {
           cleanMode = DATA_CLEAN_EXPIRED;
         }
+      } else if (pTask->triggerType == STREAM_TRIGGER_EVENT && pTask->startCondHasSubEvents) {
+        cleanMode = DATA_CLEAN_EXPIRED;
       }
       code = initStreamDataCache(pTask->task.streamId, pTask->task.taskId, pContext->sessionId, cleanMode,
                                  pTask->calcTsIndex, &pContext->pCalcDataCache);
@@ -7066,7 +7858,58 @@ static int32_t stHistoryContextCalcExpr(SSTriggerHistoryContext *pContext, SSDat
   void *px = taosArrayPush(pList, &pDataBlock);
   QUERY_CHECK_NULL(px, code, lino, _end, terrno);
 
-  if (pExpr == NULL || nodeType(pExpr) == QUERY_NODE_NODE_LIST) {
+  if (pExpr == NULL) {
+    pResCol->info.type = TSDB_DATA_TYPE_UINT;
+    pResCol->info.bytes = 1;
+    pResCol->info.scale = 0;
+    pResCol->info.precision = 0;
+
+    code = colInfoDataEnsureCapacity(pResCol, pDataBlock->info.capacity, false);
+    QUERY_CHECK_CODE(code, lino, _end);
+    TAOS_MEMSET(pResCol->nullbitmap, 0, BitmapLen(pDataBlock->info.capacity));
+    TAOS_MEMSET(pResCol->pData, 0, pDataBlock->info.capacity);
+  } else if (pTask->triggerType == STREAM_TRIGGER_EVENT && pTask->startCondHasSubEvents &&
+             (pExpr == pTask->pStartCond || pExpr == pTask->histStartCond)) {
+    bool useHistCond = (pExpr == pTask->histStartCond);
+    pResCol->info.type = TSDB_DATA_TYPE_BIGINT;
+    pResCol->info.bytes = 8;
+    pResCol->info.scale = 0;
+    pResCol->info.precision = 0;
+    int32_t nrows = blockDataGetNumOfRows(pDataBlock);
+    code = colInfoDataEnsureCapacity(pResCol, pDataBlock->info.capacity, false);
+    QUERY_CHECK_CODE(code, lino, _end);
+    TAOS_MEMSET(pResCol->nullbitmap, 0, BitmapLen(pDataBlock->info.capacity));
+    TAOS_MEMSET(pResCol->pData, 0, pDataBlock->info.capacity * sizeof(uint64_t));
+
+    int32_t nMetas = taosArrayGetSize(pTask->pStartCondMeta);
+    for (int32_t i = 0; i < nMetas; ++i) {
+      SSTriggerEventNodeMeta *pMeta = taosArrayGet(pTask->pStartCondMeta, i);
+      SNode                  *pCond = stTriggerTaskGetEventMetaCond(pMeta, useHistCond);
+      if (pMeta == NULL || !pMeta->isLeaf || pCond == NULL) {
+        continue;
+      }
+      if (pTmpCol == NULL) {
+        pTmpCol = taosMemoryCalloc(1, sizeof(SColumnInfoData));
+        QUERY_CHECK_NULL(pTmpCol, code, lino, _end, terrno);
+      }
+      SDataType *pType = &((SExprNode *)pCond)->resType;
+      pTmpCol->info.type = pType->type;
+      pTmpCol->info.bytes = pType->bytes;
+      pTmpCol->info.scale = pType->scale;
+      pTmpCol->info.precision = pType->precision;
+
+      SScalarParam output = {.columnData = pTmpCol};
+      code = scalarCalculate(pCond, pList, &output, NULL);
+      QUERY_CHECK_CODE(code, lino, _end);
+      uint8_t  *pTmpData = (uint8_t *)pTmpCol->pData;
+      uint64_t *pResData = (uint64_t *)pResCol->pData;
+      for (int32_t r = 0; r < nrows; ++r) {
+        if (pTmpData[r]) {
+          pResData[r] |= (1ULL << pMeta->leafIndex);
+        }
+      }
+    }
+  } else if (nodeType(pExpr) == QUERY_NODE_NODE_LIST) {
     pResCol->info.type = TSDB_DATA_TYPE_UINT;
     pResCol->info.bytes = 1;
     pResCol->info.scale = 0;
@@ -7077,7 +7920,6 @@ static int32_t stHistoryContextCalcExpr(SSTriggerHistoryContext *pContext, SSDat
     QUERY_CHECK_CODE(code, lino, _end);
     TAOS_MEMSET(pResCol->nullbitmap, 0, BitmapLen(pDataBlock->info.capacity));
     TAOS_MEMSET(pResCol->pData, 0, pDataBlock->info.capacity);
-
     uint8_t        idx = 1;
     SNode         *pNode = NULL;
     SNodeListNode *pListNode = (SNodeListNode *)pExpr;
@@ -7493,13 +8335,9 @@ static int32_t stHistoryContextSendPullReq(SSTriggerHistoryContext *pContext, ES
       SSTriggerTsdbCalcDataRequest *pReq = &pProgress->pullReq.tsdbCalcDataReq;
       SSTriggerHistoryGroup        *pGroup = stHistoryContextGetCurrentGroup(pContext);
       pReq->gid = pGroup->gid;
-      pReq->skey = pContext->pParamToFetch->wstart;
+      pReq->skey = stTriggerTaskGetCalcParamFetchStart(pTask, pContext->pCalcReq->params, pContext->pParamToFetch);
       pReq->ekey = pContext->pParamToFetch->wend;
       pReq->ver = pProgress->version;
-      if (pContext->pParamToFetch != TARRAY_DATA(pContext->pCalcReq->params)) {
-        int64_t prevEnd = (pContext->pParamToFetch - 1)->wend;
-        pReq->skey = TMAX(pReq->skey, prevEnd + 1);
-      }
       break;
     }
 
@@ -7698,6 +8536,8 @@ static int32_t stHistoryContextSendCalcReq(SSTriggerHistoryContext *pContext) {
         if ((pTask->windowSliding > 0) && (pTask->windowSliding < pTask->windowCount)) {
           cleanMode = DATA_CLEAN_EXPIRED;
         }
+      } else if (pTask->triggerType == STREAM_TRIGGER_EVENT && pTask->startCondHasSubEvents) {
+        cleanMode = DATA_CLEAN_EXPIRED;
       }
       code = initStreamDataCache(pTask->task.streamId, pTask->task.taskId, pContext->sessionId, cleanMode,
                                  pTask->histCalcTsIndex, &pContext->pCalcDataCache);
@@ -7706,6 +8546,10 @@ static int32_t stHistoryContextSendCalcReq(SSTriggerHistoryContext *pContext) {
 
     SSTriggerHistoryGroup *pGroup = stHistoryContextGetCurrentGroup(pContext);
     QUERY_CHECK_NULL(pGroup, code, lino, _end, terrno);
+    if (pTask->triggerType == STREAM_TRIGGER_EVENT && pTask->startCondHasSubEvents && pContext->pParamToFetch == NULL) {
+      code = cleanStreamDataCache(pContext->pCalcDataCache, pGroup->gid);
+      QUERY_CHECK_CODE(code, lino, _end);
+    }
     if (pContext->pParamToFetch == NULL) {
       pContext->pParamToFetch = TARRAY_DATA(pCalcReq->params);
     }
@@ -8998,6 +9842,9 @@ static int32_t stRealtimeGroupInit(SSTriggerRealtimeGroup *pGroup, SSTriggerReal
 
   if (pTask->triggerType == STREAM_TRIGGER_STATE) {
     pGroup->pendingNullStart = INT64_MIN;
+  } else if (pTask->triggerType == STREAM_TRIGGER_EVENT && pTask->startCondHasSubEvents) {
+    code = stTriggerTaskInitEventRuntimeStates(pTask, &pGroup->pLeafStates, &pGroup->pParentStates);
+    QUERY_CHECK_CODE(code, lino, _end);
   }
   pGroup->prevWindow = (STimeWindow){.skey = INT64_MIN, .ekey = INT64_MIN};
   code = taosObjListInit(&pGroup->windows, &pContext->windowPool);
@@ -9039,6 +9886,10 @@ static void stRealtimeGroupDestroy(void *ptr) {
   } else if (pGroup->pContext->pTask->triggerType == STREAM_TRIGGER_EVENT) {
     stRealtimeContextDestroyWindow(&pGroup->parentWindow);
     taosMemoryFreeClear(pGroup->pFirstSubWinOpenNotify);
+    taosArrayDestroyEx(pGroup->pLeafStates, stTriggerTaskDestroyLeafRuntimeState);
+    pGroup->pLeafStates = NULL;
+    taosArrayDestroyEx(pGroup->pParentStates, stTriggerTaskDestroyParentRuntimeState);
+    pGroup->pParentStates = NULL;
   }
   taosObjListClear(&pGroup->windows);
   taosObjListClearEx(&pGroup->pPendingParWinCalcParams, tDestroySSTriggerCalcParam);
@@ -9331,10 +10182,9 @@ static int32_t stRealtimeGroupNextDataBlock(SSTriggerRealtimeGroup *pGroup, SSDa
         SObjList *pMetas = tSimpleHashGet(pGroup->pWalMetas, &vgId, sizeof(int32_t));
         QUERY_CHECK_NULL(pMetas, code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
         QUERY_CHECK_NULL(pContext->pCurParam, code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
-        STimeWindow range = {.skey = pContext->pCurParam->wstart, .ekey = pContext->pCurParam->wend};
-        if (TARRAY_DATA(pContext->pCalcReq->params) != pContext->pCurParam) {
-          range.skey = TMAX(range.skey, (pContext->pCurParam - 1)->wend + 1);
-        }
+        STimeWindow range = {
+            .skey = stTriggerTaskGetCalcParamFetchStart(pTask, pContext->pCalcReq->params, pContext->pCurParam),
+            .ekey = pContext->pCurParam->wend};
         code = stNewTimestampSorterSetData(pContext->pCalcSorter, tbUid, pTask->calcTsIndex, pTask->calcPkIndex, &range,
                                            pMetas, pSlice);
         QUERY_CHECK_CODE(code, lino, _end);
@@ -9359,10 +10209,9 @@ static int32_t stRealtimeGroupNextDataBlock(SSTriggerRealtimeGroup *pGroup, SSDa
           break;
         }
         QUERY_CHECK_NULL(pContext->pCurParam, code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
-        STimeWindow range = {.skey = pContext->pCurParam->wstart, .ekey = pContext->pCurParam->wend};
-        if (TARRAY_DATA(pContext->pCalcReq->params) != pContext->pCurParam) {
-          range.skey = TMAX(range.skey, (pContext->pCurParam - 1)->wend + 1);
-        }
+        STimeWindow range = {
+            .skey = stTriggerTaskGetCalcParamFetchStart(pTask, pContext->pCalcReq->params, pContext->pCurParam),
+            .ekey = pContext->pCurParam->wend};
         code = stNewVtableMergerSetData(pContext->pCalcMerger, vtbUid, pTask->calcTsIndex, pTask->calcPkIndex, &range,
                                         &pContext->pCalcTableUids, pInfo->pCalcColRefs, pGroup->pWalMetas,
                                         pContext->pSlices);
@@ -9791,6 +10640,284 @@ _end:
   return code;
 }
 
+static int32_t stRealtimeGroupEmitParentEventWindow(SSTriggerRealtimeGroup *pGroup, SSTriggerParentRuntimeState *pState,
+                                                    const SSDataBlock *pDataBlock, int32_t rowIdx) {
+  int32_t                   code = TSDB_CODE_SUCCESS;
+  int32_t                   lino = 0;
+  SSTriggerRealtimeContext *pContext = pGroup->pContext;
+  SStreamTriggerTask       *pTask = pContext->pTask;
+  STrueForInfo             *pTrueForInfo = &pTask->eventTrueForInfo;
+  SSTriggerNotifyWindow     win = {0};
+
+  if (pState == NULL || pState->state == STRIGGER_EVENT_NODE_IDLE) {
+    goto _end;
+  }
+
+  if (!stTriggerTaskNeedRawEventNodeWindows(pTask) &&
+      !stTriggerTaskIsTrueForSatisfied(pTrueForInfo, pState->curStartTs, pState->curLastTs, pState->curRowCount)) {
+    taosMemoryFreeClear(pState->pWinOpenNotify);
+    goto _end;
+  }
+
+  win.range = (STimeWindow){.skey = pState->curStartTs, .ekey = pState->curLastTs};
+  win.wrownum = pState->curRowCount;
+  win.calcStartTs = pState->curStartTs;
+  win.calcWrownum = pState->curRowCount;
+  win.eventNodeId = pState->nodeId;
+  win.pWinOpenNotify = pState->pWinOpenNotify;
+  pState->pWinOpenNotify = NULL;
+  if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
+    int64_t parentWindowStart = stTriggerTaskGetParentEventWindowStart(pTask, pGroup->pParentStates, pState->nodeId);
+    code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->pEndCondCols, rowIdx, pState->nodeId, pGroup->gid,
+                                         win.range.skey, parentWindowStart, &win.pWinCloseNotify);
+    QUERY_CHECK_CODE(code, lino, _end);
+  }
+  void *px = taosArrayPush(pContext->pParentWindows, &win);
+  QUERY_CHECK_NULL(px, code, lino, _end, terrno);
+  win = (SSTriggerNotifyWindow){0};
+
+_end:
+  stRealtimeContextDestroyWindow(&win);
+  if (pState != NULL) {
+    pState->state = STRIGGER_EVENT_NODE_IDLE;
+    pState->curStartTs = 0;
+    pState->curLastTs = 0;
+    pState->curRowCount = 0;
+  }
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
+static int32_t stRealtimeGroupUpdateParentEventWindows(SSTriggerRealtimeGroup *pGroup, const SSDataBlock *pDataBlock,
+                                                       int32_t rowIdx, int64_t rowTs, uint64_t startMask,
+                                                       bool forceClose) {
+  int32_t             code = TSDB_CODE_SUCCESS;
+  int32_t             lino = 0;
+  SStreamTriggerTask *pTask = pGroup->pContext->pTask;
+
+  if (pGroup->pParentStates == NULL) {
+    goto _end;
+  }
+
+  for (int32_t i = 0; i < taosArrayGetSize(pGroup->pParentStates); ++i) {
+    SSTriggerParentRuntimeState *pState = taosArrayGet(pGroup->pParentStates, i);
+    bool                         nodeTrue = stTriggerTaskEventNodeTruth(pTask, pState->nodeId, startMask);
+
+    if (nodeTrue) {
+      if (pState->state == STRIGGER_EVENT_NODE_IDLE) {
+        pState->state = STRIGGER_EVENT_NODE_TRACKING;
+        pState->curStartTs = rowTs;
+        pState->curLastTs = rowTs;
+        pState->curRowCount = 1;
+        if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN) {
+          int64_t parentWindowStart =
+              stTriggerTaskGetParentEventWindowStart(pTask, pGroup->pParentStates, pState->nodeId);
+          code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->pStartCondCols, rowIdx, pState->nodeId,
+                                               pGroup->gid, pState->curStartTs, parentWindowStart,
+                                               &pState->pWinOpenNotify);
+          QUERY_CHECK_CODE(code, lino, _end);
+        }
+      } else {
+        pState->curLastTs = rowTs;
+        ++pState->curRowCount;
+      }
+      if (stTriggerTaskIsTrueForSatisfied(&pTask->eventTrueForInfo, pState->curStartTs, pState->curLastTs,
+                                          pState->curRowCount)) {
+        pState->state = STRIGGER_EVENT_NODE_SATISFIED;
+      }
+    }
+
+    if ((!nodeTrue || forceClose) && pState->state != STRIGGER_EVENT_NODE_IDLE) {
+      if (forceClose && (!stTriggerTaskNeedRawEventNodeWindows(pTask) || nodeTrue) && pState->curLastTs != rowTs) {
+        pState->curLastTs = rowTs;
+        ++pState->curRowCount;
+      }
+      code = stRealtimeGroupEmitParentEventWindow(pGroup, pState, pDataBlock, rowIdx);
+      QUERY_CHECK_CODE(code, lino, _end);
+    }
+  }
+
+_end:
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
+static int32_t stRealtimeGroupDoTreeEventCheck(SSTriggerRealtimeGroup *pGroup) {
+  int32_t                   code = TSDB_CODE_SUCCESS;
+  int32_t                   lino = 0;
+  SSTriggerRealtimeContext *pContext = pGroup->pContext;
+  SStreamTriggerTask       *pTask = pContext->pTask;
+  SSDataBlock              *pDataBlock = NULL;
+  int32_t                   startIdx = 0;
+  int32_t                   endIdx = 0;
+
+  if (TARRAY_SIZE(pContext->pWindows) == 0) {
+    SSTriggerNotifyWindow newWin = {0};
+    SSTriggerWindow      *pOldWin = NULL;
+    SObjListIter          iter = {0};
+    taosObjListInitIter(&pGroup->windows, &iter, TOBJLIST_ITER_FORWARD);
+    while ((pOldWin = taosObjListIterNext(&iter)) != NULL) {
+      newWin.range = pOldWin->range;
+      newWin.wrownum = pOldWin->wrownum;
+      newWin.calcStartTs = pOldWin->calcStartTs;
+      newWin.calcWrownum = pOldWin->calcWrownum;
+      newWin.eventNodeId = pOldWin->eventNodeId;
+      newWin.parentEventNodeId = pOldWin->parentEventNodeId;
+      newWin.parentWindowStart = pOldWin->parentWindowStart;
+      void *px = taosArrayPush(pContext->pWindows, &newWin);
+      QUERY_CHECK_NULL(px, code, lino, _end, terrno);
+    }
+    if (pGroup->pFirstSubWinOpenNotify != NULL && TARRAY_SIZE(pContext->pWindows) == 1) {
+      SSTriggerNotifyWindow *pNewWin = TARRAY_DATA(pContext->pWindows);
+      pNewWin->pWinOpenNotify = pGroup->pFirstSubWinOpenNotify;
+      pGroup->pFirstSubWinOpenNotify = NULL;
+    }
+    if (pGroup->pendingWinOpen) {
+      QUERY_CHECK_CONDITION(TARRAY_SIZE(pContext->pWindows) == 1, code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
+      SSTriggerNotifyWindow *pNewWin = TARRAY_DATA(pContext->pWindows);
+      pNewWin->pWinOpenNotify = pGroup->pPendWinOpenNotify;
+      pGroup->pendingWinOpen = false;
+      pGroup->pPendWinOpenNotify = NULL;
+      taosObjListClear(&pGroup->windows);
+    }
+  }
+
+  SSTriggerNotifyWindow *pLeafWin = taosArrayGetLast(pContext->pWindows);
+
+  while (true) {
+    code = stRealtimeGroupNextDataBlock(pGroup, &pDataBlock, &startIdx, &endIdx);
+    QUERY_CHECK_CODE(code, lino, _end);
+    if (pContext->needPseudoCols || pDataBlock == NULL || startIdx >= endIdx) {
+      break;
+    }
+
+    SColumnInfoData *pTsCol = taosArrayGet(pDataBlock->pDataBlock, pTask->trigTsIndex);
+    QUERY_CHECK_NULL(pTsCol, code, lino, _end, terrno);
+    int64_t *pTsData = (int64_t *)pTsCol->pData;
+
+    SColumnInfoData *psCol = NULL;
+    SColumnInfoData *peCol = NULL;
+    if (pTask->isVirtualTable) {
+      code = stRealtimeContextCalcExpr(pContext, pDataBlock, pTask->pStartCond, &pContext->eventStartCol);
+      QUERY_CHECK_CODE(code, lino, _end);
+      code = stRealtimeContextCalcExpr(pContext, pDataBlock, pTask->pEndCond, &pContext->eventEndCol);
+      QUERY_CHECK_CODE(code, lino, _end);
+      psCol = &pContext->eventStartCol;
+      peCol = &pContext->eventEndCol;
+    } else {
+      peCol = taosArrayGetLast(pDataBlock->pDataBlock);
+      QUERY_CHECK_NULL(peCol, code, lino, _end, terrno);
+      psCol = peCol - 1;
+    }
+    uint8_t *pe = (uint8_t *)peCol->pData;
+
+    for (int32_t i = startIdx; i < endIdx; ++i) {
+      int64_t  rowTs = pTsData[i];
+      uint64_t startMask = stTriggerTaskGetEventStartMask(psCol, i);
+      bool     forceClose = pe[i] || startMask == 0;
+
+      stTriggerTaskUpdateLeafRuntimeStates(pTask, pGroup->pLeafStates, startMask, rowTs);
+      int32_t nextLeafNodeId = stTriggerTaskGetFirstEligibleEventLeaf(pTask, pGroup->pLeafStates, startMask);
+
+      code = stRealtimeGroupUpdateParentEventWindows(pGroup, pDataBlock, i, rowTs, startMask, forceClose);
+      QUERY_CHECK_CODE(code, lino, _end);
+
+      if (pLeafWin != NULL && nextLeafNodeId >= 0 && pLeafWin->eventNodeId != nextLeafNodeId) {
+        pLeafWin->forceWinOpen = true;
+        pLeafWin->range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
+        if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
+          int64_t parentWindowStart =
+              stTriggerTaskGetParentEventWindowStart(pTask, pGroup->pParentStates, pLeafWin->eventNodeId);
+          code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->pEndCondCols, i, pLeafWin->eventNodeId,
+                                               pGroup->gid, pLeafWin->range.skey, parentWindowStart,
+                                               &pLeafWin->pWinCloseNotify);
+          QUERY_CHECK_CODE(code, lino, _end);
+        }
+        pLeafWin = NULL;
+      }
+
+      if (pLeafWin == NULL && nextLeafNodeId >= 0) {
+        SSTriggerLeafRuntimeState *pOpenState = NULL;
+        int64_t                    startTs = rowTs;
+        int64_t                    initialRows = 0;
+        if (!stTriggerTaskNeedRawEventNodeWindows(pTask) &&
+            stTriggerTaskGetLocalTrueForOpenState(pTask, pGroup->pLeafStates, nextLeafNodeId, &pOpenState)) {
+          startTs = pOpenState->curStartTs;
+          initialRows = TMAX(pOpenState->curRowCount - 1, 0);
+        }
+        SSTriggerNotifyWindow newWin = {
+            .range = {.skey = startTs, .ekey = INT64_MAX}, .wrownum = initialRows, .eventNodeId = nextLeafNodeId};
+        stTriggerTaskInitEventWindowCalcState(pTask, newWin.eventNodeId, startTs, initialRows, &newWin.calcStartTs,
+                                              &newWin.calcWrownum);
+        stTriggerTaskSetEventParentWindowInfo(pTask, pGroup->pParentStates, &newWin);
+        pLeafWin = taosArrayPush(pContext->pWindows, &newWin);
+        QUERY_CHECK_NULL(pLeafWin, code, lino, _end, terrno);
+        if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN) {
+          int64_t parentWindowStart =
+              stTriggerTaskGetParentEventWindowStart(pTask, pGroup->pParentStates, pLeafWin->eventNodeId);
+          code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->pStartCondCols, i, pLeafWin->eventNodeId,
+                                               pGroup->gid, pLeafWin->range.skey, parentWindowStart,
+                                               &pLeafWin->pWinOpenNotify);
+          QUERY_CHECK_CODE(code, lino, _end);
+        }
+      }
+
+      if (pLeafWin == NULL) {
+        if (forceClose) {
+          stTriggerTaskResetEventRuntimeStates(pGroup->pLeafStates, pGroup->pParentStates);
+        }
+        continue;
+      }
+
+      bool leafTrue = stTriggerTaskEventNodeTruth(pTask, pLeafWin->eventNodeId, startMask);
+      if (stTriggerTaskNeedRawEventNodeWindows(pTask) && forceClose && !leafTrue) {
+        pLeafWin->range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
+        if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
+          int64_t parentWindowStart =
+              stTriggerTaskGetParentEventWindowStart(pTask, pGroup->pParentStates, pLeafWin->eventNodeId);
+          code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->pEndCondCols, i, pLeafWin->eventNodeId,
+                                               pGroup->gid, pLeafWin->range.skey, parentWindowStart,
+                                               &pLeafWin->pWinCloseNotify);
+          QUERY_CHECK_CODE(code, lino, _end);
+        }
+        pLeafWin = NULL;
+        stTriggerTaskResetEventRuntimeStates(pGroup->pLeafStates, pGroup->pParentStates);
+        continue;
+      }
+
+      ++pLeafWin->wrownum;
+      pLeafWin->range.ekey = (rowTs | TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
+      stTriggerTaskAdvanceEventWindowCalcState(pTask, pLeafWin->eventNodeId, pLeafWin->range.skey, rowTs,
+                                               pLeafWin->wrownum, rowTs, &pLeafWin->calcStartTs,
+                                               &pLeafWin->calcWrownum);
+
+      if (forceClose) {
+        pLeafWin->range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
+        if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
+          int64_t parentWindowStart =
+              stTriggerTaskGetParentEventWindowStart(pTask, pGroup->pParentStates, pLeafWin->eventNodeId);
+          code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->pEndCondCols, i, pLeafWin->eventNodeId,
+                                               pGroup->gid, pLeafWin->range.skey, parentWindowStart,
+                                               &pLeafWin->pWinCloseNotify);
+          QUERY_CHECK_CODE(code, lino, _end);
+        }
+        pLeafWin = NULL;
+        stTriggerTaskResetEventRuntimeStates(pGroup->pLeafStates, pGroup->pParentStates);
+      }
+    }
+  }
+
+_end:
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
 static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
   int32_t                   code = TSDB_CODE_SUCCESS;
   int32_t                   lino = 0;
@@ -9799,6 +10926,10 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
   SSDataBlock              *pDataBlock = NULL;
   int32_t                   startIdx = 0;
   int32_t                   endIdx = 0;
+
+  if (pTask->startCondHasSubEvents) {
+    return stRealtimeGroupDoTreeEventCheck(pGroup);
+  }
 
   if (TARRAY_SIZE(pContext->pWindows) == 0) {
     SSTriggerNotifyWindow newWin = {0};
@@ -9856,14 +10987,8 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
           if (pGroup->numSubWindows == 0) {
             pGroup->parentWindow = (SSTriggerNotifyWindow){.range.skey = pTsData[i], .range.ekey = INT64_MAX};
             if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN) {
-              code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, -1, pGroup->gid,
+              code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->pStartCondCols, i, -1, pGroup->gid,
                                                    pTsData[i], 0, &pGroup->parentWindow.pWinOpenNotify);
-              QUERY_CHECK_CODE(code, lino, _end);
-              // A single sub-event is still a regular event window. Keep the first sub-window open pending until a
-              // second sub-window proves that parent/child window events are needed.
-              code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, 0, pGroup->gid,
-                                                   pTsData[i], pGroup->parentWindow.range.skey,
-                                                   &pGroup->pFirstSubWinOpenNotify);
               QUERY_CHECK_CODE(code, lino, _end);
             }
           }
@@ -9876,14 +11001,9 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
         newWin.range.ekey = INT64_MAX;
         pWin = taosArrayPush(pContext->pWindows, &newWin);
         QUERY_CHECK_NULL(pWin, code, lino, _end, terrno);
-        if ((pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN) && (!checkSubEvent || pGroup->numSubWindows > 1)) {
-          int32_t winIdx = -1;
-          if (checkSubEvent && pGroup->numSubWindows > 1) {
-            winIdx = pGroup->numSubWindows - 1;
-          }
-          int64_t parentWindowStart = (checkSubEvent && winIdx >= 0) ? pGroup->parentWindow.range.skey : 0;
-          code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, winIdx, pGroup->gid,
-                                               pTsData[i], parentWindowStart, &pWin->pWinOpenNotify);
+        if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN) {
+          code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, pGroup->gid,
+                                               pTsData[i], 0, &pWin->pWinOpenNotify);
           QUERY_CHECK_CODE(code, lino, _end);
         }
       }
@@ -9894,16 +11014,10 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
 
       if (checkSubEvent && ps[i] && ps[i] != pGroup->conditionIdx) {
         // close previous sub-window since start condition index is changed
-        pWin->forceWinOpen = true;
-        if (pGroup->pFirstSubWinOpenNotify != NULL && pWin->pWinOpenNotify == NULL) {
-          pWin->pWinOpenNotify = pGroup->pFirstSubWinOpenNotify;
-          pGroup->pFirstSubWinOpenNotify = NULL;
-        }
         pWin->range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
         if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
-          int32_t winIdx = pGroup->numSubWindows - 1;
           code =
-              streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, winIdx, pGroup->gid,
+              stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->pEndCondCols, i, ps[i] - 1, pGroup->gid,
                                             pWin->range.skey, pGroup->parentWindow.range.skey, &pWin->pWinCloseNotify);
           QUERY_CHECK_CODE(code, lino, _end);
         }
@@ -9923,20 +11037,16 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
         SSTriggerNotifyWindow *pClosedWin = pWin;
         pWin->range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
         if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
-          int32_t winIdx = -1;
-          if (checkSubEvent && pGroup->numSubWindows > 1) {
-            winIdx = pGroup->numSubWindows - 1;
-          }
-          int64_t parentWindowStart = (checkSubEvent && winIdx >= 0) ? pGroup->parentWindow.range.skey : 0;
-          code = streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, winIdx, pGroup->gid,
-                                               pWin->range.skey, parentWindowStart, &pWin->pWinCloseNotify);
+          code =
+              stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->pEndCondCols, i, ps[i] - 1, pGroup->gid,
+                                            pWin->range.skey, pGroup->parentWindow.range.skey, &pWin->pWinCloseNotify);
           QUERY_CHECK_CODE(code, lino, _end);
         }
         pWin = NULL;
         if (checkSubEvent) {
           pGroup->parentWindow.range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
           if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
-            code = streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, -1, pGroup->gid,
+            code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->pEndCondCols, i, -1, pGroup->gid,
                                                  pGroup->parentWindow.range.skey, 0,
                                                  &pGroup->parentWindow.pWinCloseNotify);
             QUERY_CHECK_CODE(code, lino, _end);
@@ -10063,6 +11173,11 @@ static int32_t stRealtimeGroupMergeWindows(SSTriggerRealtimeGroup *pGroup) {
       QUERY_CHECK_CONDITION(pTmpWin->range.skey == pWin->range.skey, code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
       pTmpWin->range.ekey = pWin->range.ekey;
       pTmpWin->wrownum = pWin->wrownum;
+      pTmpWin->calcStartTs = pWin->calcStartTs;
+      pTmpWin->calcWrownum = pWin->calcWrownum;
+      pTmpWin->eventNodeId = pWin->eventNodeId;
+      pTmpWin->parentEventNodeId = pWin->parentEventNodeId;
+      pTmpWin->parentWindowStart = pWin->parentWindowStart;
       pWin++;
     }
   }
@@ -10074,6 +11189,11 @@ static int32_t stRealtimeGroupMergeWindows(SSTriggerRealtimeGroup *pGroup) {
     SSTriggerWindow win = {0};
     win.range = pWin->range;
     win.wrownum = pWin->wrownum;
+    win.calcStartTs = pWin->calcStartTs;
+    win.calcWrownum = pWin->calcWrownum;
+    win.eventNodeId = pWin->eventNodeId;
+    win.parentEventNodeId = pWin->parentEventNodeId;
+    win.parentWindowStart = pWin->parentWindowStart;
     win.prevProcTime = now;
     code = taosObjListAppend(&pGroup->windows, &win);
     QUERY_CHECK_CODE(code, lino, _end);
@@ -10153,6 +11273,13 @@ static int32_t stRealtimeGroupFillParam(SSTriggerRealtimeGroup *pGroup, SSTrigge
       pParam->wend = pWin->range.ekey;
       pParam->wduration = pParam->wend - pParam->wstart;
       pParam->wrownum = pWin->wrownum;
+      if (pTask->triggerType == STREAM_TRIGGER_EVENT) {
+        pParam->wstart = pWin->calcWrownum > 0 ? pWin->calcStartTs : pWin->range.skey;
+        pParam->wduration = pParam->wend - pParam->wstart;
+        pParam->wrownum = pWin->calcWrownum > 0 ? pWin->calcWrownum : pWin->wrownum;
+        code = stTriggerTaskSetEventConditionPath(pTask, pWin->eventNodeId, &pParam->conditionPath);
+        QUERY_CHECK_CODE(code, lino, _end);
+      }
       break;
     }
     default: {
@@ -10254,23 +11381,75 @@ static int32_t stRealtimeGroupGenCalcParams(SSTriggerRealtimeGroup *pGroup, int3
 
   int64_t       initPendingSize = pGroup->pPendingCalcParams.neles + pGroup->pPendingParWinCalcParams.neles;
   STrueForInfo *pTrueForInfo = NULL;
+  bool          needRawNodeWindow = stTriggerTaskNeedRawEventNodeWindows(pTask);
   if (pTask->triggerType == STREAM_TRIGGER_STATE) {
     pTrueForInfo = &pTask->stateTrueForInfo;
   } else if (pTask->triggerType == STREAM_TRIGGER_EVENT) {
     pTrueForInfo = &pTask->eventTrueForInfo;
   }
+
+  if (pTask->triggerType == STREAM_TRIGGER_EVENT && !needRawNodeWindow && (calcOpen || notifyOpen) &&
+      pGroup->pParentStates != NULL) {
+    for (int32_t i = 0; i < taosArrayGetSize(pGroup->pParentStates); ++i) {
+      SSTriggerParentRuntimeState *pState = taosArrayGet(pGroup->pParentStates, i);
+      SSTriggerEventNodeMeta      *pMeta = (pState != NULL) ? stTriggerTaskGetEventMeta(pTask, pState->nodeId) : NULL;
+      if (pState == NULL || pMeta == NULL || pMeta->parentNodeId >= 0 || pState->state == STRIGGER_EVENT_NODE_IDLE ||
+          pState->pWinOpenNotify == NULL) {
+        continue;
+      }
+
+      if (!stTriggerTaskIsTrueForSatisfied(&pTask->eventTrueForInfo, pState->curStartTs, pState->curLastTs,
+                                           pState->curRowCount)) {
+        continue;
+      }
+
+      SSTriggerNotifyWindow win = {.range = {.skey = pState->curStartTs, .ekey = pState->curStartTs},
+                                   .wrownum = pState->curRowCount,
+                                   .calcStartTs = pState->curStartTs,
+                                   .calcWrownum = pState->curRowCount,
+                                   .eventNodeId = pState->nodeId,
+                                   .parentEventNodeId = -1,
+                                   .pWinOpenNotify = pState->pWinOpenNotify};
+      SSTriggerCalcParam param = {.triggerTime = now,
+                                  .notifyType = (notifyOpen ? STRIGGER_EVENT_WINDOW_OPEN : STRIGGER_EVENT_WINDOW_NONE),
+                                  .extraNotifyContent = pState->pWinOpenNotify};
+      code = stRealtimeGroupFillParam(pGroup, &param, &win);
+      QUERY_CHECK_CODE(code, lino, _end);
+      if (calcOpen) {
+        code = taosObjListAppend(&pGroup->pPendingParWinCalcParams, &param);
+        QUERY_CHECK_CODE(code, lino, _end);
+      } else {
+        void *px = taosArrayPush(pContext->pNotifyParams, &param);
+        QUERY_CHECK_NULL(px, code, lino, _end, terrno);
+      }
+      stTriggerTaskReleaseCalcParamOwnership(&param);
+      pState->pWinOpenNotify = NULL;
+      pGroup->prevParentWinStart = pState->curStartTs;
+    }
+  }
+
   // trigger all window open/close events
   for (int32_t i = 0; i < TARRAY_SIZE(pContext->pWindows); i++) {
     SSTriggerNotifyWindow *pWin = TARRAY_GET_ELEM(pContext->pWindows, i);
+    STrueForInfo           effectiveTrueForInfo = {0};
+    STrueForInfo          *pWinTrueForInfo = pTrueForInfo;
+    if (pTask->triggerType == STREAM_TRIGGER_EVENT && !needRawNodeWindow) {
+      pWinTrueForInfo =
+          (STrueForInfo *)stTriggerTaskGetEffectiveEventTrueForInfo(pTask, pWin->eventNodeId, &effectiveTrueForInfo);
+    }
     // check TRUE FOR condition
-    bool meetTrueFor = (pTrueForInfo == NULL) || (pTrueForInfo->duration == 0 && pTrueForInfo->count == 0) ||
-                       isTrueForSatisfied(pTrueForInfo, pWin->range.skey,
-                                          pWin->range.ekey & (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK), pWin->wrownum);
+    bool meetTrueFor =
+        needRawNodeWindow ||
+        stTriggerTaskIsTrueForSatisfied(pWinTrueForInfo, pWin->range.skey,
+                                        pWin->range.ekey & (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK), pWin->wrownum);
     bool forceWinOpen = pWin->forceWinOpen;
     bool ignore = ((i < nInitWins) && !forceWinOpen) || !meetTrueFor;
     bool deferFirstSubWinOpen = (pTask->triggerType == STREAM_TRIGGER_EVENT && pGroup->numSubWindows == 1 &&
                                  pWin->range.skey == pGroup->parentWindow.range.skey);
-    if ((calcOpen || notifyOpen) && !ignore && !deferFirstSubWinOpen && !pContext->recovering) {
+    bool deferSingleSubWin =
+        stTriggerTaskShouldDeferSingleEventSubWindow(pTask, pContext->pWindows, pWin, needRawNodeWindow);
+    bool deferSubWinOpen = deferFirstSubWinOpen || deferSingleSubWin;
+    if ((calcOpen || notifyOpen) && !ignore && !deferSubWinOpen && !pContext->recovering) {
       SSTriggerCalcParam param = {.triggerTime = now,
                                   .notifyType = (notifyOpen ? STRIGGER_EVENT_WINDOW_OPEN : STRIGGER_EVENT_WINDOW_NONE),
                                   .extraNotifyContent = pWin->pWinOpenNotify};
@@ -10289,13 +11468,17 @@ static int32_t stRealtimeGroupGenCalcParams(SSTriggerRealtimeGroup *pGroup, int3
         QUERY_CHECK_NULL(px, code, lino, _end, terrno);
         pWin->pWinOpenNotify = NULL;
       }
+    } else if (deferSingleSubWin && i >= numClosed && pWin->pWinOpenNotify != NULL) {
+      taosMemoryFreeClear(pGroup->pFirstSubWinOpenNotify);
+      pGroup->pFirstSubWinOpenNotify = pWin->pWinOpenNotify;
+      pWin->pWinOpenNotify = NULL;
     }
     if (forceWinOpen) {
       pWin->forceWinOpen = false;
     }
 
     ignore = (i >= numClosed) || !meetTrueFor || (pTask->ignoreNoDataTrigger && pWin->wrownum == 0);
-    if ((calcClose || notifyClose) && !ignore && !pContext->recovering) {
+    if ((calcClose || notifyClose) && !ignore && !deferSingleSubWin && !pContext->recovering) {
       SSTriggerCalcParam param = {
           .triggerTime = now,
           .notifyType = (notifyClose ? STRIGGER_EVENT_WINDOW_CLOSE : STRIGGER_EVENT_WINDOW_NONE),
@@ -10317,7 +11500,8 @@ static int32_t stRealtimeGroupGenCalcParams(SSTriggerRealtimeGroup *pGroup, int3
   for (int32_t i = 0; i < TARRAY_SIZE(pContext->pParentWindows); i++) {
     SSTriggerNotifyWindow *pWin = TARRAY_GET_ELEM(pContext->pParentWindows, i);
     // check TRUE FOR condition
-    bool meetTrueFor = (pTrueForInfo == NULL) || (pTrueForInfo->duration == 0 && pTrueForInfo->count == 0) ||
+    bool meetTrueFor = needRawNodeWindow || (pTrueForInfo == NULL) ||
+                       (pTrueForInfo->duration == 0 && pTrueForInfo->count == 0) ||
                        isTrueForSatisfied(pTrueForInfo, pWin->range.skey,
                                           pWin->range.ekey & (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK), pWin->wrownum);
     bool ignore = (pWin->range.skey <= pGroup->prevParentWinStart) || !meetTrueFor;
@@ -10367,7 +11551,8 @@ static int32_t stRealtimeGroupGenCalcParams(SSTriggerRealtimeGroup *pGroup, int3
   if (pTask->triggerType == STREAM_TRIGGER_EVENT && pGroup->numSubWindows > 0) {
     SSTriggerNotifyWindow *pWin = &pGroup->parentWindow;
     // check TRUE FOR condition
-    bool meetTrueFor = (pTrueForInfo == NULL) || (pTrueForInfo->duration == 0 && pTrueForInfo->count == 0) ||
+    bool meetTrueFor = needRawNodeWindow || (pTrueForInfo == NULL) ||
+                       (pTrueForInfo->duration == 0 && pTrueForInfo->count == 0) ||
                        isTrueForSatisfied(pTrueForInfo, pWin->range.skey,
                                           pWin->range.ekey & (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK), pWin->wrownum);
     bool ignore = (pWin->range.skey <= pGroup->prevParentWinStart) || !meetTrueFor;
@@ -10517,73 +11702,39 @@ static int32_t stRealtimeGroupRetrievePendingCalc(SSTriggerRealtimeGroup *pGroup
   SSTriggerRealtimeContext *pContext = pGroup->pContext;
   SStreamTriggerTask       *pTask = pContext->pTask;
   int64_t                   now = taosGetTimestampNs();
+  int32_t maxParamsPerReq = stTriggerTaskNeedOverlapSafeCalcRange(pTask) ? 1 : STREAM_CALC_REQ_MAX_WIN_NUM;
 
   ST_TASK_DLOG("group %" PRId64 " starts to exec %" PRId64 " pending params, %" PRId64 " pending parwin params",
                pGroup->gid, pGroup->pPendingCalcParams.neles, pGroup->pPendingParWinCalcParams.neles);
 
 #define LOG_EVERY_NUM_PARAM 10000
-  if (pGroup->pPendingParWinCalcParams.neles > 0) {
-    int64_t end = INT64_MAX;
-    if (pGroup->pPendingCalcParams.neles > 0) {
-      SSTriggerCalcParam *pParam = taosObjListGetHead(&pGroup->pPendingCalcParams);
-      end = pParam->wend;
+  if (pGroup->pPendingParWinCalcParams.neles > 0 || pGroup->pPendingCalcParams.neles > 0) {
+    int64_t origParNele = pGroup->pPendingParWinCalcParams.neles;
+    int64_t origCalcNele = pGroup->pPendingCalcParams.neles;
+    int64_t origTotal = pContext->calcParamPool.size;
+
+    while ((pGroup->pPendingParWinCalcParams.neles > 0 || pGroup->pPendingCalcParams.neles > 0) &&
+           TARRAY_SIZE(pContext->pCalcReq->params) < maxParamsPerReq) {
+      SObjList *pPendingParams =
+          stTriggerTaskUseParentCalcParam(&pGroup->pPendingParWinCalcParams, &pGroup->pPendingCalcParams)
+              ? &pGroup->pPendingParWinCalcParams
+              : &pGroup->pPendingCalcParams;
+      code = stTriggerTaskTakePendingCalcParam(pPendingParams, pContext->pCalcReq->params);
+      QUERY_CHECK_CODE(code, lino, _end);
     }
-    int64_t             origNele = pGroup->pPendingParWinCalcParams.neles;
-    int64_t             origTotal = pContext->calcParamPool.size;
-    int32_t             nele = 0;
-    SObjListIter        iter = {0};
-    SSTriggerCalcParam *pParam = NULL;
-    taosObjListInitIter(&pGroup->pPendingParWinCalcParams, &iter, TOBJLIST_ITER_FORWARD);
-    while ((pParam = taosObjListIterNext(&iter)) != NULL && pParam->wend < end &&
-           TARRAY_SIZE(pContext->pCalcReq->params) < STREAM_CALC_REQ_MAX_WIN_NUM) {
-      void *px = taosArrayPush(pContext->pCalcReq->params, pParam);
-      QUERY_CHECK_NULL(px, code, lino, _end, terrno);
-      pParam->extraNotifyContent = NULL;
-      nele++;
-    }
-    if (nele > 0) {
-      taosObjListPopHeadTo(&pGroup->pPendingParWinCalcParams, pParam, nele);
-      int64_t freedNele = origNele - pGroup->pPendingParWinCalcParams.neles;
+
+    int64_t freedParNele = origParNele - pGroup->pPendingParWinCalcParams.neles;
+    int64_t freedCalcNele = origCalcNele - pGroup->pPendingCalcParams.neles;
+    if (freedParNele > 0 || freedCalcNele > 0) {
       if (stDebugFlag & DEBUG_DEBUG) {
-        ST_TASK_DLOG("group %" PRId64 " retrieved %" PRId64 " pending parwin params, calc param pool size from %" PRId64
-                     " to %" PRId64,
-                     pGroup->gid, freedNele, origTotal, pContext->calcParamPool.size);
+        ST_TASK_DLOG("group %" PRId64 " retrieved %" PRId64 " pending params and %" PRId64
+                     " pending parwin params, calc param pool size from %" PRId64 " to %" PRId64,
+                     pGroup->gid, freedCalcNele, freedParNele, origTotal, pContext->calcParamPool.size);
       } else if ((origTotal / LOG_EVERY_NUM_PARAM) != (pContext->calcParamPool.size / LOG_EVERY_NUM_PARAM)) {
-        ST_TASK_ILOG("group %" PRId64 " retrieved %" PRId64 " pending parwin params, calc param pool size from %" PRId64
-                     " to %" PRId64,
-                     pGroup->gid, freedNele, origTotal, pContext->calcParamPool.size);
+        ST_TASK_ILOG("group %" PRId64 " retrieved %" PRId64 " pending params and %" PRId64
+                     " pending parwin params, calc param pool size from %" PRId64 " to %" PRId64,
+                     pGroup->gid, freedCalcNele, freedParNele, origTotal, pContext->calcParamPool.size);
       }
-
-      SSTriggerCalcParam *pLastParam = taosArrayGetLast(pContext->pCalcReq->params);
-      pContext->lastSentWinEnd = pLastParam ? pLastParam->wend : INT64_MIN;
-      goto _end;
-    }
-  }
-
-  if (pGroup->pPendingCalcParams.neles > 0) {
-    int64_t             origNele = pGroup->pPendingCalcParams.neles;
-    int64_t             origTotal = pContext->calcParamPool.size;
-    int32_t             nele = 0;
-    SSTriggerCalcParam *pParam = NULL;
-    SObjListIter        iter = {0};
-    taosObjListInitIter(&pGroup->pPendingCalcParams, &iter, TOBJLIST_ITER_FORWARD);
-    while ((pParam = taosObjListIterNext(&iter)) != NULL &&
-           TARRAY_SIZE(pContext->pCalcReq->params) < STREAM_CALC_REQ_MAX_WIN_NUM) {
-      void *px = taosArrayPush(pContext->pCalcReq->params, pParam);
-      QUERY_CHECK_NULL(px, code, lino, _end, terrno);
-      pParam->extraNotifyContent = NULL;
-      nele++;
-    }
-    taosObjListPopHeadTo(&pGroup->pPendingCalcParams, pParam, nele);
-    int64_t freedNele = origNele - pGroup->pPendingCalcParams.neles;
-    if (stDebugFlag & DEBUG_DEBUG) {
-      ST_TASK_DLOG("group %" PRId64 " retrieved %" PRId64 " pending params, calc param pool size from %" PRId64
-                   " to %" PRId64,
-                   pGroup->gid, freedNele, origTotal, pContext->calcParamPool.size);
-    } else if ((origTotal / LOG_EVERY_NUM_PARAM) != (pContext->calcParamPool.size / LOG_EVERY_NUM_PARAM)) {
-      ST_TASK_ILOG("group %" PRId64 " retrieved %" PRId64 " pending params, calc param pool size from %" PRId64
-                   " to %" PRId64,
-                   pGroup->gid, freedNele, origTotal, pContext->calcParamPool.size);
     }
   }
 
@@ -10595,8 +11746,7 @@ static int32_t stRealtimeGroupRetrievePendingCalc(SSTriggerRealtimeGroup *pGroup
     SObjListIter     iter = {0};
     taosObjListInitIter(&pGroup->windows, &iter, TOBJLIST_ITER_FORWARD);
     while ((pWin = taosObjListIterNext(&iter)) != NULL) {
-      if (pWin->prevProcTime + pTask->maxDelayNs <= now &&
-          TARRAY_SIZE(pContext->pCalcReq->params) < STREAM_CALC_REQ_MAX_WIN_NUM) {
+      if (pWin->prevProcTime + pTask->maxDelayNs <= now && TARRAY_SIZE(pContext->pCalcReq->params) < maxParamsPerReq) {
         SSTriggerNotifyWindow win = {.range = pWin->range, .wrownum = pWin->wrownum};
         win.range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
         SSTriggerCalcParam param = {.triggerTime = now};
@@ -10609,7 +11759,7 @@ static int32_t stRealtimeGroupRetrievePendingCalc(SSTriggerRealtimeGroup *pGroup
     }
   }
 
-  QUERY_CHECK_CONDITION(TARRAY_SIZE(pContext->pCalcReq->params) <= STREAM_CALC_REQ_MAX_WIN_NUM, code, lino, _end,
+  QUERY_CHECK_CONDITION(TARRAY_SIZE(pContext->pCalcReq->params) <= maxParamsPerReq, code, lino, _end,
                         TSDB_CODE_INTERNAL_ERROR);
 
   pGroup->nextExecTime = 0;
@@ -10696,6 +11846,9 @@ static int32_t stHistoryGroupInit(SSTriggerHistoryGroup *pGroup, SSTriggerHistor
 
   if (pTask->triggerType == STREAM_TRIGGER_STATE) {
     pGroup->pendingNullStart = INT64_MIN;
+  } else if (pTask->triggerType == STREAM_TRIGGER_EVENT && pTask->startCondHasSubEvents) {
+    code = stTriggerTaskInitEventRuntimeStates(pTask, &pGroup->pLeafStates, &pGroup->pParentStates);
+    QUERY_CHECK_CODE(code, lino, _end);
   }
   code = taosObjListInit(&pGroup->pPendingParWinCalcParams, &pContext->calcParamPool);
   QUERY_CHECK_CODE(code, lino, _end);
@@ -10729,6 +11882,10 @@ static void stHistoryGroupDestroy(void *ptr) {
     taosMemoryFreeClear(pGroup->stateVal.pData);
   } else if (pGroup->pContext->pTask->triggerType == STREAM_TRIGGER_EVENT) {
     stRealtimeContextDestroyWindow(&pGroup->parentWindow);
+    taosArrayDestroyEx(pGroup->pLeafStates, stTriggerTaskDestroyLeafRuntimeState);
+    pGroup->pLeafStates = NULL;
+    taosArrayDestroyEx(pGroup->pParentStates, stTriggerTaskDestroyParentRuntimeState);
+    pGroup->pParentStates = NULL;
   }
   taosObjListClearEx(&pGroup->pPendingParWinCalcParams, tDestroySSTriggerCalcParam);
   taosObjListClearEx(&pGroup->pPendingCalcParams, tDestroySSTriggerCalcParam);
@@ -11214,6 +12371,198 @@ _end:
   return code;
 }
 
+static int32_t stHistoryGroupFillEventParam(SSTriggerHistoryGroup *pGroup, SSTriggerCalcParam *pParam,
+                                            const SSTriggerNotifyWindow *pWin, bool isOpen) {
+  int32_t             code = TSDB_CODE_SUCCESS;
+  int32_t             lino = 0;
+  SStreamTriggerTask *pTask = pGroup->pContext->pTask;
+  int64_t             wend = isOpen ? pWin->range.skey : pWin->range.ekey;
+
+  pParam->wstart = pWin->calcWrownum > 0 ? pWin->calcStartTs : pWin->range.skey;
+  pParam->wend = wend;
+  pParam->wduration = pParam->wend - pParam->wstart;
+  pParam->wrownum = pWin->calcWrownum > 0 ? pWin->calcWrownum : pWin->wrownum;
+  code = stTriggerTaskSetEventConditionPath(pTask, pWin->eventNodeId, &pParam->conditionPath);
+  QUERY_CHECK_CODE(code, lino, _end);
+
+_end:
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
+static int32_t stHistoryGroupEmitEventWindow(SSTriggerHistoryGroup *pGroup, SSTriggerNotifyWindow *pWin,
+                                             bool isParent) {
+  int32_t                  code = TSDB_CODE_SUCCESS;
+  int32_t                  lino = 0;
+  SSTriggerHistoryContext *pContext = pGroup->pContext;
+  SStreamTriggerTask      *pTask = pContext->pTask;
+  int64_t                  now = taosGetTimestampNs();
+  bool                     calcOpen = (pTask->calcEventType & STRIGGER_EVENT_WINDOW_OPEN);
+  bool                     calcClose = (pTask->calcEventType & STRIGGER_EVENT_WINDOW_CLOSE);
+  bool                     notifyOpen = pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN);
+  bool                     notifyClose = pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE);
+  SSTriggerCalcParam       param = {0};
+  STrueForInfo             effectiveTrueForInfo = {0};
+  bool                     needRawNodeWindow = stTriggerTaskNeedRawEventNodeWindows(pTask);
+  const STrueForInfo      *pTrueForInfo =
+      isParent ? &pTask->eventTrueForInfo
+               : stTriggerTaskGetEffectiveEventTrueForInfo(pTask, pWin->eventNodeId, &effectiveTrueForInfo);
+
+  if (!needRawNodeWindow &&
+      !stTriggerTaskIsTrueForSatisfied(pTrueForInfo, pWin->range.skey, pWin->range.ekey, pWin->wrownum)) {
+    taosMemoryFreeClear(pWin->pWinOpenNotify);
+    taosMemoryFreeClear(pWin->pWinCloseNotify);
+    goto _end;
+  }
+
+  if (calcOpen || notifyOpen) {
+    param = (SSTriggerCalcParam){.triggerTime = now,
+                                 .notifyType = notifyOpen ? STRIGGER_EVENT_WINDOW_OPEN : STRIGGER_EVENT_WINDOW_NONE,
+                                 .extraNotifyContent = pWin->pWinOpenNotify};
+    pWin->pWinOpenNotify = NULL;
+    code = stHistoryGroupFillEventParam(pGroup, &param, pWin, true);
+    QUERY_CHECK_CODE(code, lino, _end);
+    if (calcOpen) {
+      code = stHistoryGroupAddCalcParam(pGroup, &param, isParent);
+      QUERY_CHECK_CODE(code, lino, _end);
+    } else {
+      void *px = taosArrayPush(pContext->pNotifyParams, &param);
+      QUERY_CHECK_NULL(px, code, lino, _end, terrno);
+    }
+    stTriggerTaskReleaseCalcParamOwnership(&param);
+  }
+
+  if (calcClose || notifyClose) {
+    param = (SSTriggerCalcParam){.triggerTime = now,
+                                 .notifyType = notifyClose ? STRIGGER_EVENT_WINDOW_CLOSE : STRIGGER_EVENT_WINDOW_NONE,
+                                 .extraNotifyContent = pWin->pWinCloseNotify};
+    pWin->pWinCloseNotify = NULL;
+    code = stHistoryGroupFillEventParam(pGroup, &param, pWin, false);
+    QUERY_CHECK_CODE(code, lino, _end);
+    if (calcClose) {
+      code = stHistoryGroupAddCalcParam(pGroup, &param, isParent);
+      QUERY_CHECK_CODE(code, lino, _end);
+    } else {
+      void *px = taosArrayPush(pContext->pNotifyParams, &param);
+      QUERY_CHECK_NULL(px, code, lino, _end, terrno);
+    }
+    stTriggerTaskReleaseCalcParamOwnership(&param);
+  }
+
+_end:
+  tDestroySSTriggerCalcParam(&param);
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
+static int32_t stHistoryGroupEmitParentEventWindow(SSTriggerHistoryGroup *pGroup, SSTriggerParentRuntimeState *pState,
+                                                   const SSDataBlock *pDataBlock, int32_t rowIdx) {
+  int32_t               code = TSDB_CODE_SUCCESS;
+  int32_t               lino = 0;
+  SStreamTriggerTask   *pTask = pGroup->pContext->pTask;
+  SSTriggerNotifyWindow win = {0};
+
+  if (pState == NULL || pState->state == STRIGGER_EVENT_NODE_IDLE) {
+    goto _end;
+  }
+
+  if (!stTriggerTaskNeedRawEventNodeWindows(pTask) &&
+      !stTriggerTaskIsTrueForSatisfied(&pTask->eventTrueForInfo, pState->curStartTs, pState->curLastTs,
+                                       pState->curRowCount)) {
+    taosMemoryFreeClear(pState->pWinOpenNotify);
+    goto _end;
+  }
+
+  win.range = (STimeWindow){.skey = pState->curStartTs, .ekey = pState->curLastTs};
+  win.wrownum = pState->curRowCount;
+  win.calcStartTs = pState->curStartTs;
+  win.calcWrownum = pState->curRowCount;
+  win.eventNodeId = pState->nodeId;
+  win.pWinOpenNotify = pState->pWinOpenNotify;
+  pState->pWinOpenNotify = NULL;
+  if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE)) {
+    int64_t parentWindowStart = stTriggerTaskGetParentEventWindowStart(pTask, pGroup->pParentStates, pState->nodeId);
+    code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->histEndCondCols, rowIdx, pState->nodeId, pGroup->gid,
+                                         win.range.skey, parentWindowStart, &win.pWinCloseNotify);
+    QUERY_CHECK_CODE(code, lino, _end);
+  }
+  code = stHistoryGroupEmitEventWindow(pGroup, &win, true);
+  QUERY_CHECK_CODE(code, lino, _end);
+
+_end:
+  stRealtimeContextDestroyWindow(&win);
+  if (pState != NULL) {
+    pState->state = STRIGGER_EVENT_NODE_IDLE;
+    pState->curStartTs = 0;
+    pState->curLastTs = 0;
+    pState->curRowCount = 0;
+  }
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
+static int32_t stHistoryGroupUpdateParentEventWindows(SSTriggerHistoryGroup *pGroup, const SSDataBlock *pDataBlock,
+                                                      int32_t rowIdx, int64_t rowTs, uint64_t startMask,
+                                                      bool forceClose) {
+  int32_t             code = TSDB_CODE_SUCCESS;
+  int32_t             lino = 0;
+  SStreamTriggerTask *pTask = pGroup->pContext->pTask;
+
+  if (pGroup->pParentStates == NULL) {
+    goto _end;
+  }
+
+  for (int32_t i = 0; i < taosArrayGetSize(pGroup->pParentStates); ++i) {
+    SSTriggerParentRuntimeState *pState = taosArrayGet(pGroup->pParentStates, i);
+    bool                         nodeTrue = stTriggerTaskEventNodeTruth(pTask, pState->nodeId, startMask);
+
+    if (nodeTrue) {
+      if (pState->state == STRIGGER_EVENT_NODE_IDLE) {
+        pState->state = STRIGGER_EVENT_NODE_TRACKING;
+        pState->curStartTs = rowTs;
+        pState->curLastTs = rowTs;
+        pState->curRowCount = 1;
+        if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN)) {
+          int64_t parentWindowStart =
+              stTriggerTaskGetParentEventWindowStart(pTask, pGroup->pParentStates, pState->nodeId);
+          code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->histStartCondCols, rowIdx, pState->nodeId,
+                                               pGroup->gid, pState->curStartTs, parentWindowStart,
+                                               &pState->pWinOpenNotify);
+          QUERY_CHECK_CODE(code, lino, _end);
+        }
+      } else {
+        pState->curLastTs = rowTs;
+        ++pState->curRowCount;
+      }
+      if (stTriggerTaskIsTrueForSatisfied(&pTask->eventTrueForInfo, pState->curStartTs, pState->curLastTs,
+                                          pState->curRowCount)) {
+        pState->state = STRIGGER_EVENT_NODE_SATISFIED;
+      }
+    }
+
+    if ((!nodeTrue || forceClose) && pState->state != STRIGGER_EVENT_NODE_IDLE) {
+      if (forceClose && (!stTriggerTaskNeedRawEventNodeWindows(pTask) || nodeTrue) && pState->curLastTs != rowTs) {
+        pState->curLastTs = rowTs;
+        ++pState->curRowCount;
+      }
+      code = stHistoryGroupEmitParentEventWindow(pGroup, pState, pDataBlock, rowIdx);
+      QUERY_CHECK_CODE(code, lino, _end);
+    }
+  }
+
+_end:
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
 static int32_t stHistoryGroupSaveInitWindow(SSTriggerHistoryGroup *pGroup, SArray *pInitWindows) {
   int32_t                  code = TSDB_CODE_SUCCESS;
   int32_t                  lino = 0;
@@ -11500,12 +12849,9 @@ static int32_t stHistoryGroupGetDataBlock(SSTriggerHistoryGroup *pGroup, bool sa
           range = pContext->stepRange;
         } else if (pContext->status == STRIGGER_CONTEXT_SEND_CALC_REQ) {
           if (pTask->triggerType != STREAM_TRIGGER_PERIOD) {
-            range.skey = pContext->pParamToFetch->wstart;
+            range.skey =
+                stTriggerTaskGetCalcParamFetchStart(pTask, pContext->pCalcReq->params, pContext->pParamToFetch);
             range.ekey = pContext->pParamToFetch->wend;
-            if (TARRAY_ELEM_IDX(pContext->pCalcReq->params, pContext->pParamToFetch) > 0) {
-              SSTriggerCalcParam *pPrevParam = pContext->pParamToFetch - 1;
-              range.skey = TMAX(range.skey, pPrevParam->wend + 1);
-            }
           }
         } else {
           code = TSDB_CODE_INTERNAL_ERROR;
@@ -11553,12 +12899,9 @@ static int32_t stHistoryGroupGetDataBlock(SSTriggerHistoryGroup *pGroup, bool sa
           range = pContext->stepRange;
         } else if (pContext->status == STRIGGER_CONTEXT_SEND_CALC_REQ) {
           if (pTask->triggerType != STREAM_TRIGGER_PERIOD) {
-            range.skey = pContext->pParamToFetch->wstart;
+            range.skey =
+                stTriggerTaskGetCalcParamFetchStart(pTask, pContext->pCalcReq->params, pContext->pParamToFetch);
             range.ekey = pContext->pParamToFetch->wend;
-            if (TARRAY_ELEM_IDX(pContext->pCalcReq->params, pContext->pParamToFetch) > 0) {
-              SSTriggerCalcParam *pPrevParam = pContext->pParamToFetch - 1;
-              range.skey = TMAX(range.skey, pPrevParam->wend + 1);
-            }
           }
         } else {
           code = TSDB_CODE_INTERNAL_ERROR;
@@ -12066,6 +13409,166 @@ _end:
   return code;
 }
 
+static int32_t stHistoryGroupCloseActiveLeafEventWindow(SSTriggerHistoryGroup *pGroup, const SSDataBlock *pDataBlock,
+                                                        int32_t rowIdx) {
+  int32_t             code = TSDB_CODE_SUCCESS;
+  int32_t             lino = 0;
+  SStreamTriggerTask *pTask = pGroup->pContext->pTask;
+
+  if (pGroup->numSubWindows == 0) {
+    goto _end;
+  }
+
+  if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE)) {
+    int64_t parentWindowStart =
+        stTriggerTaskGetParentEventWindowStart(pTask, pGroup->pParentStates, pGroup->parentWindow.eventNodeId);
+    code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->histEndCondCols, rowIdx,
+                                         pGroup->parentWindow.eventNodeId, pGroup->gid, pGroup->parentWindow.range.skey,
+                                         parentWindowStart, &pGroup->parentWindow.pWinCloseNotify);
+    QUERY_CHECK_CODE(code, lino, _end);
+  }
+  code = stHistoryGroupEmitEventWindow(pGroup, &pGroup->parentWindow, false);
+  QUERY_CHECK_CODE(code, lino, _end);
+  stRealtimeContextDestroyWindow(&pGroup->parentWindow);
+  pGroup->parentWindow = (SSTriggerNotifyWindow){0};
+  pGroup->numSubWindows = 0;
+  pGroup->conditionIdx = 0;
+
+_end:
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
+static int32_t stHistoryGroupOpenActiveLeafEventWindow(SSTriggerHistoryGroup *pGroup, const SSDataBlock *pDataBlock,
+                                                       int32_t rowIdx, int64_t rowTs, int32_t nodeId) {
+  int32_t                    code = TSDB_CODE_SUCCESS;
+  int32_t                    lino = 0;
+  SStreamTriggerTask        *pTask = pGroup->pContext->pTask;
+  SSTriggerLeafRuntimeState *pOpenState = NULL;
+  int64_t                    startTs = rowTs;
+  int64_t                    initialRows = 0;
+
+  QUERY_CHECK_CONDITION(pGroup->numSubWindows == 0, code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
+
+  if (!stTriggerTaskNeedRawEventNodeWindows(pTask) &&
+      stTriggerTaskGetLocalTrueForOpenState(pTask, pGroup->pLeafStates, nodeId, &pOpenState)) {
+    startTs = pOpenState->curStartTs;
+    initialRows = TMAX(pOpenState->curRowCount - 1, 0);
+  }
+
+  pGroup->parentWindow =
+      (SSTriggerNotifyWindow){.range = {.skey = startTs, .ekey = rowTs}, .wrownum = initialRows, .eventNodeId = nodeId};
+  stTriggerTaskInitEventWindowCalcState(pTask, nodeId, startTs, initialRows, &pGroup->parentWindow.calcStartTs,
+                                        &pGroup->parentWindow.calcWrownum);
+  pGroup->numSubWindows = 1;
+  pGroup->conditionIdx = nodeId + 1;
+  if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN)) {
+    int64_t parentWindowStart = stTriggerTaskGetParentEventWindowStart(pTask, pGroup->pParentStates, nodeId);
+    code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->histStartCondCols, rowIdx, nodeId, pGroup->gid,
+                                         pGroup->parentWindow.range.skey, parentWindowStart,
+                                         &pGroup->parentWindow.pWinOpenNotify);
+    QUERY_CHECK_CODE(code, lino, _end);
+  }
+
+_end:
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
+static int32_t stHistoryGroupDoTreeEventCheck(SSTriggerHistoryGroup *pGroup) {
+  int32_t                  code = TSDB_CODE_SUCCESS;
+  int32_t                  lino = 0;
+  SSTriggerHistoryContext *pContext = pGroup->pContext;
+  SStreamTriggerTask      *pTask = pContext->pTask;
+  bool                     allTableProcessed = false;
+  bool                     needFetchData = false;
+  SColumnInfoData          startCol = {0};
+  SColumnInfoData          endCol = {0};
+
+  while (!allTableProcessed && !needFetchData) {
+    SSDataBlock *pDataBlock = NULL;
+    int32_t      startIdx = 0;
+    int32_t      endIdx = 0;
+    code =
+        stHistoryGroupGetDataBlock(pGroup, false, &pDataBlock, &startIdx, &endIdx, &allTableProcessed, &needFetchData);
+    QUERY_CHECK_CODE(code, lino, _end);
+    if (allTableProcessed || needFetchData) {
+      break;
+    }
+
+    SColumnInfoData *pTsCol = taosArrayGet(pDataBlock->pDataBlock, pTask->histTrigTsIndex);
+    QUERY_CHECK_NULL(pTsCol, code, lino, _end, terrno);
+    int64_t *pTsData = (int64_t *)pTsCol->pData;
+
+    code = stHistoryContextCalcExpr(pContext, pDataBlock, pTask->histStartCond, &startCol);
+    QUERY_CHECK_CODE(code, lino, _end);
+    code = stHistoryContextCalcExpr(pContext, pDataBlock, pTask->histEndCond, &endCol);
+    QUERY_CHECK_CODE(code, lino, _end);
+    uint8_t *pe = (uint8_t *)endCol.pData;
+
+    for (int32_t r = startIdx; r < endIdx; ++r) {
+      int64_t  rowTs = pTsData[r];
+      uint64_t startMask = stTriggerTaskGetEventStartMask(&startCol, r);
+      bool     forceClose = pe[r] || startMask == 0;
+
+      stTriggerTaskUpdateLeafRuntimeStates(pTask, pGroup->pLeafStates, startMask, rowTs);
+      int32_t nextLeafNodeId = stTriggerTaskGetFirstEligibleEventLeaf(pTask, pGroup->pLeafStates, startMask);
+
+      code = stHistoryGroupUpdateParentEventWindows(pGroup, pDataBlock, r, rowTs, startMask, forceClose);
+      QUERY_CHECK_CODE(code, lino, _end);
+
+      if (pGroup->numSubWindows > 0 && nextLeafNodeId >= 0 && pGroup->parentWindow.eventNodeId != nextLeafNodeId) {
+        code = stHistoryGroupCloseActiveLeafEventWindow(pGroup, pDataBlock, r);
+        QUERY_CHECK_CODE(code, lino, _end);
+      }
+
+      if (pGroup->numSubWindows == 0 && nextLeafNodeId >= 0) {
+        code = stHistoryGroupOpenActiveLeafEventWindow(pGroup, pDataBlock, r, rowTs, nextLeafNodeId);
+        QUERY_CHECK_CODE(code, lino, _end);
+      }
+
+      if (pGroup->numSubWindows == 0) {
+        if (forceClose) {
+          stTriggerTaskResetEventRuntimeStates(pGroup->pLeafStates, pGroup->pParentStates);
+        }
+        continue;
+      }
+
+      bool leafTrue = stTriggerTaskEventNodeTruth(pTask, pGroup->parentWindow.eventNodeId, startMask);
+      if (stTriggerTaskNeedRawEventNodeWindows(pTask) && forceClose && !leafTrue) {
+        code = stHistoryGroupCloseActiveLeafEventWindow(pGroup, pDataBlock, r);
+        QUERY_CHECK_CODE(code, lino, _end);
+        stTriggerTaskResetEventRuntimeStates(pGroup->pLeafStates, pGroup->pParentStates);
+        continue;
+      }
+
+      ++pGroup->parentWindow.wrownum;
+      pGroup->parentWindow.range.ekey = rowTs;
+      stTriggerTaskAdvanceEventWindowCalcState(pTask, pGroup->parentWindow.eventNodeId, pGroup->parentWindow.range.skey,
+                                               rowTs, pGroup->parentWindow.wrownum, rowTs,
+                                               &pGroup->parentWindow.calcStartTs, &pGroup->parentWindow.calcWrownum);
+
+      if (forceClose) {
+        code = stHistoryGroupCloseActiveLeafEventWindow(pGroup, pDataBlock, r);
+        QUERY_CHECK_CODE(code, lino, _end);
+        stTriggerTaskResetEventRuntimeStates(pGroup->pLeafStates, pGroup->pParentStates);
+      }
+    }
+  }
+
+_end:
+  colDataDestroy(&startCol);
+  colDataDestroy(&endCol);
+  if (code != TSDB_CODE_SUCCESS) {
+    ST_TASK_ELOG("%s failed at line %d since %s", __func__, lino, tstrerror(code));
+  }
+  return code;
+}
+
 static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
   int32_t                  code = TSDB_CODE_SUCCESS;
   int32_t                  lino = 0;
@@ -12076,6 +13579,10 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
   char                    *pExtraNotifyContent = NULL;
   SColumnInfoData          startCol = {0};
   SColumnInfoData          endCol = {0};
+
+  if (pTask->startCondHasSubEvents) {
+    return stHistoryGroupDoTreeEventCheck(pGroup);
+  }
 
   while (!allTableProcessed && !needFetchData) {
     //  read all data of the current table
@@ -12106,7 +13613,7 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
           int32_t winIdx = pGroup->numSubWindows - 1;
           if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE)) {
             SSTriggerWindow *pCurWin = TRINGBUF_HEAD(&pGroup->winBuf);
-            code = streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, winIdx, pGroup->gid,
+            code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->histEndCondCols, r, ps[r] - 1, pGroup->gid,
                                                  pCurWin->range.skey, pGroup->parentWindow.range.skey,
                                                  &pExtraNotifyContent);
             QUERY_CHECK_CODE(code, lino, _end);
@@ -12128,7 +13635,7 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
           if (pGroup->numSubWindows == 0) {
             pGroup->parentWindow = (SSTriggerNotifyWindow){.range.skey = pTsData[r], .range.ekey = pTsData[r]};
             if (pTask->notifyHistory && pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN) {
-              code = streamBuildEventNotifyContent(pDataBlock, pTask->histStartCondCols, r, ps[r] - 1, -1, pGroup->gid,
+              code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->histStartCondCols, r, -1, pGroup->gid,
                                                    pTsData[r], 0, &pGroup->parentWindow.pWinOpenNotify);
               QUERY_CHECK_CODE(code, lino, _end);
             }
@@ -12149,7 +13656,7 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
         }
         if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN)) {
           int64_t parentWindowStart = (checkSubEvent && winIdx >= 0) ? pGroup->parentWindow.range.skey : 0;
-          code = streamBuildEventNotifyContent(pDataBlock, pTask->histStartCondCols, r, ps[r] - 1, winIdx, pGroup->gid,
+          code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->histStartCondCols, r, ps[r] - 1, pGroup->gid,
                                                pTsData[r], parentWindowStart, &pExtraNotifyContent);
           QUERY_CHECK_CODE(code, lino, _end);
         }
@@ -12169,7 +13676,7 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
         if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE)) {
           int64_t          parentWindowStart = (checkSubEvent && winIdx >= 0) ? pGroup->parentWindow.range.skey : 0;
           SSTriggerWindow *pCurWin = TRINGBUF_HEAD(&pGroup->winBuf);
-          code = streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, winIdx, pGroup->gid,
+          code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->histEndCondCols, r, ps[r] - 1, pGroup->gid,
                                                pCurWin->range.skey, parentWindowStart, &pExtraNotifyContent);
           QUERY_CHECK_CODE(code, lino, _end);
         }
@@ -12177,7 +13684,7 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
         QUERY_CHECK_CODE(code, lino, _end);
         if (checkSubEvent) {
           if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE)) {
-            code = streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, -1, pGroup->gid,
+            code = stTriggerTaskBuildEventNotify(pTask, pDataBlock, pTask->histEndCondCols, r, -1, pGroup->gid,
                                                  pGroup->parentWindow.range.skey, 0,
                                                  &pGroup->parentWindow.pWinCloseNotify);
             QUERY_CHECK_CODE(code, lino, _end);
@@ -12271,72 +13778,39 @@ static int32_t stHistoryGroupRetrievePendingCalc(SSTriggerHistoryGroup *pGroup) 
   int32_t                  lino = 0;
   SSTriggerHistoryContext *pContext = pGroup->pContext;
   SStreamTriggerTask      *pTask = pContext->pTask;
+  int32_t maxParamsPerReq = stTriggerTaskNeedOverlapSafeCalcRange(pTask) ? 1 : STREAM_CALC_REQ_MAX_WIN_NUM;
 
   ST_TASK_DLOG("history group %" PRId64 " starts to exec %" PRId64 " pending params, %" PRId64 " pending parwin params",
                pGroup->gid, pGroup->pPendingCalcParams.neles, pGroup->pPendingParWinCalcParams.neles);
 
 #define LOG_EVERY_NUM_PARAM 10000
-  if (pGroup->pPendingParWinCalcParams.neles > 0) {
-    int64_t end = INT64_MAX;
-    if (pGroup->pPendingCalcParams.neles > 0) {
-      SSTriggerCalcParam *pParam = taosObjListGetHead(&pGroup->pPendingCalcParams);
-      end = pParam->wend;
-    }
-    int64_t             origNele = pGroup->pPendingParWinCalcParams.neles;
-    int64_t             origTotal = pContext->calcParamPool.size;
-    int32_t             nele = 0;
-    SSTriggerCalcParam *pParam = NULL;
-    SObjListIter        iter = {0};
-    taosObjListInitIter(&pGroup->pPendingParWinCalcParams, &iter, TOBJLIST_ITER_FORWARD);
-    while ((pParam = taosObjListIterNext(&iter)) != NULL && pParam->wend < end &&
-           TARRAY_SIZE(pContext->pCalcReq->params) < STREAM_CALC_REQ_MAX_WIN_NUM) {
-      void *px = taosArrayPush(pContext->pCalcReq->params, pParam);
-      QUERY_CHECK_NULL(px, code, lino, _end, terrno);
-      pParam->extraNotifyContent = NULL;
-      nele++;
-    }
-    if (nele > 0) {
-      taosObjListPopHeadTo(&pGroup->pPendingParWinCalcParams, pParam, nele);
-      int64_t freedNele = origNele - pGroup->pPendingParWinCalcParams.neles;
-      if (stDebugFlag & DEBUG_DEBUG) {
-        ST_TASK_DLOG("history group %" PRId64 " retrieved %" PRId64
-                     " pending parwin params, calc param pool size from %" PRId64 " to %" PRId64,
-                     pGroup->gid, freedNele, origTotal, pContext->calcParamPool.size);
-      } else if ((origTotal / LOG_EVERY_NUM_PARAM) != (pContext->calcParamPool.size / LOG_EVERY_NUM_PARAM)) {
-        ST_TASK_ILOG("history group %" PRId64 " retrieved %" PRId64
-                     " pending parwin params, calc param pool size from %" PRId64 " to %" PRId64,
-                     pGroup->gid, freedNele, origTotal, pContext->calcParamPool.size);
-      }
-      SSTriggerCalcParam *pLastParam = taosArrayGetLast(pContext->pCalcReq->params);
-      pContext->lastSentWinEnd = pLastParam ? pLastParam->wend : INT64_MIN;
-      goto _end;
-    }
-  }
+  if (pGroup->pPendingParWinCalcParams.neles > 0 || pGroup->pPendingCalcParams.neles > 0) {
+    int64_t origParNele = pGroup->pPendingParWinCalcParams.neles;
+    int64_t origCalcNele = pGroup->pPendingCalcParams.neles;
+    int64_t origTotal = pContext->calcParamPool.size;
 
-  if (pGroup->pPendingCalcParams.neles > 0) {
-    int64_t             origNele = pGroup->pPendingCalcParams.neles;
-    int64_t             origTotal = pContext->calcParamPool.size;
-    int32_t             nele = 0;
-    SSTriggerCalcParam *pParam = NULL;
-    SObjListIter        iter = {0};
-    taosObjListInitIter(&pGroup->pPendingCalcParams, &iter, TOBJLIST_ITER_FORWARD);
-    while ((pParam = taosObjListIterNext(&iter)) != NULL &&
-           TARRAY_SIZE(pContext->pCalcReq->params) < STREAM_CALC_REQ_MAX_WIN_NUM) {
-      void *px = taosArrayPush(pContext->pCalcReq->params, pParam);
-      QUERY_CHECK_NULL(px, code, lino, _end, terrno);
-      pParam->extraNotifyContent = NULL;
-      nele++;
+    while ((pGroup->pPendingParWinCalcParams.neles > 0 || pGroup->pPendingCalcParams.neles > 0) &&
+           TARRAY_SIZE(pContext->pCalcReq->params) < maxParamsPerReq) {
+      SObjList *pPendingParams =
+          stTriggerTaskUseParentCalcParam(&pGroup->pPendingParWinCalcParams, &pGroup->pPendingCalcParams)
+              ? &pGroup->pPendingParWinCalcParams
+              : &pGroup->pPendingCalcParams;
+      code = stTriggerTaskTakePendingCalcParam(pPendingParams, pContext->pCalcReq->params);
+      QUERY_CHECK_CODE(code, lino, _end);
     }
-    taosObjListPopHeadTo(&pGroup->pPendingCalcParams, pParam, nele);
-    int64_t freedNele = origNele - pGroup->pPendingCalcParams.neles;
-    if (stDebugFlag & DEBUG_DEBUG) {
-      ST_TASK_DLOG("history group %" PRId64 " retrieved %" PRId64 " pending params, calc param pool size from %" PRId64
-                   " to %" PRId64,
-                   pGroup->gid, freedNele, origTotal, pContext->calcParamPool.size);
-    } else if ((origTotal / LOG_EVERY_NUM_PARAM) != (pContext->calcParamPool.size / LOG_EVERY_NUM_PARAM)) {
-      ST_TASK_ILOG("history group %" PRId64 " retrieved %" PRId64 " pending params, calc param pool size from %" PRId64
-                   " to %" PRId64,
-                   pGroup->gid, freedNele, origTotal, pContext->calcParamPool.size);
+
+    int64_t freedParNele = origParNele - pGroup->pPendingParWinCalcParams.neles;
+    int64_t freedCalcNele = origCalcNele - pGroup->pPendingCalcParams.neles;
+    if (freedParNele > 0 || freedCalcNele > 0) {
+      if (stDebugFlag & DEBUG_DEBUG) {
+        ST_TASK_DLOG("history group %" PRId64 " retrieved %" PRId64 " pending params and %" PRId64
+                     " pending parwin params, calc param pool size from %" PRId64 " to %" PRId64,
+                     pGroup->gid, freedCalcNele, freedParNele, origTotal, pContext->calcParamPool.size);
+      } else if ((origTotal / LOG_EVERY_NUM_PARAM) != (pContext->calcParamPool.size / LOG_EVERY_NUM_PARAM)) {
+        ST_TASK_ILOG("history group %" PRId64 " retrieved %" PRId64 " pending params and %" PRId64
+                     " pending parwin params, calc param pool size from %" PRId64 " to %" PRId64,
+                     pGroup->gid, freedCalcNele, freedParNele, origTotal, pContext->calcParamPool.size);
+      }
     }
   }
 

--- a/source/libs/new-stream/src/streamUtil.c
+++ b/source/libs/new-stream/src/streamUtil.c
@@ -14,14 +14,14 @@
  */
 
 #include "cJSON.h"
+#include "cmdnodes.h"
 #include "dataSink.h"
+#include "decimal.h"
 #include "osMemPool.h"
 #include "streamInt.h"
-#include "tdatablock.h"
 #include "tcurl.h"
+#include "tdatablock.h"
 #include "tstrbuild.h"
-#include "decimal.h"
-#include "cmdnodes.h"
 
 int32_t streamGetThreadIdx(int32_t threadNum, int64_t streamGId) { return threadNum ? (streamGId % threadNum) : 0; }
 
@@ -84,12 +84,11 @@ void stmHandleStreamRemovedTasks(SStreamInfo* pStream, int64_t streamId, int32_t
   if (taosArrayGetSize(pStream->undeployTriggers) > 0) {
     smHandleRemovedTask(pStream, streamId, gid, STREAM_TRIGGER_TASK, pStream->undeployTriggers, pStream->triggerList);
   }
-  
+
   if (taosArrayGetSize(pStream->undeployRunners) > 0) {
     smHandleRemovedTask(pStream, streamId, gid, STREAM_RUNNER_TASK, pStream->undeployRunners, pStream->runnerList);
   }
 }
-
 
 int32_t stmHbAddTaskStatus(int64_t streamId, SStreamHbMsg* pMsg, SStreamTask* pTask) {
   int32_t code = 0, lino = 0;
@@ -103,7 +102,7 @@ int32_t stmHbAddTaskStatus(int64_t streamId, SStreamHbMsg* pMsg, SStreamTask* pT
   } else {
     TSDB_CHECK_NULL(taosArrayPush(pMsg->pStreamStatus, pTask), code, lino, _exit, terrno);
   }
-  
+
 _exit:
 
   taosWUnLockLatch(&pTask->mgmtReqLock);
@@ -115,12 +114,11 @@ _exit:
   return code;
 }
 
-
 int32_t stmHbAddStreamStatus(SStreamHbMsg* pMsg, SStreamInfo* pStream, int64_t streamId, bool reportPeriod) {
-  int32_t code = TSDB_CODE_SUCCESS;
-  int32_t lino = 0;
-  SListIter iter = {0};
-  SListNode* listNode = NULL;
+  int32_t      code = TSDB_CODE_SUCCESS;
+  int32_t      lino = 0;
+  SListIter    iter = {0};
+  SListNode*   listNode = NULL;
   SStreamTask* pTask = NULL;
 
   taosWLockLatch(&pStream->lock);
@@ -131,7 +129,7 @@ int32_t stmHbAddStreamStatus(SStreamHbMsg* pMsg, SStreamInfo* pStream, int64_t s
     stsDebug("ignore stream status update since stream taskNum %d is invalid", pStream->taskNum);
     goto _exit;
   }
-  
+
   if (NULL == pMsg->pStreamStatus) {
     pMsg->pStreamStatus = taosArrayInit(pStream->taskNum, sizeof(SStmTaskStatusMsg));
     TSDB_CHECK_NULL(pMsg->pStreamStatus, code, lino, _exit, terrno);
@@ -145,9 +143,9 @@ int32_t stmHbAddStreamStatus(SStreamHbMsg* pMsg, SStreamInfo* pStream, int64_t s
       SStreamReaderTask* pReader = (SStreamReaderTask*)listNode->data;
       pTask = (SStreamTask*)pReader;
       TSDB_CHECK_NULL(taosArrayPush(pMsg->pStreamStatus, &pReader->task), code, lino, _exit, terrno);
-      //if (pReader->task.pMgmtReq) {
-      //  TAOS_CHECK_EXIT(stmAddMgmtReq(streamId, &pMsg->pStreamReq, taosArrayGetSize(pMsg->pStreamStatus) - 1));
-      //}
+      // if (pReader->task.pMgmtReq) {
+      //   TAOS_CHECK_EXIT(stmAddMgmtReq(streamId, &pMsg->pStreamReq, taosArrayGetSize(pMsg->pStreamStatus) - 1));
+      // }
       ST_TASK_DLOG("task status added to hb %s mgmtReq", pReader->task.pMgmtReq ? "with" : "without");
     }
 
@@ -163,9 +161,9 @@ int32_t stmHbAddStreamStatus(SStreamHbMsg* pMsg, SStreamInfo* pStream, int64_t s
     } else {
       pTask->detailStatus = -1;
     }
-    
+
     TAOS_CHECK_EXIT(stmHbAddTaskStatus(streamId, pMsg, pTask));
-    
+
     ST_TASK_DLOG("task status added to hb %s mgmtReq", pTask->pMgmtReq ? "with" : "without");
     stsDebug("%d trigger tasks status added to hb", 1);
   }
@@ -188,8 +186,9 @@ int32_t stmHbAddStreamStatus(SStreamHbMsg* pMsg, SStreamInfo* pStream, int64_t s
 
     stsDebug("%d runner tasks status added to hb", TD_DLIST_NELES(pStream->runnerList));
   }
-  
-  stsDebug("total %d:%d tasks status added to hb", (int32_t)taosArrayGetSize(pMsg->pStreamStatus) - origTaskNum, pStream->taskNum);
+
+  stsDebug("total %d:%d tasks status added to hb", (int32_t)taosArrayGetSize(pMsg->pStreamStatus) - origTaskNum,
+           pStream->taskNum);
 
 _exit:
 
@@ -210,7 +209,7 @@ int32_t stmBuildHbStreamsStatusReq(SStreamHbMsg* pMsg) {
   }
 
   stDebug("start to build hb status req, gid:%d", pMsg->streamGId);
-  
+
   SHashObj* pHash = gStreamMgmt.stmGrp[pMsg->streamGId];
   if (NULL == pHash) {
     return TSDB_CODE_SUCCESS;
@@ -239,15 +238,15 @@ void stmDestroySStreamInfo(void* param) {
   }
 
   stDebug("start to destroy stream info");
-  
+
   SStreamInfo* p = (SStreamInfo*)param;
 
-  SListIter iter = {0};
-  SListNode* listNode = NULL;  
+  SListIter  iter = {0};
+  SListNode* listNode = NULL;
   tdListInitIter(p->readerList, &iter, TD_LIST_FORWARD);
   while ((listNode = tdListNext(&iter)) != NULL) {
     SStreamTask* pTask = (SStreamTask*)listNode->data;
-    SListNode* tmp = tdListPopNode(p->readerList, listNode);
+    SListNode*   tmp = tdListPopNode(p->readerList, listNode);
     ST_TASK_DLOG("task removed from stream readerList, remain:%d, listNode:%p", TD_DLIST_NELES(p->readerList), tmp);
     taosMemoryFreeClear(tmp);
   }
@@ -257,7 +256,7 @@ void stmDestroySStreamInfo(void* param) {
   tdListInitIter(p->triggerList, &iter, TD_LIST_FORWARD);
   while ((listNode = tdListNext(&iter)) != NULL) {
     SStreamTask* pTask = (SStreamTask*)listNode->data;
-    SListNode* tmp = tdListPopNode(p->triggerList, listNode);
+    SListNode*   tmp = tdListPopNode(p->triggerList, listNode);
     ST_TASK_DLOG("task removed from stream triggerList, remain:%d", TD_DLIST_NELES(p->triggerList));
     taosMemoryFreeClear(tmp);
   }
@@ -267,7 +266,7 @@ void stmDestroySStreamInfo(void* param) {
   tdListInitIter(p->runnerList, &iter, TD_LIST_FORWARD);
   while ((listNode = tdListNext(&iter)) != NULL) {
     SStreamTask* pTask = (SStreamTask*)listNode->data;
-    SListNode* tmp = tdListPopNode(p->runnerList, listNode);
+    SListNode*   tmp = tdListPopNode(p->runnerList, listNode);
     ST_TASK_DLOG("task removed from stream runnerList, remain:%d", TD_DLIST_NELES(p->runnerList));
     taosMemoryFreeClear(tmp);
   }
@@ -284,7 +283,8 @@ void stmDestroySStreamInfo(void* param) {
 #define JSON_CHECK_ADD_ITEM(obj, str, item) \
   QUERY_CHECK_CONDITION(cJSON_AddItemToObjectCS(obj, str, item), code, lino, _end, TSDB_CODE_OUT_OF_MEMORY)
 
-static int32_t jsonAddColumnField(const char* colName, const SColumnInfo* colInfo, bool isNull, const char* pData, cJSON* obj) {
+static int32_t jsonAddColumnField(const char* colName, const SColumnInfo* colInfo, bool isNull, const char* pData,
+                                  cJSON* obj) {
   int8_t  type = colInfo->type;
   int32_t code = TSDB_CODE_SUCCESS;
   int32_t lino = 0;
@@ -487,10 +487,31 @@ _end:
   return code;
 }
 
-static void streamBuildNotifyTriggerId(int64_t groupId, int64_t windowStart, int32_t winIdx, char* triggerId);
+static void streamBuildNotifyTriggerId(int64_t groupId, int64_t windowStart, const char* conditionPath,
+                                       char* triggerId);
+
+static int32_t streamGetLastEventConditionIndex(const char* conditionPath) {
+  if (conditionPath == NULL || *conditionPath == '\0') {
+    return 0;
+  }
+
+  const char* p = conditionPath + strlen(conditionPath);
+  while (p > conditionPath && *(p - 1) != '.') {
+    --p;
+  }
+
+  int32_t idx = 0;
+  for (; *p != '\0'; ++p) {
+    if (*p < '0' || *p > '9') {
+      return 0;
+    }
+    idx = idx * 10 + (*p - '0');
+  }
+  return idx;
+}
 
 int32_t streamBuildEventNotifyContent(const SSDataBlock* pInputBlock, const SNodeList* pCondCols, int32_t rowIdx,
-                                      int32_t condIdx, int32_t winIdx, int64_t groupId, int64_t windowStart,
+                                      const char* conditionPath, int64_t groupId, int64_t windowStart,
                                       int64_t parentWindowStart, char** ppContent) {
   int32_t      code = TSDB_CODE_SUCCESS;
   int32_t      lino = 0;
@@ -513,20 +534,24 @@ int32_t streamBuildEventNotifyContent(const SSDataBlock* pInputBlock, const SNod
 
   cond = cJSON_CreateObject();
   QUERY_CHECK_NULL(cond, code, lino, _end, TSDB_CODE_OUT_OF_MEMORY);
-  JSON_CHECK_ADD_ITEM(cond, "conditionIndex", cJSON_CreateNumber(condIdx));
+  JSON_CHECK_ADD_ITEM(cond, "conditionPath", cJSON_CreateString(conditionPath != NULL ? conditionPath : ""));
+  JSON_CHECK_ADD_ITEM(cond, "conditionIndex", cJSON_CreateNumber(streamGetLastEventConditionIndex(conditionPath)));
   JSON_CHECK_ADD_ITEM(cond, "fieldValues", fields);
   fields = NULL;
 
   obj = cJSON_CreateObject();
   QUERY_CHECK_NULL(obj, code, lino, _end, TSDB_CODE_OUT_OF_MEMORY);
   char triggerId[32];
-  streamBuildNotifyTriggerId(groupId, windowStart, winIdx, triggerId);
+  streamBuildNotifyTriggerId(groupId, windowStart, conditionPath, triggerId);
   JSON_CHECK_ADD_ITEM(obj, "triggerId", cJSON_CreateString(triggerId));
   JSON_CHECK_ADD_ITEM(obj, "triggerCondition", cond);
-  JSON_CHECK_ADD_ITEM(obj, "windowIndex", cJSON_CreateNumber(winIdx));
-  if (winIdx >= 0) {
+  JSON_CHECK_ADD_ITEM(obj, "windowIndex",
+                      cJSON_CreateNumber((conditionPath != NULL && *conditionPath != '\0')
+                                             ? streamGetLastEventConditionIndex(conditionPath)
+                                             : -1));
+  if (conditionPath != NULL && *conditionPath != '\0') {
     char parentTriggerId[32];
-    streamBuildNotifyTriggerId(groupId, parentWindowStart, -1, parentTriggerId);
+    streamBuildNotifyTriggerId(groupId, parentWindowStart, NULL, parentTriggerId);
     JSON_CHECK_ADD_ITEM(obj, "parentTriggerId", cJSON_CreateString(parentTriggerId));
   }
   cond = NULL;
@@ -550,8 +575,8 @@ _end:
   return code;
 }
 
-int32_t streamBuildBlockResultNotifyContent(const SStreamRunnerTask* pTask, const SSDataBlock* pBlock, char** ppContent, const SArray* pFields,
-                                            const int32_t startRow, const int32_t endRow) {
+int32_t streamBuildBlockResultNotifyContent(const SStreamRunnerTask* pTask, const SSDataBlock* pBlock, char** ppContent,
+                                            const SArray* pFields, const int32_t startRow, const int32_t endRow) {
   int32_t code = 0, lino = 0;
   cJSON*  pContent = NULL;
   cJSON*  pResult = NULL;
@@ -696,13 +721,13 @@ _end:
   return code;
 }
 
-static void streamBuildNotifyTriggerId(int64_t groupId, int64_t windowStart, int32_t winIdx, char* triggerId) {
-  uint64_t hash = 0;
-  if (winIdx >= 0) {
-    uint64_t ar[] = {(uint64_t)groupId, (uint64_t)windowStart, (uint64_t)(uint32_t)winIdx};
-    hash = MurmurHash3_64((const char*)ar, sizeof(ar));
-  } else {
-    uint64_t ar[] = {(uint64_t)groupId, (uint64_t)windowStart};
+static void streamBuildNotifyTriggerId(int64_t groupId, int64_t windowStart, const char* conditionPath,
+                                       char* triggerId) {
+  uint64_t ar[] = {(uint64_t)groupId, (uint64_t)windowStart};
+  uint64_t hash = MurmurHash3_64((const char*)ar, sizeof(ar));
+  if (conditionPath != NULL && *conditionPath != '\0') {
+    ar[0] = hash;
+    ar[1] = MurmurHash3_64(conditionPath, strlen(conditionPath));
     hash = MurmurHash3_64((const char*)ar, sizeof(ar));
   }
   (void)u64toaFastLut(hash, triggerId);
@@ -734,7 +759,7 @@ static int32_t streamAppendNotifyContent(int32_t triggerType, int64_t groupId, c
       (pParam->notifyType == STRIGGER_EVENT_WINDOW_OPEN || pParam->notifyType == STRIGGER_EVENT_WINDOW_CLOSE) &&
       pParam->extraNotifyContent != NULL;
   if (!hasEventTriggerId) {
-    streamBuildNotifyTriggerId(groupId, pParam->wstart, -1, triggerId);
+    streamBuildNotifyTriggerId(groupId, pParam->wstart, NULL, triggerId);
   }
 
   const char* triggerTypeStr = NULL;
@@ -839,8 +864,8 @@ int32_t streamSendNotifyContent(SStreamTask* pTask, const char* streamName, cons
   SCURL          conn = {0};
   bool           shouldNotify = false;
 
-  // Remove prefix 1. 
-  char*          pos = strstr(streamName, TS_PATH_DELIMITER);
+  // Remove prefix 1.
+  char* pos = strstr(streamName, TS_PATH_DELIMITER);
   if (pos != NULL) streamName = ++pos;
 
   if (nParam <= 0 || taosArrayGetSize(pNotifyAddrUrls) <= 0) {

--- a/source/libs/nodes/src/nodesCloneFuncs.c
+++ b/source/libs/nodes/src/nodesCloneFuncs.c
@@ -411,6 +411,12 @@ static int32_t eventWindowNodeCopy(const SEventWindowNode* pSrc, SEventWindowNod
   return TSDB_CODE_SUCCESS;
 }
 
+static int32_t eventStartLeafNodeCopy(const SEventStartLeafNode* pSrc, SEventStartLeafNode* pDst) {
+  CLONE_NODE_FIELD(pCond);
+  CLONE_NODE_FIELD(pTrueForLimit);
+  return TSDB_CODE_SUCCESS;
+}
+
 static int32_t countWindowNodeCopy(const SCountWindowNode* pSrc, SCountWindowNode* pDst) {
   CLONE_NODE_FIELD(pCol);
   COPY_SCALAR_FIELD(windowCount);
@@ -1282,6 +1288,9 @@ int32_t nodesCloneNode(const SNode* pNode, SNode** ppNode) {
       break;
     case QUERY_NODE_EVENT_WINDOW:
       code = eventWindowNodeCopy((const SEventWindowNode*)pNode, (SEventWindowNode*)pDst);
+      break;
+    case QUERY_NODE_EVENT_START_LEAF:
+      code = eventStartLeafNodeCopy((const SEventStartLeafNode*)pNode, (SEventStartLeafNode*)pDst);
       break;
     case QUERY_NODE_COUNT_WINDOW:
       code = countWindowNodeCopy((const SCountWindowNode*)pNode, (SCountWindowNode*)pDst);

--- a/source/libs/nodes/src/nodesCodeFuncs.c
+++ b/source/libs/nodes/src/nodesCodeFuncs.c
@@ -113,6 +113,8 @@ const char* nodesNodeName(ENodeType type) {
       return "CaseWhen";
     case QUERY_NODE_EVENT_WINDOW:
       return "EventWindow";
+    case QUERY_NODE_EVENT_START_LEAF:
+      return "EventStartLeaf";
     case QUERY_NODE_WINDOW_OFFSET:
       return "WindowOffset";
     case QUERY_NODE_COUNT_WINDOW:
@@ -6831,6 +6833,29 @@ static int32_t jsonToEventWindowNode(const SJson* pJson, void* pObj) {
   return code;
 }
 
+static const char* jkEventStartLeafCond = "Cond";
+static const char* jkEventStartLeafTrueForLimit = "TrueForLimit";
+
+static int32_t eventStartLeafNodeToJson(const void* pObj, SJson* pJson) {
+  const SEventStartLeafNode* pNode = (const SEventStartLeafNode*)pObj;
+
+  int32_t code = tjsonAddObject(pJson, jkEventStartLeafCond, nodeToJson, pNode->pCond);
+  if (TSDB_CODE_SUCCESS == code) {
+    code = tjsonAddObject(pJson, jkEventStartLeafTrueForLimit, nodeToJson, pNode->pTrueForLimit);
+  }
+  return code;
+}
+
+static int32_t jsonToEventStartLeafNode(const SJson* pJson, void* pObj) {
+  SEventStartLeafNode* pNode = (SEventStartLeafNode*)pObj;
+
+  int32_t code = jsonToNodeObject(pJson, jkEventStartLeafCond, &pNode->pCond);
+  if (TSDB_CODE_SUCCESS == code) {
+    code = jsonToNodeObject(pJson, jkEventStartLeafTrueForLimit, &pNode->pTrueForLimit);
+  }
+  return code;
+}
+
 static const char* jkCountWindowTsPrimaryKey = "CountTsPrimaryKey";
 static const char* jkCountWindowCount = "CountWindowCount";
 static const char* jkCountWindowSliding = "CountWindowSliding";
@@ -10606,6 +10631,8 @@ static int32_t specificNodeToJson(const void* pObj, SJson* pJson) {
       return caseWhenNodeToJson(pObj, pJson);
     case QUERY_NODE_EVENT_WINDOW:
       return eventWindowNodeToJson(pObj, pJson);
+    case QUERY_NODE_EVENT_START_LEAF:
+      return eventStartLeafNodeToJson(pObj, pJson);
     case QUERY_NODE_WINDOW_OFFSET:
       return windowOffsetNodeToJson(pObj, pJson);
     case QUERY_NODE_COUNT_WINDOW:
@@ -11108,6 +11135,8 @@ static int32_t jsonToSpecificNode(const SJson* pJson, void* pObj) {
       return jsonToCaseWhenNode(pJson, pObj);
     case QUERY_NODE_EVENT_WINDOW:
       return jsonToEventWindowNode(pJson, pObj);
+    case QUERY_NODE_EVENT_START_LEAF:
+      return jsonToEventStartLeafNode(pJson, pObj);
     case QUERY_NODE_WINDOW_OFFSET:
       return jsonToWindowOffsetNode(pJson, pObj);
     case QUERY_NODE_COUNT_WINDOW:

--- a/source/libs/nodes/src/nodesTraverseFuncs.c
+++ b/source/libs/nodes/src/nodesTraverseFuncs.c
@@ -192,6 +192,14 @@ static EDealRes dispatchExpr(SNode* pNode, ETraversalOrder order, FNodeWalker wa
       }
       break;
     }
+    case QUERY_NODE_EVENT_START_LEAF: {
+      SEventStartLeafNode* pLeaf = (SEventStartLeafNode*)pNode;
+      res = walkExpr(pLeaf->pCond, order, walker, pContext);
+      if (DEAL_RES_ERROR != res && DEAL_RES_END != res) {
+        res = walkExpr(pLeaf->pTrueForLimit, order, walker, pContext);
+      }
+      break;
+    }
     case QUERY_NODE_PERIOD_WINDOW: {
       SPeriodWindowNode* pPeriod = (SPeriodWindowNode*)pNode;
       res = walkExpr(pPeriod->pOffset, order, walker, pContext);
@@ -489,6 +497,14 @@ static EDealRes rewriteExpr(SNode** pRawNode, ETraversalOrder order, FNodeRewrit
       }
       if (DEAL_RES_ERROR != res && DEAL_RES_END != res) {
         res = rewriteExpr(&pEvent->pTrueForLimit, order, rewriter, pContext);
+      }
+      break;
+    }
+    case QUERY_NODE_EVENT_START_LEAF: {
+      SEventStartLeafNode* pLeaf = (SEventStartLeafNode*)pNode;
+      res = rewriteExpr(&pLeaf->pCond, order, rewriter, pContext);
+      if (DEAL_RES_ERROR != res && DEAL_RES_END != res) {
+        res = rewriteExpr(&pLeaf->pTrueForLimit, order, rewriter, pContext);
       }
       break;
     }

--- a/source/libs/nodes/src/nodesUtilFuncs.c
+++ b/source/libs/nodes/src/nodesUtilFuncs.c
@@ -498,6 +498,9 @@ int32_t nodesMakeNode(ENodeType type, SNode** ppNodeOut) {
     case QUERY_NODE_EVENT_WINDOW:
       code = makeNode(type, sizeof(SEventWindowNode), &pNode);
       break;
+    case QUERY_NODE_EVENT_START_LEAF:
+      code = makeNode(type, sizeof(SEventStartLeafNode), &pNode);
+      break;
     case QUERY_NODE_COUNT_WINDOW:
       code = makeNode(type, sizeof(SCountWindowNode), &pNode);
       break;
@@ -1630,6 +1633,12 @@ void nodesDestroyNode(SNode* pNode) {
       nodesDestroyNode(pEvent->pStartCond);
       nodesDestroyNode(pEvent->pEndCond);
       nodesDestroyNode(pEvent->pTrueForLimit);
+      break;
+    }
+    case QUERY_NODE_EVENT_START_LEAF: {
+      SEventStartLeafNode* pLeaf = (SEventStartLeafNode*)pNode;
+      nodesDestroyNode(pLeaf->pCond);
+      nodesDestroyNode(pLeaf->pTrueForLimit);
       break;
     }
     case QUERY_NODE_COUNT_WINDOW: {
@@ -2958,7 +2967,6 @@ SNode* nodesListGetNode(SNodeList* pList, int32_t index) {
   }
   return NULL;
 }
-
 
 SListCell* nodesListGetCell(SNodeList* pList, int32_t index) {
   SNode* node;
@@ -4356,5 +4364,3 @@ SColumnNode* createColumnByExpr(const char* pStmtName, SExprNode* pExpr) {
   pCol->node.relatedTo = pExpr->relatedTo;
   return pCol;
 }
-
-

--- a/source/libs/parser/inc/parAst.h
+++ b/source/libs/parser/inc/parAst.h
@@ -227,6 +227,7 @@ SNode*     createLimitNode(SAstCreateContext* pCxt, SNode* pLimit, SNode* pOffse
 SNode*     createOrderByExprNode(SAstCreateContext* pCxt, SNode* pExpr, EOrder order, ENullOrder nullOrder);
 SNode*     createSessionWindowNode(SAstCreateContext* pCxt, SNode* pCol, SNode* pGap);
 SNode*     createStateWindowNode(SAstCreateContext* pCxt, SNode* pExpr, SNodeList* pOptions, SNode* pTrueForLimit);
+SNode*     createEventStartLeafNode(SAstCreateContext* pCxt, SNode* pCond, SNode* pTrueForLimit);
 SNode*     createEventWindowNode(SAstCreateContext* pCxt, SNode* pStartCond, SNode* pEndCond, SNode* pTrueForLimit);
 SNode*     createTrueForCountNode(SAstCreateContext* pCxt, const SToken* pCount);
 SNode*     createTrueForAndNode(SAstCreateContext* pCxt, SNode* pDuration, const SToken* pCount);

--- a/source/libs/parser/inc/sql.y
+++ b/source/libs/parser/inc/sql.y
@@ -1605,17 +1605,19 @@ stream_trigger(A) ::= trigger_type(B) trigger_table_opt(C) stream_partition_by_o
 trigger_type(A) ::= SESSION NK_LP column_reference(B) NK_COMMA interval_sliding_duration_literal(C) NK_RP.                  { A = createSessionWindowNode(pCxt, releaseRawExprNode(pCxt, B), releaseRawExprNode(pCxt, C)); }
 trigger_type(A) ::= STATE_WINDOW NK_LP expr_or_subquery(B) state_window_opt(C) NK_RP true_for_opt(D).                       { A = createStateWindowNode(pCxt, releaseRawExprNode(pCxt, B), C, D); }
 trigger_type(A) ::= interval_opt(B) SLIDING NK_LP sliding_expr(C) NK_RP.                                                    { A = createIntervalWindowNodeExt(pCxt, B, C); }
-trigger_type(A) ::= EVENT_WINDOW NK_LP START WITH search_condition(B) END WITH search_condition(C) NK_RP true_for_opt(D).   { A = createEventWindowNode(pCxt, B, C, D); }
 trigger_type(A) ::= COUNT_WINDOW NK_LP count_window_args(B) NK_RP.                                                          { A = createCountWindowNodeFromArgs(pCxt, B); }
 trigger_type(A) ::= PERIOD NK_LP interval_sliding_duration_literal(B) offset_opt(C) NK_RP.                                  { A = createPeriodWindowNode(pCxt, releaseRawExprNode(pCxt, B), C); }
-trigger_type(A) ::= EVENT_WINDOW NK_LP START WITH NK_LP search_condition_list(B) NK_RP
-                    END WITH search_condition(C) NK_RP true_for_opt(D).                                                     { A = createEventWindowNode(pCxt, createNodeListNode(pCxt, B), C, D); }
-trigger_type(A) ::= EVENT_WINDOW NK_LP START WITH NK_LP search_condition_list(B) NK_RP NK_RP true_for_opt(D).               { A = createEventWindowNode(pCxt, createNodeListNode(pCxt, B), NULL, D); }
+trigger_type(A) ::= EVENT_WINDOW NK_LP START WITH start_event_item(B) END WITH search_condition(C) NK_RP true_for_opt(D).  { A = createEventWindowNode(pCxt, B, C, D); }
+trigger_type(A) ::= EVENT_WINDOW NK_LP START WITH start_event_item(B) NK_RP true_for_opt(D).                                { A = createEventWindowNode(pCxt, B, NULL, D); }
 
-%type search_condition_list                                                                                                 { SNodeList* }
-%destructor search_condition_list                                                                                           { nodesDestroyList($$); }
-search_condition_list(A) ::= search_condition(B) NK_COMMA search_condition(C).                                              { A = addNodeToList(pCxt, createNodeList(pCxt, B), C); }
-search_condition_list(A) ::= search_condition_list(B) NK_COMMA search_condition(C).                                         { A = addNodeToList(pCxt, B, C); }
+%type start_event_item                                                                                                      { SNode* }
+%destructor start_event_item                                                                                                { nodesDestroyNode($$); }
+%type start_event_item_group                                                                                                { SNodeList* }
+%destructor start_event_item_group                                                                                          { nodesDestroyList($$); }
+start_event_item(A) ::= search_condition(B) true_for_opt(C).                                                                { A = createEventStartLeafNode(pCxt, B, C); }
+start_event_item(A) ::= NK_LP start_event_item_group(B) NK_RP.                                                              { A = createNodeListNode(pCxt, B); }
+start_event_item_group(A) ::= start_event_item(B) NK_COMMA start_event_item(C).                                            { A = addNodeToList(pCxt, createNodeList(pCxt, B), C); }
+start_event_item_group(A) ::= start_event_item_group(B) NK_COMMA start_event_item(C).                                      { A = addNodeToList(pCxt, B, C); }
 
 interval_opt(A) ::= .                                                                                                       { A = NULL; }
 interval_opt(A) ::= INTERVAL NK_LP interval_sliding_duration_literal(C) NK_RP.                                              { A = createIntervalWindowNode(pCxt, releaseRawExprNode(pCxt, C), NULL, NULL, NULL); }
@@ -2253,6 +2255,7 @@ pseudo_column(A) ::= TWROWNUM(B).                                               
 pseudo_column(A) ::= TPREV_LOCALTIME(B).                                          { A = createRawExprNode(pCxt, &B, createFunctionNode(pCxt, &B, NULL)); }
 pseudo_column(A) ::= TNEXT_LOCALTIME(B).                                          { A = createRawExprNode(pCxt, &B, createFunctionNode(pCxt, &B, NULL)); }
 pseudo_column(A) ::= TLOCALTIME(B).                                               { A = createRawExprNode(pCxt, &B, createFunctionNode(pCxt, &B, NULL)); }
+pseudo_column(A) ::= EVENT_CONDITION_PATH(B).                                     { A = createRawExprNode(pCxt, &B, createFunctionNode(pCxt, &B, NULL)); }
 pseudo_column(A) ::= TGRPID(B).                                                   { A = createRawExprNode(pCxt, &B, createFunctionNode(pCxt, &B, NULL)); }
 pseudo_column(A) ::= NK_PH NK_INTEGER(B).                                         { A = createRawExprNode(pCxt, &B, createPlaceHolderColumnNode(pCxt, createValueNode(pCxt, TSDB_DATA_TYPE_BIGINT, &B))); }
 pseudo_column(A) ::= NK_PH TBNAME(B).                                             { A = createRawExprNode(pCxt, &B, createPHTbnameFunctionNode(pCxt, &B, NULL)); }

--- a/source/libs/parser/src/parAstCreater.c
+++ b/source/libs/parser/src/parAstCreater.c
@@ -1875,9 +1875,35 @@ _err:
   return NULL;
 }
 
+SNode* createEventStartLeafNode(SAstCreateContext* pCxt, SNode* pCond, SNode* pTrueForLimit) {
+  if (pTrueForLimit == NULL) {
+    return pCond;
+  }
+
+  SEventStartLeafNode* pLeaf = NULL;
+  CHECK_PARSER_STATUS(pCxt);
+  pCxt->errCode = nodesMakeNode(QUERY_NODE_EVENT_START_LEAF, (SNode**)&pLeaf);
+  CHECK_MAKE_NODE(pLeaf);
+
+  pLeaf->pCond = pCond;
+  pLeaf->pTrueForLimit = pTrueForLimit;
+  return (SNode*)pLeaf;
+
+_err:
+  nodesDestroyNode((SNode*)pLeaf);
+  nodesDestroyNode(pCond);
+  nodesDestroyNode(pTrueForLimit);
+  return NULL;
+}
+
 SNode* createEventWindowNode(SAstCreateContext* pCxt, SNode* pStartCond, SNode* pEndCond, SNode* pTrueForLimit) {
   SEventWindowNode* pEvent = NULL;
   CHECK_PARSER_STATUS(pCxt);
+  if (pStartCond != NULL && nodeType(pStartCond) == QUERY_NODE_EVENT_START_LEAF) {
+    pCxt->errCode = generateSyntaxErrMsgExt(&pCxt->msgBuf, TSDB_CODE_PAR_SYNTAX_ERROR,
+                                            "TRUE_FOR after START WITH is only allowed inside a sub-condition list");
+    goto _err;
+  }
   pCxt->errCode = nodesMakeNode(QUERY_NODE_EVENT_WINDOW, (SNode**)&pEvent);
   CHECK_MAKE_NODE(pEvent);
   pEvent->pCol = createPrimaryKeyCol(pCxt, NULL);

--- a/source/libs/parser/src/parTokenizer.c
+++ b/source/libs/parser/src/parTokenizer.c
@@ -419,6 +419,7 @@ static SKeyword keywordTable[] = {
     {"_TPREV_LOCALTIME",     TK_TPREV_LOCALTIME},
     {"_TNEXT_LOCALTIME",     TK_TNEXT_LOCALTIME},
     {"_TLOCALTIME",          TK_TLOCALTIME},
+    {"_EVENT_CONDITION_PATH", TK_EVENT_CONDITION_PATH},
     {"_TGRPID",              TK_TGRPID},
     {"ALIVE",                TK_ALIVE},
     {"VARBINARY",            TK_VARBINARY},

--- a/source/libs/parser/src/parTranslater.c
+++ b/source/libs/parser/src/parTranslater.c
@@ -3971,6 +3971,12 @@ static EDealRes translatePlaceHolderFunc(STranslateContext* pCxt, SNode** pFunc)
       PAR_ERR_JRET(nodesMakeValueNodeFromTimestamp(0, &extraValue));
       break;
     }
+    case FUNCTION_TYPE_EVENT_CONDITION_PATH: {
+      BIT_FLAG_SET_MASK(pCxt->streamInfo.placeHolderBitmap, PLACE_HOLDER_EVENT_CONDITION_PATH);
+      PAR_ERR_JRET(nodesMakeValueNodeFromString("", (SValueNode**)&extraValue));
+      ((SValueNode*)extraValue)->node.resType.bytes = TSDB_MAX_EVENT_CONDITION_PATH_LEN + VARSTR_HEADER_SIZE;
+      break;
+    }
     case FUNCTION_TYPE_TGRPID: {
       BIT_FLAG_SET_MASK(pCxt->streamInfo.placeHolderBitmap, PLACE_HOLDER_GRPID);
       PAR_ERR_JRET(nodesMakeValueNodeFromInt64(0, &extraValue));
@@ -9688,8 +9694,53 @@ _return:
   return code;
 }
 
+static bool eventWindowHasSubEvents(const SEventWindowNode* pEventWindowNode) {
+  return pEventWindowNode != NULL && pEventWindowNode->pStartCond != NULL &&
+         nodeType(pEventWindowNode->pStartCond) == QUERY_NODE_NODE_LIST;
+}
+
+static int32_t countEventStartLeafs(const SNode* pNode) {
+  if (pNode == NULL) {
+    return 0;
+  }
+
+  if (nodeType((SNode*)pNode) != QUERY_NODE_NODE_LIST) {
+    return 1;
+  }
+
+  int32_t count = 0;
+  SNode*  pChild = NULL;
+  FOREACH(pChild, ((SNodeListNode*)pNode)->pNodeList) {
+    count += countEventStartLeafs(pChild);
+  }
+  return count;
+}
+
+static int32_t checkEventStartLeafTrueForLimit(STranslateContext* pCxt, SNode* pNode) {
+  if (pNode == NULL) {
+    return TSDB_CODE_SUCCESS;
+  }
+
+  if (nodeType(pNode) == QUERY_NODE_NODE_LIST) {
+    SNode* pChild = NULL;
+    FOREACH(pChild, ((SNodeListNode*)pNode)->pNodeList) {
+      PAR_ERR_RET(checkEventStartLeafTrueForLimit(pCxt, pChild));
+    }
+    return TSDB_CODE_SUCCESS;
+  }
+
+  if (nodeType(pNode) == QUERY_NODE_EVENT_START_LEAF) {
+    SEventStartLeafNode* pLeaf = (SEventStartLeafNode*)pNode;
+    PAR_ERR_RET(checkTrueForLimit(pCxt, pLeaf->pTrueForLimit));
+    PAR_ERR_RET(checkEventStartLeafTrueForLimit(pCxt, pLeaf->pCond));
+  }
+
+  return TSDB_CODE_SUCCESS;
+}
+
 static int32_t checkEventWindow(STranslateContext* pCxt, SEventWindowNode* pEvent) {
   PAR_ERR_RET(checkTrueForLimit(pCxt, pEvent->pTrueForLimit));
+  PAR_ERR_RET(checkEventStartLeafTrueForLimit(pCxt, pEvent->pStartCond));
   PAR_RET(checkWindowsConditonValid(pEvent));
 }
 
@@ -17619,6 +17670,11 @@ static int32_t createStreamReqBuildTriggerEventWindow(STranslateContext* pCxt, S
                                                       SCMCreateStreamReq* pReq) {
   pReq->triggerType = WINDOW_TYPE_EVENT;
   PAR_ERR_RET(checkEventWindow(pCxt, pTriggerWindow));
+  if (countEventStartLeafs(pTriggerWindow->pStartCond) > TSDB_MAX_EVENT_CONDITION_LEAF_NUM) {
+    PAR_ERR_RET(generateSyntaxErrMsgExt(&pCxt->msgBuf, TSDB_CODE_STREAM_INVALID_TRIGGER,
+                                        "Event window start condition supports at most %d leaf events",
+                                        TSDB_MAX_EVENT_CONDITION_LEAF_NUM));
+  }
   PAR_ERR_RET(nodesNodeToString(pTriggerWindow->pStartCond, false, (char**)&pReq->trigger.event.startCond, NULL));
   if (pTriggerWindow->pEndCond != NULL) {
     PAR_ERR_RET(nodesNodeToString(pTriggerWindow->pEndCond, false, (char**)&pReq->trigger.event.endCond, NULL));
@@ -18297,7 +18353,8 @@ _return:
 }
 
 static int32_t createStreamReqCheckPlaceHolder(STranslateContext* pCxt, SCMCreateStreamReq* pReq,
-                                               int32_t placeHolderBitmap, SNodeList* pTriggerPartition) {
+                                               int32_t placeHolderBitmap, SNodeList* pTriggerPartition,
+                                               SNode* pTriggerWindow) {
   int32_t code = TSDB_CODE_SUCCESS;
   bool    hasIdleResumeEvent = (pReq->eventTypes & (EVENT_IDLE | EVENT_RESUME)) != 0;
   if (BIT_FLAG_TEST_MASK(pReq->placeHolderBitmap, PLACE_HOLDER_CURRENT_TS) ||
@@ -18368,6 +18425,18 @@ static int32_t createStreamReqCheckPlaceHolder(STranslateContext* pCxt, SCMCreat
     }
   }
 
+  if (BIT_FLAG_TEST_MASK(pReq->placeHolderBitmap, PLACE_HOLDER_EVENT_CONDITION_PATH)) {
+    if (pReq->triggerType != WINDOW_TYPE_EVENT) {
+      PAR_ERR_JRET(generateSyntaxErrMsgExt(&pCxt->msgBuf, TSDB_CODE_STREAM_INVALID_PLACE_HOLDER,
+                                           "_event_condition_path can only be used in event window"));
+    }
+    if (pTriggerWindow == NULL || nodeType(pTriggerWindow) != QUERY_NODE_EVENT_WINDOW ||
+        !eventWindowHasSubEvents((SEventWindowNode*)pTriggerWindow)) {
+      PAR_ERR_JRET(generateSyntaxErrMsgExt(&pCxt->msgBuf, TSDB_CODE_STREAM_INVALID_PLACE_HOLDER,
+                                           "_event_condition_path requires event window sub-events"));
+    }
+  }
+
   return code;
 _return:
   parserError("createStreamReqCheckPlaceHolder failed, code:%d", code);
@@ -18394,7 +18463,8 @@ static int32_t createStreamReqBuildTriggerPlan(STranslateContext* pCxt, SCreateS
   PAR_ERR_JRET(createStreamReqBuildTriggerBuildPlan(pCxt, *pTriggerSelect, pReq, pTriggerSlotHash, pTriggerWindow,
                                                     pTriggerPartition));
   PAR_ERR_JRET(createStreamReqBuildTriggerBuildWindowInfo(pCxt, pTriggerWindow, pReq));
-  PAR_ERR_JRET(createStreamReqCheckPlaceHolder(pCxt, pReq, pReq->placeHolderBitmap, pTriggerPartition));
+  PAR_ERR_JRET(createStreamReqCheckPlaceHolder(pCxt, pReq, pReq->placeHolderBitmap, pTriggerPartition,
+                                               pTriggerWindow));
   PAR_ERR_JRET(createStreamReqSetDefaultTag(pCxt, pStmt, pTriggerPartition, pReq));
 
 _return:
@@ -18548,6 +18618,73 @@ static void transferSubQueries(STranslateContext* pCxt, SNode* pNode) {
   }
 }
 
+typedef struct SStreamTagCondPseudoColContext {
+  const char* pInvalidFuncName;
+} SStreamTagCondPseudoColContext;
+
+static EDealRes checkStreamTagCondPseudoCol(SNode* pNode, void* pContext) {
+  if (nodeType(pNode) != QUERY_NODE_FUNCTION) {
+    return DEAL_RES_CONTINUE;
+  }
+
+  SFunctionNode* pFunc = (SFunctionNode*)pNode;
+  if (!fmIsPlaceHolderFunc(pFunc->funcId)) {
+    return DEAL_RES_CONTINUE;
+  }
+
+  if (pFunc->funcType == FUNCTION_TYPE_PLACEHOLDER_COLUMN || pFunc->funcType == FUNCTION_TYPE_PLACEHOLDER_TBNAME) {
+    return DEAL_RES_CONTINUE;
+  }
+
+  ((SStreamTagCondPseudoColContext*)pContext)->pInvalidFuncName = pFunc->functionName;
+  return DEAL_RES_END;
+}
+
+static int32_t checkStreamCalcSelectTagCondPlaceHolder(STranslateContext* pCxt, SSelectStmt* pSelect) {
+  if (pSelect == NULL || pSelect->pWhere == NULL) {
+    return TSDB_CODE_SUCCESS;
+  }
+
+  int32_t code = TSDB_CODE_SUCCESS;
+  SNode*  pCond = NULL;
+  SNode*  pTagCond = NULL;
+
+  PAR_ERR_JRET(nodesCloneNode(pSelect->pWhere, &pCond));
+  PAR_ERR_JRET(filterPartitionCond(&pCond, NULL, NULL, &pTagCond, NULL));
+  if (pTagCond != NULL) {
+    SStreamTagCondPseudoColContext cxt = {0};
+    nodesWalkExpr(pTagCond, checkStreamTagCondPseudoCol, &cxt);
+    if (cxt.pInvalidFuncName != NULL) {
+      PAR_ERR_JRET(generateSyntaxErrMsgExt(&pCxt->msgBuf, TSDB_CODE_STREAM_INVALID_PLACE_HOLDER,
+                                           "%s can not be used in tag filter, only %%%%tbname and %%%%n are allowed",
+                                           cxt.pInvalidFuncName));
+    }
+  }
+
+_return:
+  nodesDestroyNode(pCond);
+  nodesDestroyNode(pTagCond);
+  return code;
+}
+
+static int32_t checkStreamCalcTagCondPlaceHolder(STranslateContext* pCxt, SNode* pQuery) {
+  if (pQuery == NULL) {
+    return TSDB_CODE_SUCCESS;
+  }
+
+  switch (nodeType(pQuery)) {
+    case QUERY_NODE_SELECT_STMT:
+      return checkStreamCalcSelectTagCondPlaceHolder(pCxt, (SSelectStmt*)pQuery);
+    case QUERY_NODE_SET_OPERATOR: {
+      SSetOperator* pSet = (SSetOperator*)pQuery;
+      PAR_ERR_RET(checkStreamCalcTagCondPlaceHolder(pCxt, pSet->pLeft));
+      return checkStreamCalcTagCondPlaceHolder(pCxt, pSet->pRight);
+    }
+    default:
+      return TSDB_CODE_SUCCESS;
+  }
+}
+
 static int32_t translateStreamCalcQuery(STranslateContext* pCxt, SNodeList* pTriggerPartition, SNode* pTriggerTbl,
                                         SNode* pStreamCalcQuery, SNode* pNotifyCond, SNode* pTriggerWindow) {
   int32_t    code = TSDB_CODE_SUCCESS;
@@ -18593,6 +18730,7 @@ static int32_t translateStreamCalcQuery(STranslateContext* pCxt, SNodeList* pTri
   }
 
   PAR_ERR_JRET(translateQuery(pCxt, pStreamCalcQuery));
+  PAR_ERR_JRET(checkStreamCalcTagCondPlaceHolder(pCxt, pStreamCalcQuery));
   if (pCxt->pSubQueries && pCxt->pSubQueries->length > 0) {
     if (TSDB_CODE_SUCCESS == code) {
       code = checkSubQueryStmt(pStreamCalcQuery);

--- a/source/libs/parser/test/parStreamTest.cpp
+++ b/source/libs/parser/test/parStreamTest.cpp
@@ -2496,4 +2496,191 @@ TEST_F(ParserStreamTest, TestIdleTimeoutValidation) {
       TSDB_CODE_STREAM_INVALID_PLACE_HOLDER);
 }
 
+TEST_F(ParserStreamTest, TestNestedEventWindowStartCondition) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc([&](const SQuery* pQuery, ParserStage stage) {
+    ASSERT_EQ(stage, PARSER_STAGE_TRANSLATE);
+    ASSERT_EQ(nodeType(pQuery->pRoot), QUERY_NODE_CREATE_STREAM_STMT);
+
+    SCMCreateStreamReq req = {0};
+    ASSERT_EQ(TSDB_CODE_SUCCESS,
+              tDeserializeSCMCreateStreamReq(pQuery->pCmdMsg->pMsg, pQuery->pCmdMsg->msgLen, &req));
+    ASSERT_EQ(req.triggerType, WINDOW_TYPE_EVENT);
+    ASSERT_NE(req.trigger.event.startCond, nullptr);
+
+    SNode* pStartCond = nullptr;
+    ASSERT_EQ(TSDB_CODE_SUCCESS, nodesStringToNode((char*)req.trigger.event.startCond, &pStartCond));
+    ASSERT_EQ(nodeType(pStartCond), QUERY_NODE_NODE_LIST);
+
+    SNodeList* pRootList = ((SNodeListNode*)pStartCond)->pNodeList;
+    ASSERT_EQ(LIST_LENGTH(pRootList), 2);
+
+    SNode* pFirst = nodesListGetNode(pRootList, 0);
+    SNode* pSecond = nodesListGetNode(pRootList, 1);
+    ASSERT_EQ(nodeType(pFirst), QUERY_NODE_NODE_LIST);
+    ASSERT_NE(nodeType(pSecond), QUERY_NODE_NODE_LIST);
+
+    SNodeList* pNestedList = ((SNodeListNode*)pFirst)->pNodeList;
+    ASSERT_EQ(LIST_LENGTH(pNestedList), 2);
+    ASSERT_NE(nodeType(nodesListGetNode(pNestedList, 0)), QUERY_NODE_NODE_LIST);
+    ASSERT_NE(nodeType(nodesListGetNode(pNestedList, 1)), QUERY_NODE_NODE_LIST);
+
+    nodesDestroyNode(pStartCond);
+    tFreeSCMCreateStreamReq(&req);
+  });
+
+  run("create stream stream_streamdb.s_nested "
+      "event_window(start with ((c1 > 1, c1 > 2), c2 < 3) end with c2 < 1) "
+      "from stream_triggerdb.stream_t1 into stream_outdb.stream_out "
+      "as select _tlocaltime, avg(c1) from stream_querydb.stream_t2");
+
+  run("create stream stream_streamdb.s_nested_bad "
+      "event_window(start with ((c1 > 1,), c2 < 3) end with c2 < 1) "
+      "from stream_triggerdb.stream_t1 into stream_outdb.stream_out "
+      "as select _tlocaltime, avg(c1) from stream_querydb.stream_t2",
+      TSDB_CODE_PAR_SYNTAX_ERROR, PARSER_STAGE_PARSE);
+}
+
+TEST_F(ParserStreamTest, TestEventWindowLeafTrueForWrapper) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc([&](const SQuery* pQuery, ParserStage stage) {
+    ASSERT_EQ(stage, PARSER_STAGE_TRANSLATE);
+    ASSERT_EQ(nodeType(pQuery->pRoot), QUERY_NODE_CREATE_STREAM_STMT);
+
+    SCMCreateStreamReq req = {0};
+    ASSERT_EQ(TSDB_CODE_SUCCESS,
+              tDeserializeSCMCreateStreamReq(pQuery->pCmdMsg->pMsg, pQuery->pCmdMsg->msgLen, &req));
+    ASSERT_EQ(req.triggerType, WINDOW_TYPE_EVENT);
+    ASSERT_NE(req.trigger.event.startCond, nullptr);
+
+    SNode* pStartCond = nullptr;
+    ASSERT_EQ(TSDB_CODE_SUCCESS, nodesStringToNode((char*)req.trigger.event.startCond, &pStartCond));
+    ASSERT_EQ(nodeType(pStartCond), QUERY_NODE_NODE_LIST);
+
+    SNodeList* pRootList = ((SNodeListNode*)pStartCond)->pNodeList;
+    ASSERT_EQ(LIST_LENGTH(pRootList), 2);
+
+    SNode* pFirst = nodesListGetNode(pRootList, 0);
+    SNode* pSecond = nodesListGetNode(pRootList, 1);
+    ASSERT_EQ(nodeType(pFirst), QUERY_NODE_EVENT_START_LEAF);
+    ASSERT_NE(nodeType(pSecond), QUERY_NODE_EVENT_START_LEAF);
+
+    SEventStartLeafNode* pFirstLeaf = (SEventStartLeafNode*)pFirst;
+    ASSERT_NE(pFirstLeaf->pCond, nullptr);
+    ASSERT_NE(pFirstLeaf->pTrueForLimit, nullptr);
+
+    nodesDestroyNode(pStartCond);
+    tFreeSCMCreateStreamReq(&req);
+  });
+
+  run("create stream stream_streamdb.s_leaf_true_for "
+      "event_window(start with (c1 > 1 true_for(2s), c2 < 3) end with c2 < 1) true_for(10s) "
+      "from stream_triggerdb.stream_t1 into stream_outdb.stream_out "
+      "as select _tlocaltime, avg(c1) from stream_querydb.stream_t2");
+
+  run("create stream stream_streamdb.s_leaf_true_for_bad "
+      "event_window(start with ((c1 > 1, c2 < 3) true_for(2s), c2 > 1) end with c2 < 1) "
+      "from stream_triggerdb.stream_t1 into stream_outdb.stream_out "
+      "as select _tlocaltime, avg(c1) from stream_querydb.stream_t2",
+      TSDB_CODE_PAR_SYNTAX_ERROR, PARSER_STAGE_PARSE);
+
+  run("create stream stream_streamdb.s_leaf_true_for_invalid_unit "
+      "event_window(start with (c1 > 1 true_for(1y), c2 < 3) end with c2 < 1) "
+      "from stream_triggerdb.stream_t1 into stream_outdb.stream_out "
+      "as select _tlocaltime, avg(c1) from stream_querydb.stream_t2",
+      TSDB_CODE_PAR_TRUE_FOR_UNIT);
+}
+
+TEST_F(ParserStreamTest, TestEventWindowRootLeafTrueForRejected) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  run("create stream stream_streamdb.s_leaf_true_for_bad_single "
+      "event_window(start with c1 > 1 true_for(2s) end with c2 < 1) "
+      "from stream_triggerdb.stream_t1 into stream_outdb.stream_out "
+      "as select _tlocaltime, avg(c1) from stream_querydb.stream_t2",
+      TSDB_CODE_PAR_SYNTAX_ERROR, PARSER_STAGE_PARSE);
+
+  run("create stream stream_streamdb.s_leaf_true_for_bad_single_no_end "
+      "event_window(start with c1 > 1 true_for(2s)) "
+      "from stream_triggerdb.stream_t1 into stream_outdb.stream_out "
+      "as select _tlocaltime, avg(c1) from stream_querydb.stream_t2",
+      TSDB_CODE_PAR_SYNTAX_ERROR, PARSER_STAGE_PARSE);
+}
+
+TEST_F(ParserStreamTest, TestEventConditionPathPlaceholder) {
+  setAsyncFlag("-1");
+  useDb("root", "stream_streamdb");
+
+  setCheckDdlFunc([&](const SQuery* pQuery, ParserStage stage) {
+    ASSERT_EQ(stage, PARSER_STAGE_TRANSLATE);
+    ASSERT_EQ(nodeType(pQuery->pRoot), QUERY_NODE_CREATE_STREAM_STMT);
+
+    SCMCreateStreamReq req = {0};
+    ASSERT_EQ(TSDB_CODE_SUCCESS,
+              tDeserializeSCMCreateStreamReq(pQuery->pCmdMsg->pMsg, pQuery->pCmdMsg->msgLen, &req));
+    ASSERT_EQ(req.triggerType, WINDOW_TYPE_EVENT);
+    ASSERT_NE(req.calcPlan, nullptr);
+    ASSERT_NE(req.outCols, nullptr);
+    ASSERT_GE(taosArrayGetSize(req.outCols), 2);
+    auto pPathCol = (SFieldWithOptions*)taosArrayGet(req.outCols, 1);
+    ASSERT_NE(pPathCol, nullptr);
+    ASSERT_EQ(pPathCol->bytes, TSDB_MAX_EVENT_CONDITION_PATH_LEN + VARSTR_HEADER_SIZE);
+    ASSERT_NE(std::string((char*)req.calcPlan).find("_event_condition_path"), std::string::npos);
+    tFreeSCMCreateStreamReq(&req);
+  });
+
+  run("create stream stream_streamdb.s_path_ok "
+      "event_window(start with ((c1 > 1, c1 > 2), c2 < 3) end with c2 < 1) "
+      "from stream_triggerdb.stream_t1 into stream_outdb.stream_out "
+      "as select _tlocaltime, _event_condition_path from %%trows");
+
+  run("create stream stream_streamdb.s_path_bad_single "
+      "event_window(start with c1 > 1 end with c2 < 1) "
+      "from stream_triggerdb.stream_t1 into stream_outdb.stream_out "
+      "as select _tlocaltime, _event_condition_path from %%trows",
+      TSDB_CODE_STREAM_INVALID_PLACE_HOLDER);
+
+  run("create stream stream_streamdb.s_path_bad_interval "
+      "interval(1s) sliding(1s) from stream_triggerdb.stream_t1 into stream_outdb.stream_out "
+      "as select _tlocaltime, _event_condition_path from stream_querydb.stream_t2",
+      TSDB_CODE_STREAM_INVALID_PLACE_HOLDER);
+
+  run("create stream stream_streamdb.s_path_bad_tag_cond "
+      "event_window(start with ((c1 > 1, c1 > 2), c2 < 3) end with c2 < 1) "
+      "from stream_triggerdb.st1 partition by tbname, tag2 into stream_outdb.stream_out "
+      "as select _tlocaltime, avg(c1) from %%tbname where tag2 = _event_condition_path",
+      TSDB_CODE_STREAM_INVALID_PLACE_HOLDER);
+}
+
+TEST_F(ParserStreamTest, TestEventWindowLeafCountLimit) {
+  useDb("root", "stream_streamdb");
+
+  auto buildSql = [](int32_t leafCount, const char* streamName) {
+    std::string sql = "create stream stream_streamdb.";
+    sql += streamName;
+    sql += " event_window(start with (";
+    for (int32_t i = 0; i < leafCount; ++i) {
+      if (i > 0) {
+        sql += ", ";
+      }
+      sql += "c1 > ";
+      sql += std::to_string(i + 1);
+    }
+    sql += ") end with c2 < 1) from stream_triggerdb.stream_t1 into stream_outdb.stream_out ";
+    sql += "as select _tlocaltime, avg(c1) from stream_querydb.stream_t2";
+    return sql;
+  };
+
+  std::string maxLeafSql = buildSql(TSDB_MAX_EVENT_CONDITION_LEAF_NUM, "s_path_leaf_64");
+  run(maxLeafSql.c_str());
+
+  std::string overflowLeafSql = buildSql(TSDB_MAX_EVENT_CONDITION_LEAF_NUM + 1, "s_path_leaf_65");
+  run(overflowLeafSql.c_str(), TSDB_CODE_STREAM_INVALID_TRIGGER);
+}
+
 }  // namespace ParserTest

--- a/source/libs/scalar/src/scalar.c
+++ b/source/libs/scalar/src/scalar.c
@@ -801,6 +801,9 @@ int32_t sclInitParam(SNode *node, SScalarParam *param, SScalarCtx *ctx, int32_t 
 }
 
 
+static int32_t sclSetVarDataCString(SColumnInfoData* pResColData, uint32_t rowIndex, const char* pVal);
+static int32_t sclSetVarDataCStringN(SColumnInfoData* pResColData, uint32_t currentRow, uint32_t numOfRows,
+                                     const char* pVal);
 
 int32_t sclSetStreamExtWinParam(int32_t funcId, SNodeList* pParamNodes, SScalarParam* res, SScalarCtx *pCtx) {
   int32_t code = 0;
@@ -857,6 +860,9 @@ int32_t sclSetStreamExtWinParam(int32_t funcId, SNodeList* pParamNodes, SScalarP
       case FUNCTION_TYPE_TGRPID:
         ((int64_t*)res->columnData->pData)[i] = pInfo->groupId;
         break;
+      case FUNCTION_TYPE_EVENT_CONDITION_PATH:
+        SCL_ERR_RET(sclSetVarDataCString(res->columnData, i, pParams->conditionPath));
+        break;
       case FUNCTION_TYPE_TIDLESTART:
         ((int64_t*)res->columnData->pData)[i] = pParams->idlestart;
         break;
@@ -869,6 +875,50 @@ int32_t sclSetStreamExtWinParam(int32_t funcId, SNodeList* pParamNodes, SScalarP
     }
   }
   
+  return code;
+}
+
+static int32_t sclSetVarDataCString(SColumnInfoData* pResColData, uint32_t rowIndex, const char* pVal) {
+  if (pVal == NULL) {
+    return colDataSetVal(pResColData, rowIndex, NULL, true);
+  }
+
+  size_t maxLen =
+      pResColData->info.bytes > VARSTR_HEADER_SIZE ? (size_t)pResColData->info.bytes - VARSTR_HEADER_SIZE : 0;
+  size_t len = strnlen(pVal, maxLen);
+  char*  buf = taosMemoryCalloc(len + VARSTR_HEADER_SIZE, 1);
+  if (buf == NULL) {
+    return terrno;
+  }
+  *(VarDataLenT*)buf = (VarDataLenT)len;
+  if (len > 0) {
+    (void)memcpy(varDataVal(buf), pVal, len);
+  }
+  int32_t code = colDataSetVal(pResColData, rowIndex, buf, false);
+  taosMemoryFreeClear(buf);
+  return code;
+}
+
+static int32_t sclSetVarDataCStringN(SColumnInfoData* pResColData, uint32_t currentRow, uint32_t numOfRows,
+                                     const char* pVal) {
+  if (pVal == NULL) {
+    colDataSetNItemsNull(pResColData, currentRow, numOfRows);
+    return TSDB_CODE_SUCCESS;
+  }
+
+  size_t maxLen =
+      pResColData->info.bytes > VARSTR_HEADER_SIZE ? (size_t)pResColData->info.bytes - VARSTR_HEADER_SIZE : 0;
+  size_t len = strnlen(pVal, maxLen);
+  char*  buf = taosMemoryCalloc(len + VARSTR_HEADER_SIZE, 1);
+  if (buf == NULL) {
+    return terrno;
+  }
+  *(VarDataLenT*)buf = (VarDataLenT)len;
+  if (len > 0) {
+    (void)memcpy(varDataVal(buf), pVal, len);
+  }
+  int32_t code = colDataSetNItems(pResColData, currentRow, buf, numOfRows, 1, false);
+  taosMemoryFreeClear(buf);
   return code;
 }
 
@@ -949,6 +999,8 @@ int32_t scalarAssignPlaceHolderRes(SColumnInfoData* pResColData, int64_t offset,
     case FUNCTION_TYPE_TGRPID:
       pData = &pInfo->groupId;
       break;
+    case FUNCTION_TYPE_EVENT_CONDITION_PATH:
+      return sclSetVarDataCStringN(pResColData, offset, rows, pParams->conditionPath);
     case FUNCTION_TYPE_PLACEHOLDER_TBNAME: {
       // find tbname from stream part col vals
       char buf[TSDB_TABLE_FNAME_LEN + VARSTR_HEADER_SIZE] = {0};

--- a/test/cases/18-StreamProcessing/03-TriggerMode/test_event_new.py
+++ b/test/cases/18-StreamProcessing/03-TriggerMode/test_event_new.py
@@ -44,6 +44,10 @@ class TestStreamEventTrigger:
         streams.append(self.Basic8())
         streams.append(self.Basic9())
         streams.append(self.Basic10())
+        streams.append(self.Basic11())
+        streams.append(self.Basic12())
+        streams.append(self.Basic13())
+        streams.append(self.Basic14())
 
         tdStream.checkAll(streams)
 
@@ -2998,4 +3002,216 @@ class TestStreamEventTrigger:
                 and tdSql.compareData(9, 0, "2025-01-01 00:00:35")
                 and tdSql.compareData(9, 1, "2025-01-01 00:00:38")
                 and tdSql.compareData(9, 2, 4)
+            )
+
+    class Basic11(StreamCheckItem):
+        def __init__(self):
+            self.db = "sdb11"
+            self.stbName = "stb"
+
+        def create(self):
+            tdSql.execute(f"create database {self.db} vgroups 1 buffer 8")
+            tdSql.execute(f"use {self.db}")
+            tdSql.execute(
+                f"create table if not exists {self.stbName} (cts timestamp, c1 int, c2 int) tags (tint int)"
+            )
+            tdSql.execute("create table ct1 using stb tags(1)")
+            tdSql.execute(
+                "create stream s_path "
+                "event_window(start with ((c1 >= 90, c1 >= 60), c2 < 60) end with c2 < 50) "
+                "from ct1 into res_path(startts, path primary key, cnt) "
+                "as select _twstart, _event_condition_path, count(*) from ct1 where _c0 >= _twstart and _c0 <= _twend;"
+            )
+
+        def insert1(self):
+            tdSql.executes([
+                "insert into ct1 values ('2025-01-01 00:00:00', 95, 95);",
+                "insert into ct1 values ('2025-01-01 00:00:01', 65, 65);",
+                "insert into ct1 values ('2025-01-01 00:00:02', 40, 40);",
+                "insert into ct1 values ('2025-01-01 00:00:03', 70, 70);",
+                "insert into ct1 values ('2025-01-01 00:00:04', 45, 45);",
+            ])
+
+        def check1(self):
+            tdSql.checkResultsByFunc(
+                sql=f"select startts, path, cnt from {self.db}.res_path order by startts, path",
+                func=lambda: tdSql.getRows() == 9
+                and tdSql.compareData(0, 0, "2025-01-01 00:00:00")
+                and tdSql.compareData(0, 1, "")
+                and tdSql.compareData(0, 2, 3)
+                and tdSql.compareData(1, 0, "2025-01-01 00:00:00")
+                and tdSql.compareData(1, 1, "0")
+                and tdSql.compareData(1, 2, 2)
+                and tdSql.compareData(2, 0, "2025-01-01 00:00:00")
+                and tdSql.compareData(2, 1, "0.0")
+                and tdSql.compareData(2, 2, 1)
+                and tdSql.compareData(3, 0, "2025-01-01 00:00:01")
+                and tdSql.compareData(3, 1, "0.1")
+                and tdSql.compareData(3, 2, 1)
+                and tdSql.compareData(4, 0, "2025-01-01 00:00:02")
+                and tdSql.compareData(4, 1, "1")
+                and tdSql.compareData(4, 2, 1)
+                and tdSql.compareData(5, 0, "2025-01-01 00:00:03")
+                and tdSql.compareData(5, 1, "")
+                and tdSql.compareData(5, 2, 2)
+                and tdSql.compareData(6, 0, "2025-01-01 00:00:03")
+                and tdSql.compareData(6, 1, "0")
+                and tdSql.compareData(6, 2, 1)
+                and tdSql.compareData(7, 0, "2025-01-01 00:00:03")
+                and tdSql.compareData(7, 1, "0.1")
+                and tdSql.compareData(7, 2, 1)
+                and tdSql.compareData(8, 0, "2025-01-01 00:00:04")
+                and tdSql.compareData(8, 1, "1")
+                and tdSql.compareData(8, 2, 1),
+            )
+
+    class Basic12(StreamCheckItem):
+        def __init__(self):
+            self.db = "sdb12"
+            self.stbName = "stb"
+
+        def create(self):
+            tdSql.execute(f"create database {self.db} vgroups 1 buffer 8")
+            tdSql.execute(f"use {self.db}")
+            tdSql.execute(
+                f"create table if not exists {self.stbName} (cts timestamp, c1 int, c2 int) tags (tint int)"
+            )
+            tdSql.execute("create table ct1 using stb tags(1)")
+            tdSql.executes([
+                "insert into ct1 values ('2025-01-01 00:00:00', 95, 95);",
+                "insert into ct1 values ('2025-01-01 00:00:01', 95, 95);",
+                "insert into ct1 values ('2025-01-01 00:00:02', 40, 40);",
+                "insert into ct1 values ('2025-01-01 00:00:03', 70, 70);",
+                "insert into ct1 values ('2025-01-01 00:00:04', 70, 70);",
+                "insert into ct1 values ('2025-01-01 00:00:05', 40, 40);",
+            ])
+            tdSql.execute(
+                "create stream s_path_local_true_for "
+                "event_window(start with ((c1 >= 90 true_for(1s), c1 >= 60), c2 < 0) end with c1 < 50) "
+                "true_for(5s) from ct1 stream_options(fill_history) into res_path(startts, path primary key, cnt) "
+                "as select _twstart, _event_condition_path, count(*) from ct1 where _c0 >= _twstart and _c0 <= _twend;"
+            )
+
+        def insert1(self):
+            return
+
+        def check1(self):
+            tdSql.checkResultsByFunc(
+                sql=f"select startts, path, cnt from {self.db}.res_path order by startts, path",
+                func=lambda: tdSql.getRows() == 6
+                and tdSql.compareData(0, 0, "2025-01-01 00:00:00")
+                and tdSql.compareData(0, 1, "")
+                and tdSql.compareData(0, 2, 2)
+                and tdSql.compareData(1, 0, "2025-01-01 00:00:00")
+                and tdSql.compareData(1, 1, "0")
+                and tdSql.compareData(1, 2, 2)
+                and tdSql.compareData(2, 0, "2025-01-01 00:00:00")
+                and tdSql.compareData(2, 1, "0.0")
+                and tdSql.compareData(2, 2, 2)
+                and tdSql.compareData(3, 0, "2025-01-01 00:00:03")
+                and tdSql.compareData(3, 1, "")
+                and tdSql.compareData(3, 2, 2)
+                and tdSql.compareData(4, 0, "2025-01-01 00:00:03")
+                and tdSql.compareData(4, 1, "0")
+                and tdSql.compareData(4, 2, 2)
+                and tdSql.compareData(5, 0, "2025-01-01 00:00:03")
+                and tdSql.compareData(5, 1, "0.1")
+                and tdSql.compareData(5, 2, 2)
+            )
+
+    class Basic13(StreamCheckItem):
+        def __init__(self):
+            self.db = "sdb13"
+
+        def create(self):
+            tdSql.execute(f"create database {self.db} vgroups 1 buffer 8")
+            tdSql.execute(f"use {self.db}")
+            tdSql.execute("create table ct1 (cts timestamp, c1 int, c2 int)")
+            tdSql.execute(
+                "create stream s_realtime_leaf_true_for "
+                "event_window(start with ((c1 >= 90 true_for(1s), c1 >= 60), c2 > 100) end with c2 < 0) "
+                "true_for(5s) from ct1 into res_path(startts, path primary key, cnt) "
+                "as select _twstart, _event_condition_path, count(*) from ct1 where _c0 >= _twstart and _c0 <= _twend;"
+            )
+
+        def insert1(self):
+            tdSql.executes([
+                "insert into ct1 values ('2025-01-01 00:00:00', 95, 0);",
+                "insert into ct1 values ('2025-01-01 00:00:01', 95, 0);",
+                "insert into ct1 values ('2025-01-01 00:00:02', 10, -1);",
+                "insert into ct1 values ('2025-01-01 00:00:03', 70, 0);",
+                "insert into ct1 values ('2025-01-01 00:00:04', 70, 0);",
+                "insert into ct1 values ('2025-01-01 00:00:05', 10, -1);",
+            ])
+
+        def check1(self):
+            tdSql.checkResultsByFunc(
+                sql=f"select startts, path, cnt from {self.db}.res_path order by startts, path",
+                func=lambda: tdSql.getRows() == 6
+                and tdSql.compareData(0, 0, "2025-01-01 00:00:00")
+                and tdSql.compareData(0, 1, "")
+                and tdSql.compareData(0, 2, 2)
+                and tdSql.compareData(1, 0, "2025-01-01 00:00:00")
+                and tdSql.compareData(1, 1, "0")
+                and tdSql.compareData(1, 2, 2)
+                and tdSql.compareData(2, 0, "2025-01-01 00:00:00")
+                and tdSql.compareData(2, 1, "0.0")
+                and tdSql.compareData(2, 2, 2)
+                and tdSql.compareData(3, 0, "2025-01-01 00:00:03")
+                and tdSql.compareData(3, 1, "")
+                and tdSql.compareData(3, 2, 2)
+                and tdSql.compareData(4, 0, "2025-01-01 00:00:03")
+                and tdSql.compareData(4, 1, "0")
+                and tdSql.compareData(4, 2, 2)
+                and tdSql.compareData(5, 0, "2025-01-01 00:00:03")
+                and tdSql.compareData(5, 1, "0.1")
+                and tdSql.compareData(5, 2, 2)
+            )
+
+    class Basic14(StreamCheckItem):
+        def __init__(self):
+            self.db = "sdb14"
+
+        def create(self):
+            tdSql.execute(f"create database {self.db} vgroups 1 buffer 8")
+            tdSql.execute(f"use {self.db}")
+            tdSql.execute("create table ct1 (cts timestamp, c1 int, c2 int)")
+            tdSql.execute(
+                "create stream s_realtime_pending_priority "
+                "event_window(start with ((c1 >= 90 true_for(5s), c1 >= 60 true_for(1s)), c2 > 100) end with c2 < 0) "
+                "from ct1 into res_path(startts, path primary key, cnt) "
+                "as select _twstart, _event_condition_path, count(*) from ct1 where _c0 >= _twstart and _c0 <= _twend;"
+            )
+
+        def insert1(self):
+            tdSql.executes([
+                "insert into ct1 values ('2025-01-01 00:00:00', 70, 0);",
+                "insert into ct1 values ('2025-01-01 00:00:01', 70, 0);",
+                "insert into ct1 values ('2025-01-01 00:00:02', 70, 0);",
+                "insert into ct1 values ('2025-01-01 00:00:03', 95, 0);",
+                "insert into ct1 values ('2025-01-01 00:00:04', 95, 0);",
+                "insert into ct1 values ('2025-01-01 00:00:05', 70, 0);",
+                "insert into ct1 values ('2025-01-01 00:00:06', 70, 0);",
+                "insert into ct1 values ('2025-01-01 00:00:07', 70, -1);",
+            ])
+
+        def check1(self):
+            tdSql.checkResultsByFunc(
+                sql=f"select startts, path, cnt from {self.db}.res_path order by startts, path",
+                func=lambda: tdSql.getRows() == 5
+                and tdSql.compareData(0, 0, "2025-01-01 00:00:00")
+                and tdSql.compareData(0, 1, "")
+                and tdSql.compareData(0, 2, 8)
+                and tdSql.compareData(1, 0, "2025-01-01 00:00:00")
+                and tdSql.compareData(1, 1, "0")
+                and tdSql.compareData(1, 2, 8)
+                and tdSql.compareData(2, 0, "2025-01-01 00:00:00")
+                and tdSql.compareData(2, 1, "0.1")
+                and tdSql.compareData(2, 2, 3)
+                and tdSql.compareData(3, 0, "2025-01-01 00:00:03")
+                and tdSql.compareData(3, 1, "0.0")
+                and tdSql.compareData(3, 2, 2)
+                and tdSql.compareData(4, 0, "2025-01-01 00:00:05")
+                and tdSql.compareData(4, 1, "0.1")
+                and tdSql.compareData(4, 2, 3)
             )


### PR DESCRIPTION
# Description

- Extend EVENT_WINDOW START WITH to accept nested condition trees.
- Keep the outer true_for syntax backward compatible for existing
  stream definitions.
- Allow leaf conditions to override true_for, while parent groups still
  inherit the outer setting.
- Add _event_condition_path support through parser, node serialization,
  planning, and runtime.
- Fix nested start-condition match reads in history and realtime
  execution so leaf true_for checks use the correct value width.
- Refresh parser tests, stream system tests, and SQL documentation for
  nested starts, condition-path placeholders, and leaf-specific
  true_for behavior.

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [x] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
