### PR TITLE
fix: launch tdgpt model servers with cli flags

### DIFF
--- a/packaging/docker/entrypoint.sh
+++ b/packaging/docker/entrypoint.sh
@@ -76,8 +76,12 @@ execute_startup() {
             echo "Running command: nohup python3 /usr/local/taos/taosanode/lib/taosanalytics/tsfmservice/${model}-server.py &"
             nohup python3 "${model}-server.py" --action server &
         else
-            echo "Running command: nohup python3 ${model}-server.py ${subdir} ${model_name} ${ENDPOINT_ENABLE} &"
-            nohup python3 "${model}-server.py" "${subdir}" "${model_name}" "${ENDPOINT_ENABLE}" &
+            model_args=(--model-folder "${subdir}" --model-name "${model_name}")
+            if [ "${ENDPOINT_ENABLE}" == "True" ]; then
+                model_args+=(--enable-ep)
+            fi
+            echo "Running command: nohup python3 ${model}-server.py ${model_args[*]} &"
+            nohup python3 "${model}-server.py" "${model_args[@]}" &
         fi
         SERVER_PID=$!
         if ps -p ${SERVER_PID} > /dev/null; then


### PR DESCRIPTION
## Summary
- Update TDgpt Docker entrypoint to launch non-tdtsfm model servers with argparse-compatible flags.
- Preserve tdtsfm startup behavior and append `--enable-ep` only when `EP_ENABLE=True`.

## Validation
- `bash -n packaging/docker/entrypoint.sh`
- `python3 -m py_compile tools/tdgpt/script/taosanode_service.py tools/tdgpt/packaging/win_release.py tools/tdgpt/taosanalytics/tsfmservice/{chronos,timemoe,timesfm,moment,moirai,tdtsfm}-server.py`
- `git diff --check`
- Patched-entrypoint TDgpt Docker smoke on 192.168.1.131: `PYTHONPATH=$PWD python3 /tmp/test_tdgpt_docker_entrypoint.py 3.4.1.9` passed
- Patched-entrypoint TDgpt Docker smoke on 192.168.3.91: `PYTHONPATH=$PWD python3 /tmp/test_tdgpt_docker_entrypoint.py 3.4.1.9` passed

## Notes
Windows packaging uses `taosanode_service.py model-start`, which already builds `--model-folder`, `--model-name`, and `--port` arguments for model services, so no Windows packaging change is required for this issue.
