### PR TITLE
fix(stream): link event subwindow notifications to parent

### DIFF
--- a/source/libs/new-stream/inc/streamInt.h
+++ b/source/libs/new-stream/inc/streamInt.h
@@ -120,7 +120,8 @@ int32_t streamBuildStateNotifyContent(ESTriggerEventType eventType, SColumnInfo*
                                       const char* pToState, char** ppContent);
 int32_t streamBuildIdleNotifyContent(ESTriggerEventType eventType, int64_t idleDurationMs, char** ppContent);
 int32_t streamBuildEventNotifyContent(const SSDataBlock* pInputBlock, const SNodeList* pCondCols, int32_t rowIdx,
-                                      int32_t condIdx, int32_t winIdx, char** ppContent);
+                                      int32_t condIdx, int32_t winIdx, int64_t groupId, int64_t parentWindowStart,
+                                      char** ppContent);
 int32_t streamBuildBlockResultNotifyContent(const SStreamRunnerTask* pTask, const SSDataBlock* pBlock, char** ppContent,
                                             const SArray* pFields, const int32_t startRow, const int32_t endRow);
 int32_t streamSendNotifyContent(SStreamTask* pTask, const char* streamName, const char* tableName, int32_t triggerType,

--- a/source/libs/new-stream/inc/streamInt.h
+++ b/source/libs/new-stream/inc/streamInt.h
@@ -120,8 +120,8 @@ int32_t streamBuildStateNotifyContent(ESTriggerEventType eventType, SColumnInfo*
                                       const char* pToState, char** ppContent);
 int32_t streamBuildIdleNotifyContent(ESTriggerEventType eventType, int64_t idleDurationMs, char** ppContent);
 int32_t streamBuildEventNotifyContent(const SSDataBlock* pInputBlock, const SNodeList* pCondCols, int32_t rowIdx,
-                                      int32_t condIdx, int32_t winIdx, int64_t groupId, int64_t parentWindowStart,
-                                      char** ppContent);
+                                      int32_t condIdx, int32_t winIdx, int64_t groupId, int64_t windowStart,
+                                      int64_t parentWindowStart, char** ppContent);
 int32_t streamBuildBlockResultNotifyContent(const SStreamRunnerTask* pTask, const SSDataBlock* pBlock, char** ppContent,
                                             const SArray* pFields, const int32_t startRow, const int32_t endRow);
 int32_t streamSendNotifyContent(SStreamTask* pTask, const char* streamName, const char* tableName, int32_t triggerType,

--- a/source/libs/new-stream/inc/streamTriggerTask.h
+++ b/source/libs/new-stream/inc/streamTriggerTask.h
@@ -57,6 +57,7 @@ typedef struct SSTriggerWindow {
 typedef struct SSTriggerNotifyWindow {
   STimeWindow range;
   int64_t     wrownum;
+  bool        forceWinOpen;
   char       *pWinOpenNotify;
   char       *pWinCloseNotify;
 } SSTriggerNotifyWindow;
@@ -84,6 +85,7 @@ typedef struct SSTriggerRealtimeGroup {
     };
     struct {  // for event window trigger with sub-event
       SSTriggerNotifyWindow parentWindow;
+      char                 *pFirstSubWinOpenNotify;
       int32_t               numSubWindows;
       int32_t               conditionIdx;
     };

--- a/source/libs/new-stream/src/streamTriggerTask.c
+++ b/source/libs/new-stream/src/streamTriggerTask.c
@@ -9039,6 +9039,7 @@ static void stRealtimeGroupDestroy(void *ptr) {
     taosMemoryFreeClear(pGroup->stateVal.pData);
   } else if (pGroup->pContext->pTask->triggerType == STREAM_TRIGGER_EVENT) {
     stRealtimeContextDestroyWindow(&pGroup->parentWindow);
+    taosMemoryFreeClear(pGroup->pFirstSubWinOpenNotify);
   }
   taosObjListClear(&pGroup->windows);
   taosObjListClearEx(&pGroup->pPendingParWinCalcParams, tDestroySSTriggerCalcParam);
@@ -9859,6 +9860,11 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
               code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, -1,
                                                    &pGroup->parentWindow.pWinOpenNotify);
               QUERY_CHECK_CODE(code, lino, _end);
+              // A single sub-event is still a regular event window. Keep the first sub-window open pending until a
+              // second sub-window proves that parent/child window events are needed.
+              code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, 0,
+                                                   &pGroup->pFirstSubWinOpenNotify);
+              QUERY_CHECK_CODE(code, lino, _end);
             }
           }
           pGroup->numSubWindows++;
@@ -9870,7 +9876,7 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
         newWin.range.ekey = INT64_MAX;
         pWin = taosArrayPush(pContext->pWindows, &newWin);
         QUERY_CHECK_NULL(pWin, code, lino, _end, terrno);
-        if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN) {
+        if ((pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN) && (!checkSubEvent || pGroup->numSubWindows > 1)) {
           int32_t winIdx = -1;
           if (checkSubEvent && pGroup->numSubWindows > 1) {
             winIdx = pGroup->numSubWindows - 1;
@@ -9887,6 +9893,11 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
 
       if (checkSubEvent && ps[i] && ps[i] != pGroup->conditionIdx) {
         // close previous sub-window since start condition index is changed
+        pWin->forceWinOpen = true;
+        if (pGroup->pFirstSubWinOpenNotify != NULL && pWin->pWinOpenNotify == NULL) {
+          pWin->pWinOpenNotify = pGroup->pFirstSubWinOpenNotify;
+          pGroup->pFirstSubWinOpenNotify = NULL;
+        }
         pWin->range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
         if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
           int32_t winIdx = pGroup->numSubWindows - 1;
@@ -9906,6 +9917,7 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
         pGroup->parentWindow.range.ekey = (pTsData[i] | TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
       }
       if (pe[i] || (checkSubEvent && !ps[i])) {
+        SSTriggerNotifyWindow *pClosedWin = pWin;
         pWin->range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
         if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
           int32_t winIdx = -1;
@@ -9927,9 +9939,14 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
             void *px = taosArrayPush(pContext->pParentWindows, &pGroup->parentWindow);
             QUERY_CHECK_NULL(px, code, lino, _end, terrno);
           } else {
+            if (pClosedWin->pWinOpenNotify == NULL) {
+              pClosedWin->pWinOpenNotify = pGroup->parentWindow.pWinOpenNotify;
+              pGroup->parentWindow.pWinOpenNotify = NULL;
+            }
             stRealtimeContextDestroyWindow(&pGroup->parentWindow);
           }
           pGroup->parentWindow = (SSTriggerNotifyWindow){0};
+          taosMemoryFreeClear(pGroup->pFirstSubWinOpenNotify);
           pGroup->numSubWindows = 0;
           pGroup->conditionIdx = 0;
         }
@@ -10243,11 +10260,14 @@ static int32_t stRealtimeGroupGenCalcParams(SSTriggerRealtimeGroup *pGroup, int3
     bool meetTrueFor = (pTrueForInfo == NULL) || (pTrueForInfo->duration == 0 && pTrueForInfo->count == 0) ||
                        isTrueForSatisfied(pTrueForInfo, pWin->range.skey,
                                           pWin->range.ekey & (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK), pWin->wrownum);
-    bool ignore = (i < nInitWins) || !meetTrueFor;
-    if ((calcOpen || notifyOpen) && !ignore && !pContext->recovering) {
-      SSTriggerCalcParam    param = {.triggerTime = now,
-                                     .notifyType = (notifyOpen ? STRIGGER_EVENT_WINDOW_OPEN : STRIGGER_EVENT_WINDOW_NONE),
-                                     .extraNotifyContent = pWin->pWinOpenNotify};
+    bool forceWinOpen = pWin->forceWinOpen;
+    bool ignore = ((i < nInitWins) && !forceWinOpen) || !meetTrueFor;
+    bool deferFirstSubWinOpen = (pTask->triggerType == STREAM_TRIGGER_EVENT && pGroup->numSubWindows == 1 &&
+                                 pWin->range.skey == pGroup->parentWindow.range.skey);
+    if ((calcOpen || notifyOpen) && !ignore && !deferFirstSubWinOpen && !pContext->recovering) {
+      SSTriggerCalcParam param = {.triggerTime = now,
+                                  .notifyType = (notifyOpen ? STRIGGER_EVENT_WINDOW_OPEN : STRIGGER_EVENT_WINDOW_NONE),
+                                  .extraNotifyContent = pWin->pWinOpenNotify};
       SSTriggerNotifyWindow win = *pWin;
       if (pTask->triggerType != STREAM_TRIGGER_SLIDING) {
         win.range.ekey = win.range.skey;
@@ -10263,6 +10283,9 @@ static int32_t stRealtimeGroupGenCalcParams(SSTriggerRealtimeGroup *pGroup, int3
         QUERY_CHECK_NULL(px, code, lino, _end, terrno);
         pWin->pWinOpenNotify = NULL;
       }
+    }
+    if (forceWinOpen) {
+      pWin->forceWinOpen = false;
     }
 
     ignore = (i >= numClosed) || !meetTrueFor || (pTask->ignoreNoDataTrigger && pWin->wrownum == 0);

--- a/source/libs/new-stream/src/streamTriggerTask.c
+++ b/source/libs/new-stream/src/streamTriggerTask.c
@@ -9857,14 +9857,13 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
           if (pGroup->numSubWindows == 0) {
             pGroup->parentWindow = (SSTriggerNotifyWindow){.range.skey = pTsData[i], .range.ekey = INT64_MAX};
             if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN) {
-              code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, -1,
-                                                   pGroup->gid, 0,
-                                                   &pGroup->parentWindow.pWinOpenNotify);
+              code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, -1, pGroup->gid,
+                                                   pTsData[i], 0, &pGroup->parentWindow.pWinOpenNotify);
               QUERY_CHECK_CODE(code, lino, _end);
               // A single sub-event is still a regular event window. Keep the first sub-window open pending until a
               // second sub-window proves that parent/child window events are needed.
-              code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, 0,
-                                                   pGroup->gid, pGroup->parentWindow.range.skey,
+              code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, 0, pGroup->gid,
+                                                   pTsData[i], pGroup->parentWindow.range.skey,
                                                    &pGroup->pFirstSubWinOpenNotify);
               QUERY_CHECK_CODE(code, lino, _end);
             }
@@ -9883,9 +9882,9 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
           if (checkSubEvent && pGroup->numSubWindows > 1) {
             winIdx = pGroup->numSubWindows - 1;
           }
-          code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, winIdx,
-                                               pGroup->gid, pGroup->parentWindow.range.skey,
-                                               &pWin->pWinOpenNotify);
+          int64_t parentWindowStart = (checkSubEvent && winIdx >= 0) ? pGroup->parentWindow.range.skey : 0;
+          code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, winIdx, pGroup->gid,
+                                               pTsData[i], parentWindowStart, &pWin->pWinOpenNotify);
           QUERY_CHECK_CODE(code, lino, _end);
         }
       }
@@ -9904,8 +9903,9 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
         pWin->range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
         if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
           int32_t winIdx = pGroup->numSubWindows - 1;
-          code = streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, winIdx, pGroup->gid,
-                                               pGroup->parentWindow.range.skey, &pWin->pWinCloseNotify);
+          code =
+              streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, winIdx, pGroup->gid,
+                                            pWin->range.skey, pGroup->parentWindow.range.skey, &pWin->pWinCloseNotify);
           QUERY_CHECK_CODE(code, lino, _end);
         }
         pWin = NULL;
@@ -9928,16 +9928,17 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
           if (checkSubEvent && pGroup->numSubWindows > 1) {
             winIdx = pGroup->numSubWindows - 1;
           }
+          int64_t parentWindowStart = (checkSubEvent && winIdx >= 0) ? pGroup->parentWindow.range.skey : 0;
           code = streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, winIdx, pGroup->gid,
-                                               pGroup->parentWindow.range.skey, &pWin->pWinCloseNotify);
+                                               pWin->range.skey, parentWindowStart, &pWin->pWinCloseNotify);
           QUERY_CHECK_CODE(code, lino, _end);
         }
         pWin = NULL;
         if (checkSubEvent) {
           pGroup->parentWindow.range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
           if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
-            code = streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, -1,
-                                                 pGroup->gid, 0,
+            code = streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, -1, pGroup->gid,
+                                                 pGroup->parentWindow.range.skey, 0,
                                                  &pGroup->parentWindow.pWinCloseNotify);
             QUERY_CHECK_CODE(code, lino, _end);
           }
@@ -10958,7 +10959,7 @@ _end:
 }
 
 static int32_t stHistoryGroupOpenWindow(SSTriggerHistoryGroup *pGroup, int64_t ts, char **ppExtraNotifyContent,
-                                        bool saveWindow, bool hasStartData, bool isParent) {
+                                        bool saveWindow, bool hasStartData, bool isParent, bool deferOpen) {
   int32_t                  code = TSDB_CODE_SUCCESS;
   int32_t                  lino = 0;
   SSTriggerHistoryContext *pContext = pGroup->pContext;
@@ -11045,7 +11046,8 @@ static int32_t stHistoryGroupOpenWindow(SSTriggerHistoryGroup *pGroup, int64_t t
 
   if (saveWindow) {
     // only save window when close window
-  } else if (pTrueForInfo && (pTrueForInfo->duration > 0 || pTrueForInfo->count > 0)) {
+  } else if ((needCalc || needNotify) &&
+             (deferOpen || (pTrueForInfo && (pTrueForInfo->duration > 0 || pTrueForInfo->count > 0)))) {
     pGroup->pendingWinOpen = true;
     pGroup->pendingWinParam = param;
     param.extraNotifyContent = NULL;
@@ -11644,11 +11646,11 @@ static int32_t stHistoryGroupDoSlidingCheck(SSTriggerHistoryGroup *pGroup) {
         bool meetBound = (r < endIdx) || (r > 0 && pTsData[r - 1] == ts);
         if (ts == nextStart && meetBound) {
           if (IS_TRIGGER_GROUP_NONE_WINDOW(pGroup)) {
-            code = stHistoryGroupOpenWindow(pGroup, pTsData[r], NULL, true, true, false);
+            code = stHistoryGroupOpenWindow(pGroup, pTsData[r], NULL, true, true, false, false);
             QUERY_CHECK_CODE(code, lino, _end);
             r++;
           } else {
-            code = stHistoryGroupOpenWindow(pGroup, ts, NULL, true, r > 0 && pTsData[r - 1] == nextStart, false);
+            code = stHistoryGroupOpenWindow(pGroup, ts, NULL, true, r > 0 && pTsData[r - 1] == nextStart, false, false);
             QUERY_CHECK_CODE(code, lino, _end);
           }
         }
@@ -11663,7 +11665,7 @@ static int32_t stHistoryGroupDoSlidingCheck(SSTriggerHistoryGroup *pGroup) {
       void *px = tSimpleHashGet(pContext->pFirstTsMap, &pGroup->gid, sizeof(int64_t));
       QUERY_CHECK_NULL(px, code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
       int64_t ts = *(int64_t *)px;
-      code = stHistoryGroupOpenWindow(pGroup, ts, NULL, false, false, false);
+      code = stHistoryGroupOpenWindow(pGroup, ts, NULL, false, false, false, false);
       QUERY_CHECK_CODE(code, lino, _end);
     }
     allTableProcessed = true;
@@ -11687,7 +11689,7 @@ static int32_t stHistoryGroupDoSlidingCheck(SSTriggerHistoryGroup *pGroup) {
         break;
       }
       if (ts == nextStart) {
-        code = stHistoryGroupOpenWindow(pGroup, ts, NULL, false, false, false);
+        code = stHistoryGroupOpenWindow(pGroup, ts, NULL, false, false, false, false);
         QUERY_CHECK_CODE(code, lino, _end);
       }
       if (ts == curEnd) {
@@ -11768,7 +11770,7 @@ static int32_t stHistoryGroupDoSessionCheck(SSTriggerHistoryGroup *pGroup) {
         code = stHistoryGroupCloseWindow(pGroup, NULL, true, false);
         QUERY_CHECK_CODE(code, lino, _end);
       }
-      code = stHistoryGroupOpenWindow(pGroup, nextTs, NULL, true, true, false);
+      code = stHistoryGroupOpenWindow(pGroup, nextTs, NULL, true, true, false, false);
       QUERY_CHECK_CODE(code, lino, _end);
     } else {
       // read all data of the current table
@@ -11795,7 +11797,7 @@ static int32_t stHistoryGroupDoSessionCheck(SSTriggerHistoryGroup *pGroup) {
             code = stHistoryGroupCloseWindow(pGroup, NULL, true, false);
             QUERY_CHECK_CODE(code, lino, _end);
           }
-          code = stHistoryGroupOpenWindow(pGroup, ts, NULL, true, true, false);
+          code = stHistoryGroupOpenWindow(pGroup, ts, NULL, true, true, false, false);
           QUERY_CHECK_CODE(code, lino, _end);
         }
       }
@@ -11862,7 +11864,7 @@ static int32_t stHistoryGroupDoCountCheck(SSTriggerHistoryGroup *pGroup) {
         continue;
       }
       if (nrowsCurWin + skipped == nrowsNextWstart) {
-        code = stHistoryGroupOpenWindow(pGroup, lastTs, NULL, false, true, false);
+        code = stHistoryGroupOpenWindow(pGroup, lastTs, NULL, false, true, false, false);
         QUERY_CHECK_CODE(code, lino, _end);
       }
       QUERY_CHECK_CONDITION(IS_TRIGGER_GROUP_OPEN_WINDOW(pGroup), code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
@@ -11896,7 +11898,7 @@ static int32_t stHistoryGroupDoCountCheck(SSTriggerHistoryGroup *pGroup) {
           TRINGBUF_HEAD(&pGroup->winBuf)->wrownum += skipped;
         }
         if (nrowsCurWin + skipped == nrowsNextWstart) {
-          code = stHistoryGroupOpenWindow(pGroup, lastTs, NULL, false, true, false);
+          code = stHistoryGroupOpenWindow(pGroup, lastTs, NULL, false, true, false, false);
           QUERY_CHECK_CODE(code, lino, _end);
         }
         QUERY_CHECK_CONDITION(IS_TRIGGER_GROUP_OPEN_WINDOW(pGroup), code, lino, _end, TSDB_CODE_INTERNAL_ERROR);
@@ -12036,12 +12038,12 @@ static int32_t stHistoryGroupDoStateCheck(SSTriggerHistoryGroup *pGroup) {
             QUERY_CHECK_CODE(code, lino, _end);
           }
           if (pTask->stateExtend == STATE_WIN_EXTEND_OPTION_FORWARD) {
-            code = stHistoryGroupOpenWindow(pGroup, startTs, &pExtraNotifyContent, false, true, false);
+            code = stHistoryGroupOpenWindow(pGroup, startTs, &pExtraNotifyContent, false, true, false, false);
             QUERY_CHECK_CODE(code, lino, _end);
             TRINGBUF_HEAD(&pGroup->winBuf)->wrownum += pGroup->numPendingNull;
             TRINGBUF_HEAD(&pGroup->winBuf)->range.ekey = pTsData[r];
           } else {
-            code = stHistoryGroupOpenWindow(pGroup, pTsData[r], &pExtraNotifyContent, false, true, false);
+            code = stHistoryGroupOpenWindow(pGroup, pTsData[r], &pExtraNotifyContent, false, true, false, false);
             QUERY_CHECK_CODE(code, lino, _end);
           }
           memcpy(pStateData, newVal, bytes);
@@ -12102,11 +12104,12 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
       if (IS_TRIGGER_GROUP_OPEN_WINDOW(pGroup)) {
         if (checkSubEvent && ps[r] && ps[r] != pGroup->conditionIdx) {
           // close previous sub-window since start condition index is changed
+          int32_t winIdx = pGroup->numSubWindows - 1;
           if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE)) {
-            int32_t winIdx = pGroup->numSubWindows - 1;
-            code =
-                streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, winIdx, pGroup->gid,
-                                              pGroup->parentWindow.range.skey, &pExtraNotifyContent);
+            SSTriggerWindow *pCurWin = TRINGBUF_HEAD(&pGroup->winBuf);
+            code = streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, winIdx, pGroup->gid,
+                                                 pCurWin->range.skey, pGroup->parentWindow.range.skey,
+                                                 &pExtraNotifyContent);
             QUERY_CHECK_CODE(code, lino, _end);
           }
           code = stHistoryGroupCloseWindow(pGroup, &pExtraNotifyContent, false, false);
@@ -12126,9 +12129,8 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
           if (pGroup->numSubWindows == 0) {
             pGroup->parentWindow = (SSTriggerNotifyWindow){.range.skey = pTsData[r], .range.ekey = pTsData[r]};
             if (pTask->notifyHistory && pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN) {
-              code = streamBuildEventNotifyContent(pDataBlock, pTask->histStartCondCols, r, ps[r] - 1, -1,
-                                                   pGroup->gid, 0,
-                                                   &pGroup->parentWindow.pWinOpenNotify);
+              code = streamBuildEventNotifyContent(pDataBlock, pTask->histStartCondCols, r, ps[r] - 1, -1, pGroup->gid,
+                                                   pTsData[r], 0, &pGroup->parentWindow.pWinOpenNotify);
               QUERY_CHECK_CODE(code, lino, _end);
             }
           }
@@ -12136,41 +12138,54 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
           pGroup->numSubWindows++;
           pGroup->conditionIdx = ps[r];
         }
-        if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN)) {
-          int32_t winIdx = -1;
-          if (checkSubEvent && pGroup->numSubWindows > 1) {
+        int32_t winIdx = -1;
+        bool    deferOpen = false;
+        if (checkSubEvent) {
+          if (pGroup->numSubWindows == 1) {
+            winIdx = 0;
+            deferOpen = true;
+          } else {
             winIdx = pGroup->numSubWindows - 1;
           }
-          code = streamBuildEventNotifyContent(pDataBlock, pTask->histStartCondCols, r, ps[r] - 1, winIdx,
-                                               pGroup->gid, pGroup->parentWindow.range.skey,
-                                               &pExtraNotifyContent);
+        }
+        if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN)) {
+          int64_t parentWindowStart = (checkSubEvent && winIdx >= 0) ? pGroup->parentWindow.range.skey : 0;
+          code = streamBuildEventNotifyContent(pDataBlock, pTask->histStartCondCols, r, ps[r] - 1, winIdx, pGroup->gid,
+                                               pTsData[r], parentWindowStart, &pExtraNotifyContent);
           QUERY_CHECK_CODE(code, lino, _end);
         }
-        code = stHistoryGroupOpenWindow(pGroup, pTsData[r], &pExtraNotifyContent, false, true, false);
+        code = stHistoryGroupOpenWindow(pGroup, pTsData[r], &pExtraNotifyContent, false, true, false, deferOpen);
         QUERY_CHECK_CODE(code, lino, _end);
       }
       if (IS_TRIGGER_GROUP_OPEN_WINDOW(pGroup) && (pe[r] || (checkSubEvent && !ps[r]))) {
+        int32_t winIdx = -1;
+        if (checkSubEvent && pGroup->numSubWindows > 1) {
+          winIdx = pGroup->numSubWindows - 1;
+        }
+        if (checkSubEvent && pGroup->numSubWindows == 1 && pGroup->pendingWinOpen) {
+          taosMemoryFreeClear(pGroup->pendingWinParam.extraNotifyContent);
+          pGroup->pendingWinParam.extraNotifyContent = pGroup->parentWindow.pWinOpenNotify;
+          pGroup->parentWindow.pWinOpenNotify = NULL;
+        }
         if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE)) {
-          int32_t winIdx = -1;
-          if (checkSubEvent && pGroup->numSubWindows > 1) {
-            winIdx = pGroup->numSubWindows - 1;
-          }
+          int64_t          parentWindowStart = (checkSubEvent && winIdx >= 0) ? pGroup->parentWindow.range.skey : 0;
+          SSTriggerWindow *pCurWin = TRINGBUF_HEAD(&pGroup->winBuf);
           code = streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, winIdx, pGroup->gid,
-                                               pGroup->parentWindow.range.skey, &pExtraNotifyContent);
+                                               pCurWin->range.skey, parentWindowStart, &pExtraNotifyContent);
           QUERY_CHECK_CODE(code, lino, _end);
         }
         code = stHistoryGroupCloseWindow(pGroup, &pExtraNotifyContent, false, false);
         QUERY_CHECK_CODE(code, lino, _end);
         if (checkSubEvent) {
           if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE)) {
-            code = streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, -1,
-                                                 pGroup->gid, 0,
+            code = streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, -1, pGroup->gid,
+                                                 pGroup->parentWindow.range.skey, 0,
                                                  &pGroup->parentWindow.pWinCloseNotify);
             QUERY_CHECK_CODE(code, lino, _end);
           }
           if (pGroup->numSubWindows > 1) {
             code = stHistoryGroupOpenWindow(pGroup, pGroup->parentWindow.range.skey,
-                                            &pGroup->parentWindow.pWinOpenNotify, false, true, true);
+                                            &pGroup->parentWindow.pWinOpenNotify, false, true, true, false);
             QUERY_CHECK_CODE(code, lino, _end);
             TRINGBUF_HEAD(&pGroup->winBuf)->range = pGroup->parentWindow.range;
             TRINGBUF_HEAD(&pGroup->winBuf)->wrownum = pGroup->parentWindow.wrownum;

--- a/source/libs/new-stream/src/streamTriggerTask.c
+++ b/source/libs/new-stream/src/streamTriggerTask.c
@@ -9858,11 +9858,13 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
             pGroup->parentWindow = (SSTriggerNotifyWindow){.range.skey = pTsData[i], .range.ekey = INT64_MAX};
             if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN) {
               code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, -1,
+                                                   pGroup->gid, 0,
                                                    &pGroup->parentWindow.pWinOpenNotify);
               QUERY_CHECK_CODE(code, lino, _end);
               // A single sub-event is still a regular event window. Keep the first sub-window open pending until a
               // second sub-window proves that parent/child window events are needed.
               code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, 0,
+                                                   pGroup->gid, pGroup->parentWindow.range.skey,
                                                    &pGroup->pFirstSubWinOpenNotify);
               QUERY_CHECK_CODE(code, lino, _end);
             }
@@ -9882,6 +9884,7 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
             winIdx = pGroup->numSubWindows - 1;
           }
           code = streamBuildEventNotifyContent(pDataBlock, pTask->pStartCondCols, i, ps[i] - 1, winIdx,
+                                               pGroup->gid, pGroup->parentWindow.range.skey,
                                                &pWin->pWinOpenNotify);
           QUERY_CHECK_CODE(code, lino, _end);
         }
@@ -9901,7 +9904,8 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
         pWin->range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
         if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
           int32_t winIdx = pGroup->numSubWindows - 1;
-          code = streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, winIdx, &pWin->pWinCloseNotify);
+          code = streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, winIdx, pGroup->gid,
+                                               pGroup->parentWindow.range.skey, &pWin->pWinCloseNotify);
           QUERY_CHECK_CODE(code, lino, _end);
         }
         pWin = NULL;
@@ -9924,7 +9928,8 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
           if (checkSubEvent && pGroup->numSubWindows > 1) {
             winIdx = pGroup->numSubWindows - 1;
           }
-          code = streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, winIdx, &pWin->pWinCloseNotify);
+          code = streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, winIdx, pGroup->gid,
+                                               pGroup->parentWindow.range.skey, &pWin->pWinCloseNotify);
           QUERY_CHECK_CODE(code, lino, _end);
         }
         pWin = NULL;
@@ -9932,6 +9937,7 @@ static int32_t stRealtimeGroupDoEventCheck(SSTriggerRealtimeGroup *pGroup) {
           pGroup->parentWindow.range.ekey &= (~TRIGGER_GROUP_UNCLOSED_WINDOW_MASK);
           if (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE) {
             code = streamBuildEventNotifyContent(pDataBlock, pTask->pEndCondCols, i, 0, -1,
+                                                 pGroup->gid, 0,
                                                  &pGroup->parentWindow.pWinCloseNotify);
             QUERY_CHECK_CODE(code, lino, _end);
           }
@@ -12099,7 +12105,8 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
           if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE)) {
             int32_t winIdx = pGroup->numSubWindows - 1;
             code =
-                streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, winIdx, &pExtraNotifyContent);
+                streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, winIdx, pGroup->gid,
+                                              pGroup->parentWindow.range.skey, &pExtraNotifyContent);
             QUERY_CHECK_CODE(code, lino, _end);
           }
           code = stHistoryGroupCloseWindow(pGroup, &pExtraNotifyContent, false, false);
@@ -12120,6 +12127,7 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
             pGroup->parentWindow = (SSTriggerNotifyWindow){.range.skey = pTsData[r], .range.ekey = pTsData[r]};
             if (pTask->notifyHistory && pTask->notifyEventType & STRIGGER_EVENT_WINDOW_OPEN) {
               code = streamBuildEventNotifyContent(pDataBlock, pTask->histStartCondCols, r, ps[r] - 1, -1,
+                                                   pGroup->gid, 0,
                                                    &pGroup->parentWindow.pWinOpenNotify);
               QUERY_CHECK_CODE(code, lino, _end);
             }
@@ -12134,6 +12142,7 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
             winIdx = pGroup->numSubWindows - 1;
           }
           code = streamBuildEventNotifyContent(pDataBlock, pTask->histStartCondCols, r, ps[r] - 1, winIdx,
+                                               pGroup->gid, pGroup->parentWindow.range.skey,
                                                &pExtraNotifyContent);
           QUERY_CHECK_CODE(code, lino, _end);
         }
@@ -12146,7 +12155,8 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
           if (checkSubEvent && pGroup->numSubWindows > 1) {
             winIdx = pGroup->numSubWindows - 1;
           }
-          code = streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, winIdx, &pExtraNotifyContent);
+          code = streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, winIdx, pGroup->gid,
+                                               pGroup->parentWindow.range.skey, &pExtraNotifyContent);
           QUERY_CHECK_CODE(code, lino, _end);
         }
         code = stHistoryGroupCloseWindow(pGroup, &pExtraNotifyContent, false, false);
@@ -12154,6 +12164,7 @@ static int32_t stHistoryGroupDoEventCheck(SSTriggerHistoryGroup *pGroup) {
         if (checkSubEvent) {
           if (pTask->notifyHistory && (pTask->notifyEventType & STRIGGER_EVENT_WINDOW_CLOSE)) {
             code = streamBuildEventNotifyContent(pDataBlock, pTask->histEndCondCols, r, 0, -1,
+                                                 pGroup->gid, 0,
                                                  &pGroup->parentWindow.pWinCloseNotify);
             QUERY_CHECK_CODE(code, lino, _end);
           }

--- a/source/libs/new-stream/src/streamUtil.c
+++ b/source/libs/new-stream/src/streamUtil.c
@@ -490,8 +490,8 @@ _end:
 static void streamBuildNotifyTriggerId(int64_t groupId, int64_t windowStart, int32_t winIdx, char* triggerId);
 
 int32_t streamBuildEventNotifyContent(const SSDataBlock* pInputBlock, const SNodeList* pCondCols, int32_t rowIdx,
-                                      int32_t condIdx, int32_t winIdx, int64_t groupId, int64_t parentWindowStart,
-                                      char** ppContent) {
+                                      int32_t condIdx, int32_t winIdx, int64_t groupId, int64_t windowStart,
+                                      int64_t parentWindowStart, char** ppContent) {
   int32_t      code = TSDB_CODE_SUCCESS;
   int32_t      lino = 0;
   const SNode* pNode = NULL;
@@ -519,6 +519,9 @@ int32_t streamBuildEventNotifyContent(const SSDataBlock* pInputBlock, const SNod
 
   obj = cJSON_CreateObject();
   QUERY_CHECK_NULL(obj, code, lino, _end, TSDB_CODE_OUT_OF_MEMORY);
+  char triggerId[32];
+  streamBuildNotifyTriggerId(groupId, windowStart, winIdx, triggerId);
+  JSON_CHECK_ADD_ITEM(obj, "triggerId", cJSON_CreateString(triggerId));
   JSON_CHECK_ADD_ITEM(obj, "triggerCondition", cond);
   JSON_CHECK_ADD_ITEM(obj, "windowIndex", cJSON_CreateNumber(winIdx));
   if (winIdx >= 0) {
@@ -705,26 +708,6 @@ static void streamBuildNotifyTriggerId(int64_t groupId, int64_t windowStart, int
   (void)u64toaFastLut(hash, triggerId);
 }
 
-static int32_t streamGetNotifyWindowIndex(const char* content) {
-  int32_t winIdx = -1;
-  cJSON*  obj = NULL;
-
-  if (content == NULL) {
-    return winIdx;
-  }
-
-  obj = cJSON_Parse(content);
-  if (obj != NULL) {
-    cJSON* item = cJSON_GetObjectItem(obj, "windowIndex");
-    if (cJSON_IsNumber(item)) {
-      winIdx = item->valueint;
-    }
-    cJSON_Delete(obj);
-  }
-
-  return winIdx;
-}
-
 static int32_t streamAppendNotifyContent(int32_t triggerType, int64_t groupId, const SSTriggerCalcParam* pParam,
                                          SStringBuilder* pBuilder, const char* tableName) {
   int32_t code = TSDB_CODE_SUCCESS;
@@ -746,8 +729,13 @@ static int32_t streamAppendNotifyContent(int32_t triggerType, int64_t groupId, c
   }
 
   char triggerId[32];
-  int32_t winIdx = (triggerType == STREAM_TRIGGER_EVENT) ? streamGetNotifyWindowIndex(pParam->extraNotifyContent) : -1;
-  streamBuildNotifyTriggerId(groupId, pParam->wstart, winIdx, triggerId);
+  bool hasEventTriggerId =
+      triggerType == STREAM_TRIGGER_EVENT &&
+      (pParam->notifyType == STRIGGER_EVENT_WINDOW_OPEN || pParam->notifyType == STRIGGER_EVENT_WINDOW_CLOSE) &&
+      pParam->extraNotifyContent != NULL;
+  if (!hasEventTriggerId) {
+    streamBuildNotifyTriggerId(groupId, pParam->wstart, -1, triggerId);
+  }
 
   const char* triggerTypeStr = NULL;
   switch (triggerType) {
@@ -778,7 +766,9 @@ static int32_t streamAppendNotifyContent(int32_t triggerType, int64_t groupId, c
   QUERY_CHECK_NULL(obj, code, lino, _end, TSDB_CODE_OUT_OF_MEMORY);
   JSON_CHECK_ADD_ITEM(obj, "eventType", cJSON_CreateStringReference(eventType));
   JSON_CHECK_ADD_ITEM(obj, "eventTime", cJSON_CreateNumber(taosGetTimestampMs()));
-  JSON_CHECK_ADD_ITEM(obj, "triggerId", cJSON_CreateStringReference(triggerId));
+  if (!hasEventTriggerId) {
+    JSON_CHECK_ADD_ITEM(obj, "triggerId", cJSON_CreateStringReference(triggerId));
+  }
   JSON_CHECK_ADD_ITEM(obj, "triggerType", cJSON_CreateStringReference(triggerTypeStr));
 
   if (tableName != NULL) {

--- a/source/libs/new-stream/src/streamUtil.c
+++ b/source/libs/new-stream/src/streamUtil.c
@@ -487,8 +487,11 @@ _end:
   return code;
 }
 
+static void streamBuildNotifyTriggerId(int64_t groupId, int64_t windowStart, int32_t winIdx, char* triggerId);
+
 int32_t streamBuildEventNotifyContent(const SSDataBlock* pInputBlock, const SNodeList* pCondCols, int32_t rowIdx,
-                                      int32_t condIdx, int32_t winIdx, char** ppContent) {
+                                      int32_t condIdx, int32_t winIdx, int64_t groupId, int64_t parentWindowStart,
+                                      char** ppContent) {
   int32_t      code = TSDB_CODE_SUCCESS;
   int32_t      lino = 0;
   const SNode* pNode = NULL;
@@ -518,6 +521,11 @@ int32_t streamBuildEventNotifyContent(const SSDataBlock* pInputBlock, const SNod
   QUERY_CHECK_NULL(obj, code, lino, _end, TSDB_CODE_OUT_OF_MEMORY);
   JSON_CHECK_ADD_ITEM(obj, "triggerCondition", cond);
   JSON_CHECK_ADD_ITEM(obj, "windowIndex", cJSON_CreateNumber(winIdx));
+  if (winIdx >= 0) {
+    char parentTriggerId[32];
+    streamBuildNotifyTriggerId(groupId, parentWindowStart, -1, parentTriggerId);
+    JSON_CHECK_ADD_ITEM(obj, "parentTriggerId", cJSON_CreateString(parentTriggerId));
+  }
   cond = NULL;
 
   *ppContent = cJSON_PrintUnformatted(obj);
@@ -685,6 +693,38 @@ _end:
   return code;
 }
 
+static void streamBuildNotifyTriggerId(int64_t groupId, int64_t windowStart, int32_t winIdx, char* triggerId) {
+  uint64_t hash = 0;
+  if (winIdx >= 0) {
+    uint64_t ar[] = {(uint64_t)groupId, (uint64_t)windowStart, (uint64_t)(uint32_t)winIdx};
+    hash = MurmurHash3_64((const char*)ar, sizeof(ar));
+  } else {
+    uint64_t ar[] = {(uint64_t)groupId, (uint64_t)windowStart};
+    hash = MurmurHash3_64((const char*)ar, sizeof(ar));
+  }
+  (void)u64toaFastLut(hash, triggerId);
+}
+
+static int32_t streamGetNotifyWindowIndex(const char* content) {
+  int32_t winIdx = -1;
+  cJSON*  obj = NULL;
+
+  if (content == NULL) {
+    return winIdx;
+  }
+
+  obj = cJSON_Parse(content);
+  if (obj != NULL) {
+    cJSON* item = cJSON_GetObjectItem(obj, "windowIndex");
+    if (cJSON_IsNumber(item)) {
+      winIdx = item->valueint;
+    }
+    cJSON_Delete(obj);
+  }
+
+  return winIdx;
+}
+
 static int32_t streamAppendNotifyContent(int32_t triggerType, int64_t groupId, const SSTriggerCalcParam* pParam,
                                          SStringBuilder* pBuilder, const char* tableName) {
   int32_t code = TSDB_CODE_SUCCESS;
@@ -705,10 +745,9 @@ static int32_t streamAppendNotifyContent(int32_t triggerType, int64_t groupId, c
     eventType = "ON_TIME";
   }
 
-  uint64_t ar[] = {groupId, pParam->wstart};
-  uint64_t hash = MurmurHash3_64((const char*)ar, sizeof(ar));
-  char     triggerId[32];
-  (void)u64toaFastLut(hash, triggerId);
+  char triggerId[32];
+  int32_t winIdx = (triggerType == STREAM_TRIGGER_EVENT) ? streamGetNotifyWindowIndex(pParam->extraNotifyContent) : -1;
+  streamBuildNotifyTriggerId(groupId, pParam->wstart, winIdx, triggerId);
 
   const char* triggerTypeStr = NULL;
   switch (triggerType) {

--- a/test/cases/18-StreamProcessing/05-Notify/test_notify.py
+++ b/test/cases/18-StreamProcessing/05-Notify/test_notify.py
@@ -33,7 +33,7 @@ def _wait_notify_events(path, min_events, retries=30):
             events = _load_notify_events(path)
             if len(events) >= min_events:
                 return events
-        except FileNotFoundError:
+        except (FileNotFoundError, ValueError):
             pass
         time.sleep(1)
     return _load_notify_events(path)
@@ -2274,12 +2274,13 @@ class TestStreamNotifyTrigger:
 
             tdSql.execute("create table t_single (ts timestamp, c0 int, c1 int)")
             tdSql.execute("create table t_order (ts timestamp, c0 int, c1 int)")
+            tdSql.execute("create table t_history (ts timestamp, c0 int, c1 int)")
 
             tdSql.execute(
                 "create stream s_single "
                 "event_window(start with (c0 = 1, c1 = 1)) "
                 "from t_single "
-                "stream_options(event_type(window_open|window_close)) "
+                "stream_options(DELETE_RECALC|event_type(window_open|window_close)) "
                 "notify('ws://localhost:12345/basic18_single') "
                 "on(window_open|window_close) notify_options(notify_history) "
                 "into r_single as "
@@ -2297,11 +2298,23 @@ class TestStreamNotifyTrigger:
                 "select _twstart, _twend, count(*) from t_order "
                 "where ts >= _twstart and ts <= _twend"
             )
+            tdSql.execute(
+                "create stream s_history "
+                "event_window(start with (c0 = 1, c1 = 1)) "
+                "from t_history "
+                "stream_options(event_type(window_open|window_close)) "
+                "notify('ws://localhost:12345/basic18_history') "
+                "on(window_open|window_close) notify_options(notify_history) "
+                "into r_history as "
+                "select _twstart, _twend, count(*) from t_history "
+                "where ts >= _twstart and ts <= _twend"
+            )
 
         def insert1(self):
             tdSql.execute("insert into t_single values ('2025-01-01 00:00:00.000', 1, 0)")
             tdSql.execute("insert into t_single values ('2025-01-01 00:00:01.000', 0, 0)")
             tdSql.execute("insert into t_order values ('2025-01-01 00:00:00.000', 1, 0)")
+            tdSql.execute("insert into t_history values ('2025-01-01 00:00:00.000', 1, 0)")
 
         def check1(self):
             single_log = os.path.join(NOTIFY_RESULT_DIR, "basic18_single.log")
@@ -2320,8 +2333,16 @@ class TestStreamNotifyTrigger:
             events = _load_notify_events(order_log)
             assert [_subevent_key(e) for e in events] == [("WINDOW_OPEN", -1, 0, 1735660800000)], events
 
+            history_log = os.path.join(NOTIFY_RESULT_DIR, "basic18_history.log")
+            _wait_notify_events(history_log, 1)
+            time.sleep(1)
+            events = _load_notify_events(history_log)
+            assert [_subevent_key(e) for e in events] == [("WINDOW_OPEN", -1, 0, 1735660800000)], events
+
         def insert2(self):
             tdSql.execute("insert into t_order values ('2025-01-01 00:00:01.000', 0, 1)")
+            tdSql.execute("insert into t_history values ('2025-01-01 00:00:01.000', 0, 1)")
+            tdSql.execute("delete from t_history where ts = '2025-01-01 00:00:01.000'")
 
         def check2(self):
             order_log = os.path.join(NOTIFY_RESULT_DIR, "basic18_order.log")
@@ -2341,6 +2362,19 @@ class TestStreamNotifyTrigger:
             parent_trigger_id = parent_open.get("triggerId")
             assert parent_trigger_id, events
             assert first_child_open.get("triggerId") != parent_trigger_id, events
+            assert first_child_close.get("triggerId") != parent_trigger_id, events
+            assert first_child_close.get("triggerId") == first_child_open.get("triggerId"), events
             assert first_child_open.get("parentTriggerId") == parent_trigger_id, events
             assert first_child_close.get("parentTriggerId") == parent_trigger_id, events
             assert second_child_open.get("parentTriggerId") == parent_trigger_id, events
+
+            history_log = os.path.join(NOTIFY_RESULT_DIR, "basic18_history.log")
+            events = _wait_notify_events(history_log, 4)
+            actual = [_subevent_key(e) for e in events[:4]]
+            assert actual == expected, events
+            parent_open = events[0]
+            parent_trigger_id = parent_open.get("triggerId")
+            assert parent_trigger_id, events
+            for child_event in events[1:4]:
+                assert child_event.get("triggerId") != parent_trigger_id, events
+                assert child_event.get("parentTriggerId") == parent_trigger_id, events

--- a/test/cases/18-StreamProcessing/05-Notify/test_notify.py
+++ b/test/cases/18-StreamProcessing/05-Notify/test_notify.py
@@ -1,3 +1,4 @@
+import json
 import os
 import time
 import inspect
@@ -11,6 +12,42 @@ from notify_check import expect_event, expect_event_count, expect_rows
 caller_file = os.path.realpath(__file__)
 caller_dir = os.path.dirname(caller_file)
 NOTIFY_RESULT_DIR = os.path.join(caller_dir, "notify_result_tmp")
+
+
+def _load_notify_events(path):
+    events = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            for stream in obj.get("streams", []):
+                events.extend(stream.get("events", []))
+    return events
+
+
+def _wait_notify_events(path, min_events, retries=30):
+    for _ in range(retries):
+        try:
+            events = _load_notify_events(path)
+            if len(events) >= min_events:
+                return events
+        except FileNotFoundError:
+            pass
+        time.sleep(1)
+    return _load_notify_events(path)
+
+
+def _subevent_key(event):
+    cond = event.get("triggerCondition", {})
+    return (
+        event.get("eventType"),
+        event.get("windowIndex"),
+        cond.get("conditionIndex"),
+        event.get("windowStart"),
+    )
+
 
 class TestStreamNotifyTrigger:
 
@@ -84,6 +121,7 @@ class TestStreamNotifyTrigger:
         streams.append(self.Basic15())
         streams.append(self.Basic16())
         streams.append(self.Basic17())
+        streams.append(self.Basic18())
 
         tdStream.checkAll(streams)      
         stop_notify_server_background()
@@ -2224,3 +2262,75 @@ class TestStreamNotifyTrigger:
                 eventType="WINDOW_CLOSE",
                 result_pred=lambda data: len(data) > 0,
             )
+
+    class Basic18(StreamCheckItem):
+        def __init__(self):
+            self.db = "sdb18"
+
+        def create(self):
+            tdLog.info("=============== create database")
+            tdSql.execute(f"create database {self.db} vgroups 1")
+            tdSql.execute(f"use {self.db}")
+
+            tdSql.execute("create table t_single (ts timestamp, c0 int, c1 int)")
+            tdSql.execute("create table t_order (ts timestamp, c0 int, c1 int)")
+
+            tdSql.execute(
+                "create stream s_single "
+                "event_window(start with (c0 = 1, c1 = 1)) "
+                "from t_single "
+                "stream_options(event_type(window_open|window_close)) "
+                "notify('ws://localhost:12345/basic18_single') "
+                "on(window_open|window_close) notify_options(notify_history) "
+                "into r_single as "
+                "select _twstart, _twend, count(*) from t_single "
+                "where ts >= _twstart and ts <= _twend"
+            )
+            tdSql.execute(
+                "create stream s_order "
+                "event_window(start with (c0 = 1, c1 = 1)) "
+                "from t_order "
+                "stream_options(event_type(window_open|window_close)) "
+                "notify('ws://localhost:12345/basic18_order') "
+                "on(window_open|window_close) notify_options(notify_history) "
+                "into r_order as "
+                "select _twstart, _twend, count(*) from t_order "
+                "where ts >= _twstart and ts <= _twend"
+            )
+
+        def insert1(self):
+            tdSql.execute("insert into t_single values ('2025-01-01 00:00:00.000', 1, 0)")
+            tdSql.execute("insert into t_single values ('2025-01-01 00:00:01.000', 0, 0)")
+            tdSql.execute("insert into t_order values ('2025-01-01 00:00:00.000', 1, 0)")
+
+        def check1(self):
+            single_log = os.path.join(NOTIFY_RESULT_DIR, "basic18_single.log")
+            events = _wait_notify_events(single_log, 2)
+            actual = [_subevent_key(e) for e in events[:2]]
+            expected = [
+                ("WINDOW_OPEN", -1, 0, 1735660800000),
+                ("WINDOW_CLOSE", -1, 0, 1735660800000),
+            ]
+            assert actual == expected, events
+            assert len(events) == 2, events
+
+            order_log = os.path.join(NOTIFY_RESULT_DIR, "basic18_order.log")
+            _wait_notify_events(order_log, 1)
+            time.sleep(1)
+            events = _load_notify_events(order_log)
+            assert [_subevent_key(e) for e in events] == [("WINDOW_OPEN", -1, 0, 1735660800000)], events
+
+        def insert2(self):
+            tdSql.execute("insert into t_order values ('2025-01-01 00:00:01.000', 0, 1)")
+
+        def check2(self):
+            order_log = os.path.join(NOTIFY_RESULT_DIR, "basic18_order.log")
+            events = _wait_notify_events(order_log, 4)
+            actual = [_subevent_key(e) for e in events[:4]]
+            expected = [
+                ("WINDOW_OPEN", -1, 0, 1735660800000),
+                ("WINDOW_OPEN", 0, 0, 1735660800000),
+                ("WINDOW_CLOSE", 0, 0, 1735660800000),
+                ("WINDOW_OPEN", 1, 1, 1735660801000),
+            ]
+            assert actual == expected, events

--- a/test/cases/18-StreamProcessing/05-Notify/test_notify.py
+++ b/test/cases/18-StreamProcessing/05-Notify/test_notify.py
@@ -2334,3 +2334,13 @@ class TestStreamNotifyTrigger:
                 ("WINDOW_OPEN", 1, 1, 1735660801000),
             ]
             assert actual == expected, events
+            parent_open = events[0]
+            first_child_open = events[1]
+            first_child_close = events[2]
+            second_child_open = events[3]
+            parent_trigger_id = parent_open.get("triggerId")
+            assert parent_trigger_id, events
+            assert first_child_open.get("triggerId") != parent_trigger_id, events
+            assert first_child_open.get("parentTriggerId") == parent_trigger_id, events
+            assert first_child_close.get("parentTriggerId") == parent_trigger_id, events
+            assert second_child_open.get("parentTriggerId") == parent_trigger_id, events


### PR DESCRIPTION
# Description

- Avoid triggerId collisions between parent and first child event windows.
- Add parentTriggerId to subwindow notification content without expanding window state.
- Cover parent-child triggerId behavior in notify tests.

# Issue(s)

- Fix: https://project.feishu.cn/taosdata_td/feature/detail/6987137653

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
