### PR TITLE
docs: fix includes for taosbenchmark

### DIFF
--- a/docs/en/14-reference/02-tools/10-taosbenchmark.md
+++ b/docs/en/14-reference/02-tools/10-taosbenchmark.md
@@ -498,7 +498,7 @@ Below are a few examples of configuration files:
 <summary>insert.json</summary>
 
 ```json
-{{#include source/taos-community/tools/taos-tools/example/insert.json}}
+{{#include tools/taos-tools/example/insert.json}}
 ```
 
 </details>
@@ -509,7 +509,7 @@ Below are a few examples of configuration files:
 <summary>query.json</summary>
 
 ```json
-{{#include source/taos-community/tools/taos-tools/example/query.json}}
+{{#include tools/taos-tools/example/query.json}}
 ```
 
 </details>
@@ -518,7 +518,7 @@ Below are a few examples of configuration files:
 <summary>queryStb.json</summary>
 
 ```json
-{{#include source/taos-community/tools/taos-tools/example/queryStb.json}}
+{{#include tools/taos-tools/example/queryStb.json}}
 ```
 
 </details>
@@ -529,7 +529,7 @@ Below are a few examples of configuration files:
 <summary>tmq.json</summary>
 
 ```json
-{{#include source/taos-community/tools/taos-tools/example/tmq.json}}
+{{#include tools/taos-tools/example/tmq.json}}
 ```
 
 </details>
@@ -540,7 +540,7 @@ Below are a few examples of configuration files:
 <summary>csv-export.json</summary>
 
 ```json
-{{#include source/taos-community/tools/taos-tools/example/csv-export.json}}
+{{#include tools/taos-tools/example/csv-export.json}}
 ```
 
 </details>

--- a/docs/zh/14-reference/02-tools/10-taosbenchmark.md
+++ b/docs/zh/14-reference/02-tools/10-taosbenchmark.md
@@ -424,7 +424,7 @@ taosBenchmark -f <json file>
 <summary>insert.json</summary>
 
 ```json
-{{#include source/taos-community/tools/taos-tools/example/insert.json}}
+{{#include tools/taos-tools/example/insert.json}}
 ```
 
 </details>
@@ -435,7 +435,7 @@ taosBenchmark -f <json file>
 <summary>query.json</summary>
 
 ```json
-{{#include source/taos-community/tools/taos-tools/example/query.json}}
+{{#include tools/taos-tools/example/query.json}}
 ```
 
 </details>
@@ -444,7 +444,7 @@ taosBenchmark -f <json file>
 <summary>queryStb.json</summary>
 
 ```json
-{{#include source/taos-community/tools/taos-tools/example/queryStb.json}}
+{{#include tools/taos-tools/example/queryStb.json}}
 ```
 
 </details>
@@ -455,7 +455,7 @@ taosBenchmark -f <json file>
 <summary>tmq.json</summary>
 
 ```json
-{{#include source/taos-community/tools/taos-tools/example/tmq.json}}
+{{#include tools/taos-tools/example/tmq.json}}
 ```
 
 </details>
@@ -466,7 +466,7 @@ taosBenchmark -f <json file>
 <summary>csv-export.json</summary>
 
 ```json
-{{#include source/taos-community/tools/taos-tools/example/csv-export.json}}
+{{#include tools/taos-tools/example/csv-export.json}}
 ```
 
 </details>


### PR DESCRIPTION
use partial link for included files for compatibility purposes