### PR TITLE
fix: null pointer dereference and resource leak in qWorkerInit error paths

### DIFF
--- a/source/libs/qworker/src/qworker.c
+++ b/source/libs/qworker/src/qworker.c
@@ -1627,7 +1627,6 @@ int32_t qWorkerInit(int8_t nodeType, int32_t nodeId, void **qWorkerMgmt, const S
   mgmt->schHash = taosHashInit(mgmt->cfg.maxSchedulerNum, taosGetDefaultHashFunction(TSDB_DATA_TYPE_UBIGINT), false,
                                HASH_ENTRY_LOCK);
   if (NULL == mgmt->schHash) {
-    taosMemoryFreeClear(mgmt);
     qError("init %d scheduler hash failed", mgmt->cfg.maxSchedulerNum);
     QW_ERR_JRET(terrno);
   }
@@ -1680,7 +1679,7 @@ int32_t qWorkerInit(int8_t nodeType, int32_t nodeId, void **qWorkerMgmt, const S
 
 _return:
 
-  if (mgmt->refId >= 0) {
+  if (mgmt->refId > 0) {
     (void)qwRelease(mgmt->refId);  // ignore error
   } else {
     taosHashCleanup(mgmt->schHash);

--- a/source/libs/qworker/test/qworkerTests.cpp
+++ b/source/libs/qworker/test/qworkerTests.cpp
@@ -41,7 +41,9 @@
 #include "tdatablock.h"
 #include "tdef.h"
 #include "tglobal.h"
+#include "thash.h"
 #include "trpc.h"
+#include "ttimer.h"
 #include "tvariant.h"
 
 namespace {
@@ -1397,6 +1399,64 @@ TEST(rcTest, dropTest) {
   taosSsleep(3);
 
   qWorkerDestroy(&mgmt);
+}
+
+// Mock helpers for qWorkerInit error-path tests.
+// These are placed outside the anonymous namespace so their addresses can be
+// taken by Stub::set() directly (statically-linked targets).
+
+static SHashObj *qwtMockHashInitNull(size_t capacity, _hash_fn_t fn, bool update, SHashLockTypeE type) {
+  terrno = TSDB_CODE_OUT_OF_MEMORY;
+  return NULL;
+}
+
+static void *qwtMockTmrInitNull(int32_t maxTmr, int32_t resolution, int32_t longest, const char *label) {
+  terrno = TSDB_CODE_OUT_OF_MEMORY;
+  return NULL;
+}
+
+// Regression test: before the fix, qWorkerInit crashed with SIGSEGV when
+// taosHashInit returned NULL because taosMemoryFreeClear(mgmt) was called
+// before the qError() that dereferenced mgmt.
+TEST(initErrorTest, schHashAllocFail) {
+  void   *mgmt = NULL;
+  int32_t code = 0;
+
+  qwtInitLogFile();
+
+  Stub stub;
+  stub.set(taosHashInit, qwtMockHashInitNull);
+
+  SMsgCb msgCb = {0};
+  msgCb.mgmt = (void *)0x1;
+  msgCb.putToQueueFp = (PutToQueueFp)qwtPutReqToQueue;
+
+  // Must not crash; must return a non-zero error code.
+  code = qWorkerInit(NODE_TYPE_VNODE, 1, &mgmt, &msgCb);
+  ASSERT_NE(code, TSDB_CODE_SUCCESS);
+  // mgmt must remain NULL — init failed, nothing was handed out.
+  ASSERT_EQ(mgmt, (void *)NULL);
+}
+
+// Regression test: when taosTmrInit fails the _return block must take the
+// else-branch (correct cleanup) rather than calling qwRelease(0) which silently
+// ignores the error and leaks schHash / ctxHash / mgmt.
+TEST(initErrorTest, timerInitFail) {
+  void   *mgmt = NULL;
+  int32_t code = 0;
+
+  qwtInitLogFile();
+
+  Stub stub;
+  stub.set(taosTmrInit, qwtMockTmrInitNull);
+
+  SMsgCb msgCb = {0};
+  msgCb.mgmt = (void *)0x1;
+  msgCb.putToQueueFp = (PutToQueueFp)qwtPutReqToQueue;
+
+  code = qWorkerInit(NODE_TYPE_VNODE, 1, &mgmt, &msgCb);
+  ASSERT_NE(code, TSDB_CODE_SUCCESS);
+  ASSERT_EQ(mgmt, (void *)NULL);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## 问题

vnode 启动时若 `taosHashInit` 分配 `schHash` 失败，进程立即 SEGV 崩溃。关联 Issue：#35280

## 根因

**Bug 1（SEGV）**：`schHash` 失败分支先调 `taosMemoryFreeClear(mgmt)` 将 mgmt 置为 NULL，随后 `qError()` 访问 `mgmt->cfg.maxSchedulerNum` 导致 NULL 指针解引用。

**Bug 2（资源泄漏）**：`_return` 清理块判断 `mgmt->refId >= 0`，而 `taosMemoryCalloc` 零初始化令 refId=0，导致所有 `taosAddRef` 调用之前的失败路径都错走 `qwRelease(0)`（静默返回错误），schHash/ctxHash/timer/mgmt 均未释放。

## 修复

- **Fix 1**：删除 schHash 失败分支中多余的 `taosMemoryFreeClear(mgmt)`，由统一的 `_return` 负责清理。
- **Fix 2**：将 `refId >= 0` 改为 `refId > 0`（有效 refId 从 1 开始，0 表示 taosAddRef 尚未被调用）。

## 测试

新增回归测试（`qworkerTests.cpp`）：
- `initErrorTest.schHashAllocFail`：stub `taosHashInit` 返回 NULL，验证不崩溃且返回错误码
- `initErrorTest.timerInitFail`：stub `taosTmrInit` 返回 NULL，验证错误路径正确清理

两个用例均已通过。