### PR TITLE
fix: make TDgpt Docker model startup and downloads robust

### DIFF
--- a/packaging/docker/entrypoint.sh
+++ b/packaging/docker/entrypoint.sh
@@ -76,8 +76,12 @@ execute_startup() {
             echo "Running command: nohup python3 /usr/local/taos/taosanode/lib/taosanalytics/tsfmservice/${model}-server.py &"
             nohup python3 "${model}-server.py" --action server &
         else
-            echo "Running command: nohup python3 ${model}-server.py ${subdir} ${model_name} ${ENDPOINT_ENABLE} &"
-            nohup python3 "${model}-server.py" "${subdir}" "${model_name}" "${ENDPOINT_ENABLE}" &
+            model_args=(--model-folder "${subdir}" --model-name "${model_name}")
+            if [ "${ENDPOINT_ENABLE}" == "True" ]; then
+                model_args+=(--enable-ep)
+            fi
+            echo "Running command: nohup python3 ${model}-server.py ${model_args[*]} &"
+            nohup python3 "${model}-server.py" "${model_args[@]}" &
         fi
         SERVER_PID=$!
         if ps -p ${SERVER_PID} > /dev/null; then

--- a/tools/tdgpt/taosanalytics/misc/hf_download.py
+++ b/tools/tdgpt/taosanalytics/misc/hf_download.py
@@ -1,0 +1,68 @@
+import os
+from typing import Any, Optional
+
+from huggingface_hub import snapshot_download
+
+
+DEFAULT_HF_MIRROR_ENDPOINT = "https://hf-mirror.com"
+OFFICIAL_HF_ENDPOINT = "https://huggingface.co"
+
+
+def parse_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "y", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "n", "off", ""}:
+        return False
+    raise ValueError(f"invalid boolean value: {value!r}")
+
+
+def resolve_endpoint(enable_ep: object) -> Optional[str]:
+    if not parse_bool(enable_ep):
+        return None
+    return (
+        os.environ.get("TAOS_HF_ENDPOINT")
+        or os.environ.get("HF_ENDPOINT")
+        or DEFAULT_HF_MIRROR_ENDPOINT
+    )
+
+
+def is_official_endpoint(endpoint: Optional[str]) -> bool:
+    if not endpoint:
+        return True
+    return endpoint.rstrip("/") == OFFICIAL_HF_ENDPOINT
+
+
+def snapshot_download_with_fallback(
+    *,
+    repo_id: str,
+    local_dir: str,
+    enable_ep: object = False,
+    **kwargs: Any,
+) -> str:
+    endpoint = resolve_endpoint(enable_ep)
+    print(f"set the download ep:{endpoint}")
+    try:
+        return snapshot_download(
+            repo_id=repo_id,
+            local_dir=local_dir,
+            endpoint=endpoint,
+            **kwargs,
+        )
+    except Exception as exc:
+        if is_official_endpoint(endpoint):
+            raise
+        print(
+            f"download from endpoint {endpoint} failed: {exc}; "
+            f"fallback to {OFFICIAL_HF_ENDPOINT}"
+        )
+        return snapshot_download(
+            repo_id=repo_id,
+            local_dir=local_dir,
+            endpoint=OFFICIAL_HF_ENDPOINT,
+            **kwargs,
+        )

--- a/tools/tdgpt/taosanalytics/misc/hf_download.py
+++ b/tools/tdgpt/taosanalytics/misc/hf_download.py
@@ -40,7 +40,6 @@ def is_official_endpoint(endpoint: Optional[str]) -> bool:
 def snapshot_download_with_fallback(
     repo_id: str,
     local_dir: str,
-    *,
     enable_ep: object = False,
     **kwargs: Any,
 ) -> str:

--- a/tools/tdgpt/taosanalytics/misc/hf_download.py
+++ b/tools/tdgpt/taosanalytics/misc/hf_download.py
@@ -38,9 +38,9 @@ def is_official_endpoint(endpoint: Optional[str]) -> bool:
 
 
 def snapshot_download_with_fallback(
-    *,
     repo_id: str,
     local_dir: str,
+    *,
     enable_ep: object = False,
     **kwargs: Any,
 ) -> str:

--- a/tools/tdgpt/taosanalytics/misc/model_downloader.py
+++ b/tools/tdgpt/taosanalytics/misc/model_downloader.py
@@ -1,28 +1,28 @@
 import os
 import sys
-from huggingface_hub import snapshot_download
 from tqdm import tqdm
+
+try:
+    from .hf_download import parse_bool, snapshot_download_with_fallback
+except ImportError:
+    from hf_download import parse_bool, snapshot_download_with_fallback
 
 
 def download_model(model_name, model_dir, enable_ep = False):
     # model_list = ['Salesforce/moirai-1.0-R-small']
-    ep = 'https://hf-mirror.com' if enable_ep else None
     model_list = [model_name]
 
     if not os.path.exists(model_dir):
         print(f"create model directory: {model_dir}")
         os.mkdir(model_dir)
 
-    if ep:
-        print(f"set the download ep:{ep}")
-
     for item in tqdm(model_list):
-        snapshot_download(
+        snapshot_download_with_fallback(
             repo_id=item,
             local_dir=model_dir,  # storage directory
+            enable_ep=enable_ep,
             local_dir_use_symlinks=False,   # disable the link
             resume_download=True,
-            endpoint=ep
         )
 
 
@@ -36,10 +36,15 @@ if __name__ == '__main__':
     """
     if len(sys.argv) < 4:
         print("invalid parameters, e.g.,:\n python model_downloader.py model_directory model_name ep_enable")
-        exit(-1)
+        sys.exit(1)
 
     path = sys.argv[1].strip('\'"')
     model_name = sys.argv[2].strip('\'"')
-    ep_enable = bool(sys.argv[3])
+    ep_raw = sys.argv[3]
+    try:
+        ep_enable = parse_bool(ep_raw)
+    except ValueError:
+        print(f"invalid ep_enable parameter: {ep_raw}")
+        sys.exit(1)
 
     do_download_tsfm(path, model_name, ep_enable)

--- a/tools/tdgpt/taosanalytics/tsfmservice/chronos-server.py
+++ b/tools/tdgpt/taosanalytics/tsfmservice/chronos-server.py
@@ -1,10 +1,15 @@
 import argparse
 import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'misc'))
+
 import torch
 from flask import Flask, request, jsonify
 from chronos import BaseChronosPipeline
-from huggingface_hub import snapshot_download
 from tqdm import tqdm
+
+from hf_download import snapshot_download_with_fallback
 
 app = Flask(__name__)
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -13,7 +18,6 @@ pretrained_model = None
 
 def download_model(model_name, root_dir, enable_ep = False):
     # model_list = ['Salesforce/moirai-1.0-R-small']
-    ep = 'https://hf-mirror.com' if enable_ep else None
     model_list = [model_name]
 
     # root_dir = '/var/lib/taos/taosanode/model/chronos/'
@@ -25,12 +29,12 @@ def download_model(model_name, root_dir, enable_ep = False):
         os.mkdir(dst_folder)
 
     for item in tqdm(model_list):
-        snapshot_download(
+        snapshot_download_with_fallback(
             repo_id=item,
             local_dir=dst_folder,  # storage directory
+            enable_ep=enable_ep,
             local_dir_use_symlinks=False,   # disable the link
             resume_download=True,
-            endpoint=ep
         )
 
 @app.route('/ds_predict', methods=['POST'])
@@ -179,5 +183,4 @@ def main():
 
 if __name__ == "__main__":
     main()
-
 

--- a/tools/tdgpt/taosanalytics/tsfmservice/moirai-server.py
+++ b/tools/tdgpt/taosanalytics/tsfmservice/moirai-server.py
@@ -1,13 +1,16 @@
 import argparse
 import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'misc'))
 
 import torch
 from flask import Flask, request, jsonify
 from gluonts.dataset.pandas import PandasDataset
 from gluonts.dataset.split import split
-from huggingface_hub import snapshot_download
 from tqdm import tqdm
 
+from hf_download import snapshot_download_with_fallback
 from uni2ts.model.moirai_moe import MoiraiMoEForecast, MoiraiMoEModule
 from einops import rearrange
 
@@ -228,7 +231,6 @@ def handle_future_covariate_forecast(input_data, prediction_length, interval, pa
 
 def download_model(model_name, root_dir, enable_ep=False):
     # model_list = ['Salesforce/moirai-1.0-R-small']
-    ep = 'https://hf-mirror.com' if enable_ep else None
     model_list = [model_name]
 
     # root_dir = '/var/lib/taos/taosanode/model/moirai/'
@@ -240,12 +242,12 @@ def download_model(model_name, root_dir, enable_ep=False):
         os.mkdir(dst_folder)
 
     for item in tqdm(model_list):
-        snapshot_download(
+        snapshot_download_with_fallback(
             repo_id=item,
             local_dir=dst_folder,  # storage directory
+            enable_ep=enable_ep,
             local_dir_use_symlinks=False,  # disable the link
             resume_download=True,
-            endpoint=ep
         )
 
 

--- a/tools/tdgpt/taosanalytics/tsfmservice/moment-server.py
+++ b/tools/tdgpt/taosanalytics/tsfmservice/moment-server.py
@@ -1,11 +1,13 @@
 import argparse
 import os
 import re
+import sys
 from datetime import timedelta
 import matplotlib.pyplot as plt
 import pandas as pd
 import numpy as np
-from huggingface_hub import snapshot_download
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'misc'))
 
 from sklearn.preprocessing import StandardScaler
 
@@ -18,6 +20,7 @@ from momentfm import MOMENTPipeline
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
+from hf_download import snapshot_download_with_fallback
 pretrained_model = None
 control_randomness(seed=13) # Set random seeds for PyTorch, Numpy etc.
 
@@ -302,7 +305,6 @@ def convert_ts(ts_list, precision):
 
 def download_model(model_name, root_dir, enable_ep = False):
     # model_list = ['Salesforce/moirai-moe-1.0-R-small']
-    ep = 'https://hf-mirror.com' if enable_ep else None
     model_list = [model_name]
 
     # root_dir = '/var/lib/taos/taosanode/model/moment/'
@@ -314,12 +316,12 @@ def download_model(model_name, root_dir, enable_ep = False):
         os.mkdir(dst_folder)
 
     for item in tqdm(model_list):
-        snapshot_download(
+        snapshot_download_with_fallback(
             repo_id=item,
             local_dir=dst_folder,  # storage directory
+            enable_ep=enable_ep,
             local_dir_use_symlinks=False,   # disable the link
             resume_download=True,
-            endpoint=ep
         )
 
 def main():

--- a/tools/tdgpt/taosanalytics/tsfmservice/timemoe-server.py
+++ b/tools/tdgpt/taosanalytics/tsfmservice/timemoe-server.py
@@ -1,19 +1,21 @@
 import argparse
 import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'misc'))
 
 import torch
 from flask import Flask, request, jsonify
-from huggingface_hub import snapshot_download
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM
 
+from hf_download import snapshot_download_with_fallback
 app = Flask(__name__)
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 pretrained_model = None
 
 def download_model(model_name, root_dir, enable_ep = False):
     # model_list = ['Maple728/TimeMoE-50M']
-    ep = 'https://hf-mirror.com' if enable_ep else None
     model_list = [model_name]
 
     # root_dir = '/var/lib/taos/taosanode/model/timemoe'
@@ -25,12 +27,12 @@ def download_model(model_name, root_dir, enable_ep = False):
         os.mkdir(dst_folder)
 
     for item in tqdm(model_list):
-        snapshot_download(
+        snapshot_download_with_fallback(
             repo_id=item,
             local_dir=dst_folder,  # storage directory
+            enable_ep=enable_ep,
             local_dir_use_symlinks=False,   # disable the link
             resume_download=True,
-            endpoint=ep
         )
 
 
@@ -182,4 +184,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/tools/tdgpt/taosanalytics/tsfmservice/timesfm-server.py
+++ b/tools/tdgpt/taosanalytics/tsfmservice/timesfm-server.py
@@ -1,19 +1,21 @@
 import argparse
 import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'misc'))
 
 import torch
 from flask import Flask, request, jsonify
 import timesfm
 import numpy as np
-from huggingface_hub import snapshot_download
 from tqdm import tqdm
 
+from hf_download import snapshot_download_with_fallback
 app = Flask(__name__)
 pretrained_model = None
 
 def download_model(model_name, root_dir, enable_ep = False):
     # model_list = ['google/timesfm-2.0-500m-pytorch']
-    ep = 'https://hf-mirror.com' if enable_ep else None
     model_list = [model_name]
 
     # root_dir = '/var/lib/taos/taosanode/model/timesfm/'
@@ -25,12 +27,12 @@ def download_model(model_name, root_dir, enable_ep = False):
         os.mkdir(dst_folder)
 
     for item in tqdm(model_list):
-        snapshot_download(
+        snapshot_download_with_fallback(
             repo_id=item,
             local_dir=dst_folder,  # storage directory
+            enable_ep=enable_ep,
             local_dir_use_symlinks=False,   # disable the link
             resume_download=True,
-            endpoint=ep
         )
 
 @app.route('/ds_predict', methods=['POST'])

--- a/tools/tdgpt/tests/hf_download_test.py
+++ b/tools/tdgpt/tests/hf_download_test.py
@@ -1,0 +1,29 @@
+"""
+Tests for hf_download helpers.
+"""
+import importlib
+import os
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
+
+
+def test_snapshot_download_with_fallback_accepts_positional_args(monkeypatch):
+    module_name = "taosanalytics.misc.hf_download"
+    fake_hf = SimpleNamespace(snapshot_download=mock.Mock(return_value="ok"))
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    hf_download = importlib.import_module(module_name)
+
+    result = hf_download.snapshot_download_with_fallback("repo-id", "local-dir")
+
+    assert result == "ok"
+    fake_hf.snapshot_download.assert_called_once_with(
+        repo_id="repo-id",
+        local_dir="local-dir",
+        endpoint=None,
+    )

--- a/tools/tdgpt/tests/hf_download_test.py
+++ b/tools/tdgpt/tests/hf_download_test.py
@@ -7,22 +7,116 @@ import sys
 from types import SimpleNamespace
 from unittest import mock
 
+import pytest
+
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
 
 
-def test_snapshot_download_with_fallback_accepts_positional_args(monkeypatch):
+def import_hf_download(monkeypatch):
     module_name = "taosanalytics.misc.hf_download"
-    fake_hf = SimpleNamespace(snapshot_download=mock.Mock(return_value="ok"))
+    fake_hf = SimpleNamespace(snapshot_download=mock.Mock())
     monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
     if module_name in sys.modules:
         del sys.modules[module_name]
     hf_download = importlib.import_module(module_name)
+    return hf_download, fake_hf.snapshot_download
 
-    result = hf_download.snapshot_download_with_fallback("repo-id", "local-dir")
+
+def test_parse_bool_false_string(monkeypatch):
+    hf_download, _ = import_hf_download(monkeypatch)
+
+    assert hf_download.parse_bool("False") is False
+
+
+def test_resolve_endpoint_false_string_returns_none(monkeypatch):
+    hf_download, _ = import_hf_download(monkeypatch)
+    monkeypatch.delenv("TAOS_HF_ENDPOINT", raising=False)
+    monkeypatch.delenv("HF_ENDPOINT", raising=False)
+
+    assert hf_download.resolve_endpoint("False") is None
+
+
+def test_resolve_endpoint_env_precedence(monkeypatch):
+    hf_download, _ = import_hf_download(monkeypatch)
+    monkeypatch.setenv("TAOS_HF_ENDPOINT", "https://taos.example")
+    monkeypatch.setenv("HF_ENDPOINT", "https://hf.example")
+
+    assert hf_download.resolve_endpoint(True) == "https://taos.example"
+
+    monkeypatch.delenv("TAOS_HF_ENDPOINT")
+    assert hf_download.resolve_endpoint(True) == "https://hf.example"
+
+    monkeypatch.delenv("HF_ENDPOINT")
+    assert hf_download.resolve_endpoint(True) == hf_download.DEFAULT_HF_MIRROR_ENDPOINT
+
+
+def test_snapshot_download_with_fallback_accepts_positional_enable(monkeypatch):
+    hf_download, snapshot_download = import_hf_download(monkeypatch)
+    snapshot_download.return_value = "ok"
+
+    result = hf_download.snapshot_download_with_fallback("repo-id", "local-dir", True)
 
     assert result == "ok"
-    fake_hf.snapshot_download.assert_called_once_with(
+    snapshot_download.assert_called_once_with(
+        repo_id="repo-id",
+        local_dir="local-dir",
+        endpoint=hf_download.DEFAULT_HF_MIRROR_ENDPOINT,
+    )
+
+
+def test_snapshot_download_with_fallback_calls_official_on_failure(monkeypatch):
+    hf_download, snapshot_download = import_hf_download(monkeypatch)
+    monkeypatch.setenv("TAOS_HF_ENDPOINT", "https://custom.endpoint")
+
+    def side_effect(**kwargs):
+        if kwargs.get("endpoint") == "https://custom.endpoint":
+            raise RuntimeError("boom")
+        return "ok"
+
+    snapshot_download.side_effect = side_effect
+
+    result = hf_download.snapshot_download_with_fallback("repo-id", "local-dir", True)
+
+    assert result == "ok"
+    assert snapshot_download.call_args_list == [
+        mock.call(
+            repo_id="repo-id",
+            local_dir="local-dir",
+            endpoint="https://custom.endpoint",
+        ),
+        mock.call(
+            repo_id="repo-id",
+            local_dir="local-dir",
+            endpoint=hf_download.OFFICIAL_HF_ENDPOINT,
+        ),
+    ]
+
+
+def test_snapshot_download_with_fallback_reraises_official_env_endpoint(monkeypatch):
+    hf_download, snapshot_download = import_hf_download(monkeypatch)
+    monkeypatch.delenv("TAOS_HF_ENDPOINT", raising=False)
+    monkeypatch.setenv("HF_ENDPOINT", hf_download.OFFICIAL_HF_ENDPOINT)
+    snapshot_download.side_effect = RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        hf_download.snapshot_download_with_fallback("repo-id", "local-dir", True)
+
+    snapshot_download.assert_called_once_with(
+        repo_id="repo-id",
+        local_dir="local-dir",
+        endpoint=hf_download.OFFICIAL_HF_ENDPOINT,
+    )
+
+
+def test_snapshot_download_with_fallback_reraises_official(monkeypatch):
+    hf_download, snapshot_download = import_hf_download(monkeypatch)
+    snapshot_download.side_effect = RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        hf_download.snapshot_download_with_fallback("repo-id", "local-dir", False)
+
+    snapshot_download.assert_called_once_with(
         repo_id="repo-id",
         local_dir="local-dir",
         endpoint=None,

--- a/tools/tdgpt/tests/hf_download_test.py
+++ b/tools/tdgpt/tests/hf_download_test.py
@@ -53,6 +53,8 @@ def test_resolve_endpoint_env_precedence(monkeypatch):
 
 def test_snapshot_download_with_fallback_accepts_positional_enable(monkeypatch):
     hf_download, snapshot_download = import_hf_download(monkeypatch)
+    monkeypatch.delenv("TAOS_HF_ENDPOINT", raising=False)
+    monkeypatch.delenv("HF_ENDPOINT", raising=False)
     snapshot_download.return_value = "ok"
 
     result = hf_download.snapshot_download_with_fallback("repo-id", "local-dir", True)

--- a/tools/tdgpt/tests/model_downloader_test.py
+++ b/tools/tdgpt/tests/model_downloader_test.py
@@ -1,0 +1,36 @@
+import os
+import runpy
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+tdgpt_root = os.path.dirname(os.path.abspath(__file__)) + "/.."
+sys.path.append(tdgpt_root)
+sys.path.append(os.path.join(tdgpt_root, "taosanalytics", "misc"))
+
+
+def test_model_downloader_invalid_bool_exits(monkeypatch, capsys):
+    monkeypatch.setitem(
+        sys.modules,
+        "tqdm",
+        SimpleNamespace(tqdm=lambda items: items),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(snapshot_download=mock.Mock()),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["model_downloader.py", "model_dir", "model_name", "notabool"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_module("taosanalytics.misc.model_downloader", run_name="__main__")
+
+    assert excinfo.value.code == 1
+    assert "notabool" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Launch TDgpt non-tdtsfm model servers with argparse flags from Docker entrypoint.
- Add shared Hugging Face download helper with correct boolean parsing, endpoint override support, and fallback from non-official endpoints to official Hugging Face.
- Wire Docker downloader and non-tdtsfm model service scripts to the helper, with focused tests for endpoint/fallback behavior.

## Test Plan
- [x] python3 -m pytest tools/tdgpt/tests/hf_download_test.py tools/tdgpt/tests/model_downloader_test.py -q
- [x] python3 -m py_compile tools/tdgpt/taosanalytics/misc/hf_download.py tools/tdgpt/taosanalytics/misc/model_downloader.py tools/tdgpt/taosanalytics/tsfmservice/chronos-server.py tools/tdgpt/taosanalytics/tsfmservice/timemoe-server.py tools/tdgpt/taosanalytics/tsfmservice/timesfm-server.py tools/tdgpt/taosanalytics/tsfmservice/moirai-server.py tools/tdgpt/taosanalytics/tsfmservice/moment-server.py
- [x] git diff --check
- [x] In-image validation on 192.168.3.91 with tdengine/tdgpt-arm64:3.4.1.9 for False parsing and endpoint fallback call sequence