### PR TITLE
docs(opcua): rename "GE Cimplicity" to "GE CSS OPC UA Server" #6984382630

### DIFF
--- a/docs/en/06-advanced/05-data-in/05-opcua/01-client-certificate.md
+++ b/docs/en/06-advanced/05-data-in/05-opcua/01-client-certificate.md
@@ -3,7 +3,7 @@ title: "Generate the taosX OPC UA Client Certificate"
 sidebar_label: "Client Certificate"
 ---
 
-When the OPC UA server's **Security Mode** is set to `Sign` or `SignAndEncrypt`, taosX must establish the secure channel with a client certificate and private key. This page documents the standard procedure for generating that certificate on Windows and on Linux/macOS. **All scenarios that require certificate-encrypted access (Ignition, GE Cimplicity, …) follow the same procedure once.**
+When the OPC UA server's **Security Mode** is set to `Sign` or `SignAndEncrypt`, taosX must establish the secure channel with a client certificate and private key. This page documents the standard procedure for generating that certificate on Windows and on Linux/macOS. **All scenarios that require certificate-encrypted access (Ignition, GE CSS OPC UA Server, …) follow the same procedure once.**
 
 ## 1. Certificate Requirements
 
@@ -88,7 +88,7 @@ echo Verify certificate:
 "%OPENSSL%" x509 -in "%CERT_FILE%" -noout -subject -ext subjectAltName
 
 echo.
-echo SHA1 fingerprint (used by some servers, e.g. GE Cimplicity, to map the certificate to a user):
+echo SHA1 fingerprint (used by some servers, e.g. GE CSS OPC UA Server, to map the certificate to a user):
 "%OPENSSL%" x509 -in "%CERT_FILE%" -noout -fingerprint -sha1
 
 pause
@@ -174,7 +174,7 @@ X509v3 Subject Alternative Name:
     URI:urn:taosx-opc:client
 ```
 
-Some servers (for example GE Cimplicity) bind the client certificate to a user by its SHA1 fingerprint. Capture it with:
+Some servers (for example GE CSS OPC UA Server) bind the client certificate to a user by its SHA1 fingerprint. Capture it with:
 
 ```bash
 openssl x509 -in client_cert.pem -noout -fingerprint -sha1
@@ -189,4 +189,4 @@ The two generated files map to the **Connection Configuration** fields in taosX 
 | `client_cert.pem`   | Secure Channel Certificate    |
 | `client_key.pem`    | Certificate's Private Key     |
 
-The first **Check Connection** attempt usually fails, because the server has not yet trusted the certificate. Follow the vendor-specific steps to trust or bind the certificate on the server side (see [Ignition Integration Guide](./03-ignition.md) and [GE Cimplicity Integration Guide](./04-ge-cimplicity.md)), then run **Check Connection** again.
+The first **Check Connection** attempt usually fails, because the server has not yet trusted the certificate. Follow the vendor-specific steps to trust or bind the certificate on the server side (see [Ignition Integration Guide](./03-ignition.md) and [GE CSS OPC UA Server Integration Guide](./04-ge-opcua-server.md)), then run **Check Connection** again.

--- a/docs/en/06-advanced/05-data-in/05-opcua/04-ge-opcua-server.md
+++ b/docs/en/06-advanced/05-data-in/05-opcua/04-ge-opcua-server.md
@@ -1,11 +1,11 @@
 ---
-title: "GE Cimplicity OPC UA Server Integration Guide"
-sidebar_label: "GE Cimplicity"
+title: "GE CSS OPC UA Server Integration Guide"
+sidebar_label: "GE CSS OPC UA Server"
 ---
 
-This page describes how to configure the OPC UA connection in taosX Explorer when the data source is a **GE Cimplicity OPC UA Server**.
+This page describes how to configure the OPC UA connection in taosX Explorer when the data source is a **GE CSS OPC UA Server**.
 
-OPC UA security has two independent layers, and you have to satisfy both for a GE Cimplicity OPC UA Server.
+OPC UA security has two independent layers, and you have to satisfy both for a GE CSS OPC UA Server.
 
 ### Secure Channel
 

--- a/docs/en/06-advanced/05-data-in/05-opcua/index.md
+++ b/docs/en/06-advanced/05-data-in/05-opcua/index.md
@@ -56,7 +56,7 @@ When **Security Mode** is `Sign` or `SignAndEncrypt`, both **Secure Channel Cert
 Different OPC UA Server products use different endpoint formats, security policy combinations, and client-certificate trust workflows. If you are connecting to one of the servers below, **read the dedicated integration guide first** for verified settings and the server-side trust flow:
 
 - [Ignition OPC UA Server Integration Guide](./03-ignition.md)
-- [GE Cimplicity OPC UA Server Integration Guide](./04-ge-cimplicity.md)
+- [GE CSS OPC UA Server Integration Guide](./04-ge-opcua-server.md)
 
 For OPC UA Servers from other vendors, follow the generic steps in this section.
 

--- a/docs/zh/06-advanced/05-data-in/05-opcua/01-client-certificate.md
+++ b/docs/zh/06-advanced/05-data-in/05-opcua/01-client-certificate.md
@@ -3,7 +3,7 @@ title: "生成 taosX OPC UA 客户端证书"
 sidebar_label: "客户端证书"
 ---
 
-当 OPC UA 服务端的 **Security Mode** 设置为 `Sign` 或 `SignAndEncrypt` 时，taosX 必须以客户端证书与私钥的方式与之建立安全通道。本页给出在 Windows 与 Linux/macOS 上生成证书与私钥的标准步骤，**Ignition、GE Cimplicity 等所有需要证书加密的场景都按本页执行一次即可**。
+当 OPC UA 服务端的 **Security Mode** 设置为 `Sign` 或 `SignAndEncrypt` 时，taosX 必须以客户端证书与私钥的方式与之建立安全通道。本页给出在 Windows 与 Linux/macOS 上生成证书与私钥的标准步骤，**Ignition、GE CSS OPC UA Server 等所有需要证书加密的场景都按本页执行一次即可**。
 
 ## 1. 证书要求
 
@@ -88,7 +88,7 @@ echo Verify certificate:
 "%OPENSSL%" x509 -in "%CERT_FILE%" -noout -subject -ext subjectAltName
 
 echo.
-echo SHA1 fingerprint (used by some servers, e.g. GE Cimplicity, to map the certificate to a user):
+echo SHA1 fingerprint (used by some servers, e.g. GE CSS OPC UA Server, to map the certificate to a user):
 "%OPENSSL%" x509 -in "%CERT_FILE%" -noout -fingerprint -sha1
 
 pause
@@ -174,7 +174,7 @@ X509v3 Subject Alternative Name:
     URI:urn:taosx-opc:client
 ```
 
-如果服务端（例如 GE Cimplicity）需要按 SHA1 指纹将证书绑定到某个用户，使用如下命令获取指纹：
+如果服务端（例如 GE CSS OPC UA Server）需要按 SHA1 指纹将证书绑定到某个用户，使用如下命令获取指纹：
 
 ```bash
 openssl x509 -in client_cert.pem -noout -fingerprint -sha1
@@ -189,4 +189,4 @@ openssl x509 -in client_cert.pem -noout -fingerprint -sha1
 | `client_cert.pem` | Secure Channel Certificate |
 | `client_key.pem`  | Certificate's Private Key  |
 
-上传后第一次 **Check Connection** 通常会失败，因为服务端尚未信任该证书。请按对应厂商的指南完成服务端"信任 / 绑定证书"的操作（参见 [Ignition 集成指南](./03-ignition.md) 和 [GE Cimplicity 集成指南](./04-ge-cimplicity.md)），随后重新进行连通性检查。
+上传后第一次 **Check Connection** 通常会失败，因为服务端尚未信任该证书。请按对应厂商的指南完成服务端"信任 / 绑定证书"的操作（参见 [Ignition 集成指南](./03-ignition.md) 和 [GE CSS OPC UA Server 集成指南](./04-ge-opcua-server.md)），随后重新进行连通性检查。

--- a/docs/zh/06-advanced/05-data-in/05-opcua/04-ge-opcua-server.md
+++ b/docs/zh/06-advanced/05-data-in/05-opcua/04-ge-opcua-server.md
@@ -1,11 +1,11 @@
 ---
-title: "GE Cimplicity OPC UA Server 集成指南"
-sidebar_label: "GE Cimplicity"
+title: "GE CSS OPC UA Server 集成指南"
+sidebar_label: "GE CSS OPC UA Server"
 ---
 
-本页介绍当数据源是 **GE Cimplicity OPC UA Server** 时，如何在 taosX Explorer 中配置 OPC UA 连接。
+本页介绍当数据源是 **GE CSS OPC UA Server** 时，如何在 taosX Explorer 中配置 OPC UA 连接。
 
-OPC UA 安全分为两个相互独立的层级，连接 GE Cimplicity OPC Server 时两者都必须满足：
+OPC UA 安全分为两个相互独立的层级，连接 GE CSS OPC UA Server 时两者都必须满足：
 
 ### 安全通道（Secure Channel）
 

--- a/docs/zh/06-advanced/05-data-in/05-opcua/index.md
+++ b/docs/zh/06-advanced/05-data-in/05-opcua/index.md
@@ -61,7 +61,7 @@ TDengine TSDB 可以高效地从 OPC UA 服务器读取数据并将其写入 TDe
 不同厂商的 OPC UA Server 在端点格式、安全策略组合、客户端证书信任流程上存在差异。如果你使用下列任意一款 Server，**建议先阅读对应的专属指南** 获取经过验证的配置参考与服务端信任流程：
 
 - [Ignition OPC UA Server 集成指南](./03-ignition.md)
-- [GE Cimplicity OPC UA Server 集成指南](./04-ge-cimplicity.md)
+- [GE CSS OPC UA Server 集成指南](./04-ge-opcua-server.md)
 
 其他厂商的 OPC UA Server，按本节通用步骤填写即可。
 


### PR DESCRIPTION
# Description

docs(opcua): rename "GE Cimplicity" to "GE CSS OPC UA Server" #6984382630

GE Cimplicity is the SCADA/HMI platform, not the OPC UA Server itself. The actual OPC UA Server component is "GE CSS OPC UA Server" (endpoint /GeCssOpcUaServer). Update titles, body text, script comments, and internal links accordingly. Retain "GE Cimplicity user" where it refers to the Cimplicity user management context.

Rename 04-ge-cimplicity.md -> 04-ge-opcua-server.md (en/zh).

# Issue(s)

close https://project.feishu.cn/taosdata_td/feature/detail/6984382630

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
