### PR TITLE
docs: escape some characters for pdf compat

### DIFF
--- a/docs/en/06-advanced/05-data-in/06-opcda.md
+++ b/docs/en/06-advanced/05-data-in/06-opcda.md
@@ -168,8 +168,8 @@ In **Maximum Retention Days**, set the maximum retention days for raw data.
 
 In **Raw Data Storage Directory**, set the path for saving raw data. If using Agent, the storage path refers to the path on the server where Agent is located, otherwise it is on the taosX server. The path can include placeholders `$DATA_DIR` and `:id` as part of the path.
 
-- On Linux platform, `$DATA_DIR` is /var/lib/taos/taosx, by default the storage path is `/var/lib/taos/taosx/tasks/<task_id>/rawdata`.
-- On Windows platform, `$DATA_DIR` is C:\TDengine\data\taosx, by default the storage path is `C:\TDengine\data\taosx\tasks\<task_id>\rawdata`.
+- On Linux platform, `$DATA_DIR` is `/var/lib/taos/taosx`, by default the storage path is `/var/lib/taos/taosx/tasks/<task_id>/rawdata`.
+- On Windows platform, `$DATA_DIR` is `C:\TDengine\data\taosx`, by default the storage path is `C:\TDengine\data\taosx\tasks\<task_id>\rawdata`.
 
 ### Completion
 

--- a/docs/en/07-develop/04-schemaless.md
+++ b/docs/en/07-develop/04-schemaless.md
@@ -42,8 +42,8 @@ In the schemaless writing line protocol, each data item in field_set needs to de
 - If enclosed in double quotes, it represents varchar type, e.g., "abc".
 - If enclosed in double quotes and prefixed with L or l, it represents nchar type, e.g., L" error message ".
 - If enclosed in double quotes and prefixed with G or g, it represents geometry type, e.g., G"Point(4.343 89.342)".
-- If enclosed in double quotes and prefixed with B or b, it represents varbinary type, the double quotes can contain hexadecimal starting with \x or strings, e.g., B"\x98f46e" and B"hello".
-- For spaces, equal signs (=), commas (,), double quotes ("), and backslashes (\), a backslash (\) is needed for escaping (all in half-width English characters). The domain escape rules for the schemaless writing protocol are shown in the following table.
+- If enclosed in double quotes and prefixed with B or b, it represents varbinary type, the double quotes can contain hexadecimal starting with `\x` or strings, e.g., `B"\x98f46e"` and `B"hello"`.
+- For spaces, equal signs (=), commas (,), double quotes ("), and backslashes (\\), a backslash (\\) is needed for escaping (all in half-width English characters). The domain escape rules for the schemaless writing protocol are shown in the following table.
 
 | **Number** | **Field**   | **Characters to Escape**   |
 | -------- | -------- | ---------------- |

--- a/docs/en/07-develop/connector-security-best-practices.md
+++ b/docs/en/07-develop/connector-security-best-practices.md
@@ -762,30 +762,30 @@ Before production rollout, verify the following controls:
 
 ### Transport Encryption
 
-- [ ] **Enable SSL/TLS**: all JDBC/REST/TMQ connections use encrypted transport (`useSSL=true` or equivalent).
-- [ ] **Certificate validation**: do not skip certificate verification in production.
-- [ ] **Strong ciphers**: TLS >= 1.2 and weak ciphers disabled (for example RC4, DES).
+- **Enable SSL/TLS**: all JDBC/REST/TMQ connections use encrypted transport (`useSSL=true` or equivalent).
+- **Certificate validation**: do not skip certificate verification in production.
+- **Strong ciphers**: TLS >= 1.2 and weak ciphers disabled (for example RC4, DES).
 
 ### Token Management
 
-- [ ] **Least privilege**: grant only required permissions.
-- [ ] **Reasonable TTL**: not more than 7 days; 24 hours recommended.
-- [ ] **No plaintext storage**: avoid storing tokens in plaintext in code/config.
-- [ ] **Secret management**: use KMS/Vault or equivalent.
-- [ ] **Regular rotation**: rotate automatically before expiration.
+- **Least privilege**: grant only required permissions.
+- **Reasonable TTL**: not more than 7 days; 24 hours recommended.
+- **No plaintext storage**: avoid storing tokens in plaintext in code/config.
+- **Secret management**: use KMS/Vault or equivalent.
+- **Regular rotation**: rotate automatically before expiration.
 
 ### Operations Security
 
-- [ ] **Audit logs**: record token creation/use/revocation.
-- [ ] **Monitoring and alerts**: token expiration, rotation failure, and connection anomalies.
-- [ ] **Incident response**: be able to revoke leaked tokens quickly.
-- [ ] **Exposure isolation**: use separate tokens per application.
+- **Audit logs**: record token creation/use/revocation.
+- **Monitoring and alerts**: token expiration, rotation failure, and connection anomalies.
+- **Incident response**: be able to revoke leaked tokens quickly.
+- **Exposure isolation**: use separate tokens per application.
 
 ### Code Security
 
-- [ ] **Log masking**: avoid printing full tokens in logs.
-- [ ] **Pool isolation**: isolate pools by tenant/service where required.
-- [ ] **Exception handling**: fail gracefully on token invalidation without leaking sensitive details.
+- **Log masking**: avoid printing full tokens in logs.
+- **Pool isolation**: isolate pools by tenant/service where required.
+- **Exception handling**: fail gracefully on token invalidation without leaking sensitive details.
 
 ---
 

--- a/docs/en/08-operation/13-network.md
+++ b/docs/en/08-operation/13-network.md
@@ -157,4 +157,4 @@ There is some impact: overall performance typically decreases by less than 5% (a
 
 #### Operations and upgrades
 
-Dynamic upgrades are not supported.\n
+Dynamic upgrades are not supported.

--- a/docs/en/14-reference/01-components/03-taosadapter.md
+++ b/docs/en/14-reference/01-components/03-taosadapter.md
@@ -1510,7 +1510,7 @@ Records are written before `taos_free_result` is executed or when the task ends 
 Records are stored in CSV format without headers. Each line includes the following fields:
 
 1. `TS`: Log timestamp (format: yyyy-MM-dd HH:mm:ss.SSSSSS, timezone: server's timezone).
-1. `SQL`: Executed SQL statement. Line breaks in SQL are preserved per CSV standards. Special characters (\n, \r, ") are wrapped in double quotes.
+1. `SQL`: Executed SQL statement. Line breaks in SQL are preserved per CSV standards. Special characters (`\n`, `\r`, `"`) are wrapped in double quotes.
    SQL containing special characters cannot be directly copied for use. Example:
 
    Original SQL:

--- a/docs/en/14-reference/03-taos-sql/01-datatype.md
+++ b/docs/en/14-reference/03-taos-sql/01-datatype.md
@@ -59,9 +59,9 @@ In TDengine, the following data types can be used in the data model of basic tab
     | 3    | POLYGON((1.0 1.0, 2.0 2.0, 1.0 1.0)) | 13+3*16            | 13+4094*16         | +16                              |
 
 - In SQL statements, the type of numerical values will be determined based on the presence of a decimal point or the use of scientific notation, so care must be taken to avoid type overflow. For example, 9999999999999999999 will be considered to exceed the upper boundary of long integers and overflow, while 9999999999999999999.0 will be considered a valid floating point number.
-- VARBINARY is a data type for storing binary data, with a maximum length of 65,517 bytes for data columns and 16,382 bytes for label columns. Binary data can be written via SQL or schemaless methods (needs to be converted to a string starting with \x), or through stmt methods (can use binary directly). Displayed as hexadecimal starting with \x.
+- VARBINARY is a data type for storing binary data, with a maximum length of 65,517 bytes for data columns and 16,382 bytes for label columns. Binary data can be written via SQL or schemaless methods (needs to be converted to a string starting with `\x`), or through stmt methods (can use binary directly). Displayed as hexadecimal starting with `\x`.
 
-- BLOB is a data type for storing binary data, with a maximum length of 419,430,465 bytes for data columns. BLOB data can be written via SQL or schemaless methods (needs to be converted to a string starting with \x), or through stmt methods (can use binary directly). Displayed as hexadecimal starting with \x.
+- BLOB is a data type for storing binary data, with a maximum length of 419,430,465 bytes for data columns. BLOB data can be written via SQL or schemaless methods (needs to be converted to a string starting with `\x`), or through stmt methods (can use binary directly). Displayed as hexadecimal starting with `\x`.
 
 :::
 
@@ -79,7 +79,7 @@ When querying `DECIMAL` type expressions, if the intermediate result of the calc
 
 ### BLOB Data type
 
-The BLOB data type is used for storing binary data, with a maximum length of 4,194,304 bytes. Binary data can be written via SQL or stmt2 by converting it to a string that starts with \x, or directly as binary data using the stmt interface. When displayed, BLOB data is shown in hexadecimal format starting with \x
+The BLOB data type is used for storing binary data, with a maximum length of 4,194,304 bytes. Binary data can be written via SQL or stmt2 by converting it to a string that starts with `\x`, or directly as binary data using the stmt interface. When displayed, BLOB data is shown in hexadecimal format starting with `\x`
 `Limitations`
 Only one BLOB column is allowed per table.
 BLOB columns are not supported as tag columns.

--- a/docs/en/14-reference/03-taos-sql/52-show.md
+++ b/docs/en/14-reference/03-taos-sql/52-show.md
@@ -208,7 +208,7 @@ Displays the data distribution information of the table.
 
 Example explanation:
 
-Statement: show table distributed d0\G;   Displays the BLOCK distribution of table d0 vertically
+Statement: `show table distributed d0\G;`   Displays the BLOCK distribution of table d0 vertically
 
 <details>
  <summary>Display example</summary>

--- a/docs/en/14-reference/03-taos-sql/index.md
+++ b/docs/en/14-reference/03-taos-sql/index.md
@@ -13,7 +13,7 @@ This section follows the conventions below for SQL syntax:
 
 - Keywords are represented in uppercase letters, but SQL itself does not distinguish between the case of keywords and identifiers
 - Lowercase letters indicate content that needs to be entered by the user
-- \[ \] indicates optional content, but you cannot enter [] itself
+- Square brackets [ ] indicate optional content, but you cannot enter [] itself
 - | indicates a choice among multiple options, choose one, but you cannot enter | itself
 - ... indicates that the previous item can be repeated multiple times
 

--- a/docs/en/14-reference/05-connector/14-java.md
+++ b/docs/en/14-reference/05-connector/14-java.md
@@ -154,7 +154,7 @@ Please refer to:
 
   **Reason**: The program cannot find the required local function library taos.
 
-  **Solution**: On Windows, you can copy C:\TDengine\driver\taos.dll to the C:\Windows\System32\ directory. On Linux, create the following symlink `ln -s /usr/local/taos/driver/libtaos.so.x.x.x.x /usr/lib/libtaos.so`. On macOS, create a symlink `ln -s /usr/local/lib/libtaos.dylib`.
+  **Solution**: On Windows, you can copy `C:\TDengine\driver\taos.dll` to the `C:\Windows\System32\` directory. On Linux, create the following symlink `ln -s /usr/local/taos/driver/libtaos.so.x.x.x.x /usr/lib/libtaos.so`. On macOS, create a symlink `ln -s /usr/local/lib/libtaos.dylib`.
 
 3. java.lang.UnsatisfiedLinkError: taos.dll Can't load AMD 64 bit on a IA 32-bit platform
 

--- a/docs/en/27-train-faq/index.md
+++ b/docs/en/27-train-faq/index.md
@@ -554,7 +554,7 @@ Due to the limited display width in the TDengine CLI terminal, longer table name
 
 ### 8.3 How to fully display field content in TDengine CLI queries?
 
-You can use the \G parameter for vertical display, such as `show databases\G\;` (for ease of input, press TAB after "\" to automatically complete the content).
+You can use the `\G` parameter for vertical display, such as `show databases\G\;` (for ease of input, press TAB after "\" to automatically complete the content).
 
 ### 8.4 What should I do if string data appears garbled in DBeaver?
 

--- a/docs/en/28-releases/03-notes/3.3.6.6.md
+++ b/docs/en/28-releases/03-notes/3.3.6.6.md
@@ -37,7 +37,7 @@ description: Version 3.3.6.6 Notes
   7. fix: timezone in taos.cfg not work in taosc websocket connection
   8. fix: multiple prepare operations on the same STMT statement can cause the program to crash.
   9. fix: multiple prepare operations on an STMT statement may report error.
- 10. fix: allow spaces between \G and ;
+ 10. fix: allow spaces between `\G` and ;
  11. fix: taosBenchmark -s parameter parse error in
  12. fix: ensure uid/pwd are passed during ws_connect in ODBC
  13. fix: taosBenchmark create table with tag values cause core dump

--- a/docs/en/28-releases/03-notes/3.3.6.9.md
+++ b/docs/en/28-releases/03-notes/3.3.6.9.md
@@ -14,7 +14,7 @@ description: Version 3.3.6.9 Notes
 
   1. enh: optimize the update logic for data subscription offsets.
   2. enh: update the method for generating driver version numbers
-  3. enh: Explorer support \n in JSON payload
+  3. enh: Explorer support `\n` in JSON payload
   4. enh: Kafka/MQTT support keep original payload/value
   5. enh: kafka group and client_id should be editable after imported
   6. enh: optimize the config parameter's persistence behavior


### PR DESCRIPTION
1. escape or remove backslashes to prevent errors when creating pdf docs
2. replace checklists with normal bullets for same reason