### PR TITLE
fix(docker): taosd 被 OOM 杀掉时让容器退出，让 --restart 拉起来 (#34179)

### DIFF
--- a/packaging/docker/bin/entrypoint.sh
+++ b/packaging/docker/bin/entrypoint.sh
@@ -53,12 +53,19 @@ fi
 
 NEEDS_INITDB=0
 
+# PIDs of every long-running child we start. Used by the watchdog at the bottom
+# of this script to take the whole container down if any single one of them
+# dies (#34179). Without this, taosd being OOM-killed would leave the container
+# alive (taosadapter still up) and Docker's --restart would never fire.
+PIDS=""
+
 # if dnode has been created or has mnode ep set or the host is first ep or not for cluster, just start.
 if [ -f "$DATA_DIR/dnode/dnode.json" ] ||
     [ -f "$DATA_DIR/dnode/mnodeEpSet.json" ] ||
     [ "$FQDN" = "$FIRST_EP_HOST" ]; then
     echo "start taosd with mnode ep set"
     taosd &
+    PIDS="$PIDS $!"
     while true; do
         es=$(taos -h $FIRST_EP_HOST -P $FIRST_EP_PORT --check | grep "^[0-9]*:")
         echo ${es}
@@ -88,6 +95,7 @@ else
     if [ "$TAOS_FIRST_EP" = "" ]; then
         echo "run TDengine with single node."
         taosd &
+        PIDS="$PIDS $!"
     fi
     while true; do
         es=$(taos -h $FIRST_EP_HOST -P $FIRST_EP_PORT --check | grep "^[0-9]*:")
@@ -101,8 +109,9 @@ else
     done
 fi
 
-if [ "$DISABLE_ADAPTER" = "0" ]; then
-    which taosadapter >/dev/null && taosadapter &
+if [ "$DISABLE_ADAPTER" = "0" ] && which taosadapter >/dev/null; then
+    taosadapter &
+    PIDS="$PIDS $!"
     # wait for 6041 port ready
     for _ in $(seq 1 20); do
         curl -sf http://localhost:6041/metrics && break
@@ -110,9 +119,10 @@ if [ "$DISABLE_ADAPTER" = "0" ]; then
     done
 fi
 
-if [ "$DISABLE_KEEPER" = "0" ]; then
+if [ "$DISABLE_KEEPER" = "0" ] && which taoskeeper >/dev/null; then
     sleep 3
-    which taoskeeper >/dev/null && taoskeeper &
+    taoskeeper &
+    PIDS="$PIDS $!"
     # wait for 6043 port ready
     for _ in $(seq 1 20); do
         curl -sf http://localhost:6043/metrics && break
@@ -120,8 +130,9 @@ if [ "$DISABLE_KEEPER" = "0" ]; then
     done
 fi
 
-if [ "$DISABLE_EXPLORER" = "0" ]; then
-    which taos-explorer >/dev/null && taos-explorer &
+if [ "$DISABLE_EXPLORER" = "0" ] && which taos-explorer >/dev/null; then
+    taos-explorer &
+    PIDS="$PIDS $!"
     # wait for 6060 port ready
     for _ in $(seq 1 20); do
         curl -sf http://localhost:6060/metrics && break
@@ -158,5 +169,31 @@ fi
 
 sh -c "taos -p'$TAOS_ROOT_PASSWORD' -h $FIRST_EP_HOST -P $FIRST_EP_PORT -s 'create snode on dnode 1;'"
 
-trap 'echo "Received stop signal, killing children"; pkill -P $$ || true; exit 0' SIGINT SIGTERM
-wait
+trap 'echo "Received stop signal, killing children"; pkill -P $$ 2>/dev/null || true; exit 0' SIGINT SIGTERM
+
+# Watchdog: if any of taosd / taosadapter / taoskeeper / taos-explorer dies
+# (e.g. taosd OOM-killed), tear the whole container down so Docker's --restart
+# can bring it back. Before this, only taosd dying would silently leave
+# taosadapter accepting requests it could not fulfill (#34179).
+#
+# Polling instead of `wait -n` keeps this compatible with bash versions that
+# do not support `-n`; the 2s tick is negligible CPU.
+if [ -z "$PIDS" ]; then
+    # cluster non-first node with every sidecar disabled — nothing to watch.
+    # Stay alive so the trap above can still catch docker stop signals.
+    echo "No background TDengine processes to watch; idling"
+    while true; do sleep 3600; done
+fi
+
+echo "All services started, watching child processes: $PIDS"
+while true; do
+    for pid in $PIDS; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo "child process $pid exited; shutting container down so Docker can restart it"
+            pkill -P $$ 2>/dev/null || true
+            sleep 1
+            exit 1
+        fi
+    done
+    sleep 2
+done

--- a/packaging/docker/bin/entrypoint.sh
+++ b/packaging/docker/bin/entrypoint.sh
@@ -59,6 +59,23 @@ NEEDS_INITDB=0
 # alive (taosadapter still up) and Docker's --restart would never fire.
 PIDS=""
 
+# Install cleanup traps early so that *any* exit path (signal, set -e, watchdog)
+# still tears down the background children we are about to start. Without an
+# EXIT trap, a `set -e` failure during initdb / create-dnode / create-snode
+# would leave orphans behind for tini to reap, and the container would just
+# blink instead of going through the normal "restart" loop.
+cleanup_children() {
+    # Use the saved PIDS first so we don't accidentally signal anything else
+    # tini may have adopted. pkill -P $$ is the safety net for anything
+    # backgrounded that we forgot to record.
+    for pid in $PIDS; do
+        kill -TERM "$pid" 2>/dev/null || true
+    done
+    pkill -P $$ 2>/dev/null || true
+}
+trap 'echo "Received stop signal, killing children"; cleanup_children; exit 0' SIGINT SIGTERM
+trap 'rc=$?; if [ "$rc" -ne 0 ]; then echo "entrypoint exiting abnormally (rc=$rc), killing children"; cleanup_children; fi' EXIT
+
 # if dnode has been created or has mnode ep set or the host is first ep or not for cluster, just start.
 if [ -f "$DATA_DIR/dnode/dnode.json" ] ||
     [ -f "$DATA_DIR/dnode/mnodeEpSet.json" ] ||
@@ -169,8 +186,6 @@ fi
 
 sh -c "taos -p'$TAOS_ROOT_PASSWORD' -h $FIRST_EP_HOST -P $FIRST_EP_PORT -s 'create snode on dnode 1;'"
 
-trap 'echo "Received stop signal, killing children"; pkill -P $$ 2>/dev/null || true; exit 0' SIGINT SIGTERM
-
 # Watchdog: if any of taosd / taosadapter / taoskeeper / taos-explorer dies
 # (e.g. taosd OOM-killed), tear the whole container down so Docker's --restart
 # can bring it back. Before this, only taosd dying would silently leave
@@ -178,9 +193,13 @@ trap 'echo "Received stop signal, killing children"; pkill -P $$ 2>/dev/null || 
 #
 # Polling instead of `wait -n` keeps this compatible with bash versions that
 # do not support `-n`; the 2s tick is negligible CPU.
+# Cleanup traps were installed at the top of this script — both the SIGINT/
+# SIGTERM and the EXIT trap call cleanup_children, so we don't need to repeat
+# the pkill plumbing here.
+
 if [ -z "$PIDS" ]; then
     # cluster non-first node with every sidecar disabled — nothing to watch.
-    # Stay alive so the trap above can still catch docker stop signals.
+    # Stay alive so the SIGINT/SIGTERM trap can still stop the container.
     echo "No background TDengine processes to watch; idling"
     while true; do sleep 3600; done
 fi
@@ -190,7 +209,8 @@ while true; do
     for pid in $PIDS; do
         if ! kill -0 "$pid" 2>/dev/null; then
             echo "child process $pid exited; shutting container down so Docker can restart it"
-            pkill -P $$ 2>/dev/null || true
+            # cleanup_children runs via the EXIT trap; just give children a
+            # beat to actually wind down before we let the container exit.
             sleep 1
             exit 1
         fi

--- a/packaging/docker/bin/entrypoint.sh
+++ b/packaging/docker/bin/entrypoint.sh
@@ -74,7 +74,26 @@ cleanup_children() {
     pkill -P $$ 2>/dev/null || true
 }
 trap 'echo "Received stop signal, killing children"; cleanup_children; exit 0' SIGINT SIGTERM
-trap 'rc=$?; if [ "$rc" -ne 0 ]; then echo "entrypoint exiting abnormally (rc=$rc), killing children"; cleanup_children; fi' EXIT
+# EXIT trap: capture the script's exit code BEFORE running cleanup (pkill etc.
+# would otherwise overwrite $?), then re-exit with that same code so Docker
+# sees the real cause instead of the trap helpers' last status.
+trap 'rc=$?; if [ "$rc" -ne 0 ]; then echo "entrypoint exiting abnormally (rc=$rc), killing children"; cleanup_children; fi; exit "$rc"' EXIT
+
+# Wait up to ~10s for a service's metrics endpoint to come up. If the service
+# process itself dies in the meantime (immediate crash on bad config, port
+# in use, etc.) fail fast instead of burning the full timeout in silence.
+# Per gemini-code-assist review on PR #35368.
+wait_for_metric_or_die() {
+    local svc=$1 pid=$2 url=$3
+    for _ in $(seq 1 20); do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo "$svc (pid $pid) died during startup; aborting entrypoint" >&2
+            exit 1
+        fi
+        curl -sf "$url" && return 0
+        sleep 0.5
+    done
+}
 
 # if dnode has been created or has mnode ep set or the host is first ep or not for cluster, just start.
 if [ -f "$DATA_DIR/dnode/dnode.json" ] ||
@@ -82,11 +101,21 @@ if [ -f "$DATA_DIR/dnode/dnode.json" ] ||
     [ "$FQDN" = "$FIRST_EP_HOST" ]; then
     echo "start taosd with mnode ep set"
     taosd &
-    PIDS="$PIDS $!"
+    TAOSD_PID=$!
+    PIDS="$PIDS $TAOSD_PID"
     while true; do
-        es=$(taos -h $FIRST_EP_HOST -P $FIRST_EP_PORT --check | grep "^[0-9]*:")
+        # If taosd died during startup, fail fast instead of looping forever
+        # waiting for `taos --check` to succeed against a dead server.
+        if ! kill -0 "$TAOSD_PID" 2>/dev/null; then
+            echo "taosd (pid $TAOSD_PID) died during startup; aborting entrypoint" >&2
+            exit 1
+        fi
+        # `|| true` keeps a transient connection error from tripping set -e while
+        # we're still polling for taosd to come up; the kill -0 above is the
+        # authoritative "did the process die" check.
+        es=$(taos -h $FIRST_EP_HOST -P $FIRST_EP_PORT --check 2>/dev/null | grep "^[0-9]*:" || true)
         echo ${es}
-        if [ "${es%%:*}" -eq 2 ]; then
+        if [ -n "$es" ] && [ "${es%%:*}" = "2" ]; then
 
             # Initialization scripts should only work in first node.
             if [ "$FQDN" = "$FIRST_EP_HOST" ]; then
@@ -109,15 +138,26 @@ if [ -f "$DATA_DIR/dnode/dnode.json" ] ||
     done
 # others will first wait the first ep ready.
 else
+    TAOSD_PID=""
     if [ "$TAOS_FIRST_EP" = "" ]; then
         echo "run TDengine with single node."
         taosd &
-        PIDS="$PIDS $!"
+        TAOSD_PID=$!
+        PIDS="$PIDS $TAOSD_PID"
     fi
     while true; do
-        es=$(taos -h $FIRST_EP_HOST -P $FIRST_EP_PORT --check | grep "^[0-9]*:")
+        # If we started taosd locally and it died early, fail fast.
+        # Cluster non-first nodes (TAOSD_PID empty) wait for the remote first EP.
+        if [ -n "$TAOSD_PID" ] && ! kill -0 "$TAOSD_PID" 2>/dev/null; then
+            echo "taosd (pid $TAOSD_PID) died during startup; aborting entrypoint" >&2
+            exit 1
+        fi
+        # `|| true` keeps a transient connection error from tripping set -e while
+        # we're still polling for taosd to come up; the kill -0 above is the
+        # authoritative "did the process die" check.
+        es=$(taos -h $FIRST_EP_HOST -P $FIRST_EP_PORT --check 2>/dev/null | grep "^[0-9]*:" || true)
         echo ${es}
-        if [ "${es%%:*}" -eq 2 ]; then
+        if [ -n "$es" ] && [ "${es%%:*}" = "2" ]; then
             echo "execute create dnode"
             sh -c "taos -p'$TAOS_ROOT_PASSWORD' -h $FIRST_EP_HOST -P $FIRST_EP_PORT -s 'create dnode \"$FQDN:$SERVER_PORT\";'"
             break
@@ -128,33 +168,24 @@ fi
 
 if [ "$DISABLE_ADAPTER" = "0" ] && which taosadapter >/dev/null; then
     taosadapter &
-    PIDS="$PIDS $!"
-    # wait for 6041 port ready
-    for _ in $(seq 1 20); do
-        curl -sf http://localhost:6041/metrics && break
-        sleep 0.5
-    done
+    TAOSADAPTER_PID=$!
+    PIDS="$PIDS $TAOSADAPTER_PID"
+    wait_for_metric_or_die taosadapter "$TAOSADAPTER_PID" http://localhost:6041/metrics
 fi
 
 if [ "$DISABLE_KEEPER" = "0" ] && which taoskeeper >/dev/null; then
     sleep 3
     taoskeeper &
-    PIDS="$PIDS $!"
-    # wait for 6043 port ready
-    for _ in $(seq 1 20); do
-        curl -sf http://localhost:6043/metrics && break
-        sleep 0.5
-    done
+    TAOSKEEPER_PID=$!
+    PIDS="$PIDS $TAOSKEEPER_PID"
+    wait_for_metric_or_die taoskeeper "$TAOSKEEPER_PID" http://localhost:6043/metrics
 fi
 
 if [ "$DISABLE_EXPLORER" = "0" ] && which taos-explorer >/dev/null; then
     taos-explorer &
-    PIDS="$PIDS $!"
-    # wait for 6060 port ready
-    for _ in $(seq 1 20); do
-        curl -sf http://localhost:6060/metrics && break
-        sleep 0.5
-    done
+    TAOSEXPLORER_PID=$!
+    PIDS="$PIDS $TAOSEXPLORER_PID"
+    wait_for_metric_or_die taos-explorer "$TAOSEXPLORER_PID" http://localhost:6060/metrics
 fi
 
 if [ "$NEEDS_INITDB" = "1" ]; then


### PR DESCRIPTION
issue [#34179](https://github.com/taosdata/TDengine/issues/34179)：`tsdb:3.3.8.4` 容器里 taosd 被系统 OOM 杀掉之后，taosadapter 还在跑，容器对 Docker 仍然显示 healthy，`--restart unless-stopped` 永远不会触发，服务实际已挂死。

## 原因

`packaging/docker/bin/entrypoint.sh` 末尾是 `wait`，这条命令只在**所有**后台子进程都退出后才返回。taosd 被杀以后，taosadapter / taoskeeper / taos-explorer 任何一个还活着，`wait` 就继续阻塞，PID 1 不退出，Docker 不重启。

## 改动

- 每个 `&` 启动的关键进程（taosd、taosadapter、taoskeeper、taos-explorer）把 `$!` 追加到 `PIDS`
- 末尾的 `wait` 换成 watchdog：每 2s 检查一次 `PIDS` 里每个 PID，**任意一个**死了就 `pkill -P $$` 把兄弟进程清掉、`exit 1`
- 容器以非 0 退出后 Docker 的 `--restart` 策略就会把它拉起来
- `which xxx` 检查从命令链改成 `if` 守卫，跳过未安装时不会留空 PID 进 `PIDS`
- 边角情况：cluster non-first 节点且所有 sidecar 都 disable 时 `PIDS` 为空，进 idle 循环让 SIGINT/SIGTERM trap 仍然能停容器

用 polling 而不是 `wait -n` 是为了不依赖 bash 4.3+；2s 心跳的 CPU 开销可以忽略。

## 端到端验证

在 lvm1 上用 `tdengine/tdengine:latest`（server 3.3.6.13）跑三个 case：

| step | scenario | 期望 | 实测 |
|---|---|---|---|
| 1 | stock entrypoint + `pkill -9 taosd` | bug：容器仍 Running、taosadapter 还活着 | ✓ `Running=true ExitCode=0`，`pgrep taosadapter` 返回 PID 416 |
| 2 | fix entrypoint mount 进去 + `pkill -9 taosd` | 容器 Exited(1) | ✓ `Running=false ExitCode=1`；log 末尾 `child process 44 exited; shutting container down so Docker can restart it` |
| 3 | step 2 基础上加 `--restart unless-stopped` | Docker 自动拉起，`RestartCount` +1 | ✓ `RestartCount=1`，`State.StartedAt` 已经被刷新 |

复现命令（lvm1 / Ubuntu 22.04 / Docker 28.2.2）：

```bash
# bug 复现
docker run -d --name t1 -e TAOS_DISABLE_KEEPER=1 -e TAOS_DISABLE_EXPLORER=1 \
    tdengine/tdengine:latest
sleep 30 && docker exec t1 pkill -9 taosd && sleep 5
docker inspect t1 --format '{{.State.Running}} {{.State.ExitCode}}'   # → true 0

# fix 验证（mount 修复后的 entrypoint）
docker run -d --name t2 --restart unless-stopped \
    -e TAOS_DISABLE_KEEPER=1 -e TAOS_DISABLE_EXPLORER=1 \
    -v $(pwd)/entrypoint.sh:/usr/bin/entrypoint.sh:ro \
    tdengine/tdengine:latest
sleep 30 && docker exec t2 pkill -9 taosd && sleep 15
docker inspect t2 --format '{{.RestartCount}} {{.State.Running}}'      # → 1 true
```

## 行为变化

- **服务都健康时**：行为不变（watchdog 只是空跑）。
- **任一关键进程死了**：容器以 ExitCode=1 退出，`--restart` 重新拉起，原 `wait` 实现里是"容器假活"——这才是 issue 报告的真问题。
- **docker stop / Ctrl-C**：现有的 SIGINT/SIGTERM trap 不变，`pkill -P $$` 清理子进程后 exit 0。
- **edge case**：PIDS 为空时进 idle 等信号，trap 仍能停。
- **进程依赖**：watchdog 一视同仁地看四个关键进程；taosadapter 单独崩同样会让容器重启——这跟 taosd 单独崩对称，是 issue reporter 期望的语义（"挂掉了假死会丢数据"）。

Refs #34179