### PR TITLE
[3.4.0] backport: wait for in-flight stream timer callbacks before cleanup (fix UAF)

### DIFF
--- a/source/libs/new-stream/inc/streamInt.h
+++ b/source/libs/new-stream/inc/streamInt.h
@@ -90,6 +90,23 @@ typedef struct SStreamMgmtInfo {
   SHashObj*              vgroupMap;                       // vgId => SStreamVgReaderTasks
 
   SArray*                snodeTasks;                      // SArray<SStreamTask*>
+
+  // Cleanup gating for stream timer callbacks.
+  //   tmrStopped:  set to 1 by streamCleanup before tearing down shared state.
+  //                streamTmrStart() checks this flag and refuses to (re-)arm
+  //                any stream timer once cleanup has been signaled, so timer
+  //                callbacks can no longer be scheduled.
+  //   tmrInflight: bumped on entry of every stream timer callback (via the
+  //                STREAM_TMR_CB_ENTER / STREAM_TMR_CB_LEAVE macros below)
+  //                and decremented at exit; streamTmrWaitAllCallbacks()
+  //                spins until it observes zero so that streamCleanup never
+  //                frees state a callback is still dereferencing.  The
+  //                increment MUST happen before the tmrStopped load
+  //                (publish-before-check) to close the TOCTOU window with
+  //                the cleaner; the macros below encode that order, do not
+  //                hand-roll it at the call site.
+  volatile int8_t        tmrStopped;
+  volatile int32_t       tmrInflight;
 } SStreamMgmtInfo;
 
 extern SStreamMgmtInfo gStreamMgmt;
@@ -129,10 +146,40 @@ int32_t streamSendNotifyContent(SStreamTask* pTask, const char* streamName, cons
 int32_t readStreamDataCache(int64_t streamId, int64_t taskId, int64_t sessionId, int64_t groupId, TSKEY start,
                             TSKEY end, void*** pppIter);
 void streamTimerCleanUp();
+void streamTmrWaitAllCallbacks(void);
 void smRemoveTaskPostCheck(int64_t streamId, SStreamInfo* pStream, bool* isLastTask);
 void streamTmrStop(tmr_h tmrId);
 void smEnableVgDeploy(int32_t vgId);
 void smUndeployStreamTriggerTasks(SStreamInfo* pStream, int64_t streamId);
+
+// Stream timer callback entry/leave protocol.
+// MUST be used by every callback installed via streamTmrStart so that
+// streamCleanup can drain in-flight callbacks before freeing shared state.
+// See SStreamMgmtInfo.tmrStopped / tmrInflight for the protocol overview.
+//
+// Ordering is publish-before-check (inflight++ then load tmrStopped) to
+// close the TOCTOU window with streamTmrWaitAllCallbacks().  Do NOT hand
+// roll this protocol at the call site; adding a new stream timer callback
+// just means wrapping its body in the two macros below.
+//
+// Usage:
+//   static void myCallback(void *param, void *tmrId) {
+//     STREAM_TMR_CB_ENTER("my-cb");   // returns early if cleanup started
+//     ... callback body, may self re-arm via streamTmrStart ...
+//     STREAM_TMR_CB_LEAVE();           // MUST be the last statement
+//   }
+#define STREAM_TMR_CB_ENTER(_name)                                  \
+  do {                                                              \
+    atomic_add_fetch_32(&gStreamMgmt.tmrInflight, 1);               \
+    if (atomic_load_8(&gStreamMgmt.tmrStopped)) {                   \
+      atomic_sub_fetch_32(&gStreamMgmt.tmrInflight, 1);             \
+      stTrace("%s skipped: timer stopped", (_name));                \
+      return;                                                       \
+    }                                                               \
+  } while (0)
+
+#define STREAM_TMR_CB_LEAVE() \
+  (void)atomic_sub_fetch_32(&gStreamMgmt.tmrInflight, 1)
 
 #ifdef __cplusplus
 }

--- a/source/libs/new-stream/src/stream.c
+++ b/source/libs/new-stream/src/stream.c
@@ -62,6 +62,24 @@ void streamCleanup(void) {
   }
   
   stInfo("stream cleanup start");
+
+  // Phase 1: stop the hb timer up-front and wait until every callback that was
+  // already in flight has finished, so no stream callback can dereference
+  // module state after this point.  This MUST happen before any per-module
+  // free runs, otherwise we race into a heap-use-after-free (see
+  // streamUtil.c:stmHbAddStreamStatus).
+  atomic_store_8(&gStreamMgmt.tmrStopped, 1);
+  streamTmrStop(gStreamMgmt.hb.hbTmr);
+  streamTmrWaitAllCallbacks();
+
+  // Phase 2: now that no in-flight stream timer callback can be running
+  // (Phase 1 set tmrStopped=1 and streamTmrWaitAllCallbacks drained every
+  // callback, including the trigger one), per-module cleanups only need
+  // to do passive teardown.  Note that stTriggerTaskEnvCleanup() itself
+  // does NOT synchronously wait for the trigger callback -- it just calls
+  // streamTmrStop, which only cancels callbacks still in the timer wheel.
+  // Safety here relies entirely on Phase 1; do not skip Phase 1 thinking
+  // any per-module cleanup will rescue you.
   stTriggerTaskEnvCleanup();
   streamTimerCleanUp();
   smUndeployAllTasks();
@@ -84,6 +102,11 @@ int32_t streamInit(void* pDnode, getDnodeId_f getDnode, getMnodeEpset_f getMnode
   gStreamMgmt.getMnode = getMnode;
   gStreamMgmt.getDnode = getDnode;
   gStreamMgmt.getSynEpset = getSynEpset;
+
+  // Reset cleanup gating in case dnode is being re-initialized after a
+  // previous streamCleanup() within the same process.
+  atomic_store_8(&gStreamMgmt.tmrStopped, 0);
+  atomic_store_32(&gStreamMgmt.tmrInflight, 0);
 
   gStreamMgmt.vgLeaders = taosArrayInit(20, sizeof(int32_t));
   TSDB_CHECK_NULL(gStreamMgmt.vgLeaders, code, lino, _exit, terrno);

--- a/source/libs/new-stream/src/streamHb.c
+++ b/source/libs/new-stream/src/streamHb.c
@@ -113,8 +113,10 @@ void streamHbStart(void* param, void* tmrId) {
   SStreamHbMsg reqMsg = {0};
   SEpSet epSet = {0};
 
+  STREAM_TMR_CB_ENTER("stream hb");
+
   stTrace("stream hb begin");
-  
+
   TAOS_CHECK_EXIT(streamHbBuildRequestMsg(&reqMsg, &skipHb));
   if (skipHb) {
     stTrace("stream hb skipped");
@@ -135,6 +137,8 @@ _exit:
   } else {
     stTrace("stream hb end");
   }
+
+  STREAM_TMR_CB_LEAVE();
 }
 
 int32_t streamHbInit(SStreamHbInfo* pHb) {

--- a/source/libs/new-stream/src/streamTimer.c
+++ b/source/libs/new-stream/src/streamTimer.c
@@ -14,6 +14,7 @@
  */
 
 #include "streamInt.h"
+#include "osSleep.h"
 #include "ttimer.h"
 
 int32_t streamTimerInit(void** ppTimer) {
@@ -33,6 +34,17 @@ int32_t streamTimerGetInstance(tmr_h* pTmr) {
 }
 
 void streamTmrStart(TAOS_TMR_CALLBACK fp, int32_t mseconds, void* pParam, void* pHandle, tmr_h* pTmrId, const char* pMsg) {
+  // Refuse to (re-)arm any stream timer once cleanup has been signaled. Without
+  // this gate, the timer callbacks (streamHbStart, stTriggerTaskCheckWaitSession)
+  // would keep re-scheduling themselves from their _exit path and race with
+  // streamMgmtCleanup() / stTriggerTaskEnvCleanup() that frees the very objects
+  // those callbacks dereference, producing an ASan UAF in atomic_store_32 /
+  // taosWUnLockLatch (see streamUtil.c stmHbAddStreamStatus).
+  if (atomic_load_8(&gStreamMgmt.tmrStopped)) {
+    stTrace("stream timer stopped, skip start %s tmr", pMsg);
+    return;
+  }
+
   if (*pTmrId == NULL) {
     *pTmrId = taosTmrStart(fp, mseconds, pParam, pHandle);
     if (*pTmrId == NULL) {
@@ -57,10 +69,52 @@ void streamTmrStop(tmr_h tmrId) {
   }
 }
 
+// Spin-wait until every stream timer callback that may have already been
+// dispatched (and is therefore beyond the reach of taosTmrStop) has finished.
+//
+// Caller MUST set gStreamMgmt.tmrStopped = 1 before invoking this helper,
+// otherwise a callback could re-arm itself after we observe zero inflight and
+// race with subsequent cleanup.
+//
+// On hard-cap timeout we log an error and return rather than abort: aborting
+// during dnode shutdown would mask the real defect with a SIGABRT crash dump.
+// The hard cap is a last-resort safety valve to keep shutdown from hanging
+// forever; if it ever trips, the error log is the signal to investigate the
+// stuck callback.
+void streamTmrWaitAllCallbacks(void) {
+  const int32_t poll_ms       = 10;
+  const int32_t warn_step_ms  = 1000;
+  const int32_t hard_cap_ms   = 30000;
+
+  int32_t waited = 0;
+  int32_t inflight;
+  while ((inflight = atomic_load_32(&gStreamMgmt.tmrInflight)) > 0) {
+    if (waited == 0) {
+      stDebug("waiting for stream timer callbacks to drain, inflight:%d", inflight);
+    } else if (waited % warn_step_ms == 0) {
+      stWarn("still waiting for stream timer callbacks, inflight:%d, waited:%dms",
+             inflight, waited);
+    }
+    if (waited >= hard_cap_ms) {
+      stError("stream timer callbacks drain timeout, inflight:%d still running after %dms, giving up "
+              "to avoid blocking shutdown indefinitely (subsequent cleanup may race)",
+              inflight, waited);
+      return;
+    }
+    taosMsleep(poll_ms);
+    waited += poll_ms;
+  }
+  stDebug("stream timer callbacks drained after %dms", waited);
+}
+
 
 void streamTimerCleanUp() {
   stInfo("cleanup stream timer, %p", gStreamMgmt.timer);
-  streamTmrStop(gStreamMgmt.hb.hbTmr);
+
+  // NOTE: tmrStopped has already been set by streamCleanup() before any
+  // module-level cleanup ran, and streamTmrWaitAllCallbacks() has already
+  // drained every in-flight callback.  At this point no callback can be
+  // executing or pending in the wheel, so it is safe to tear the module down.
   taosTmrCleanUp(gStreamMgmt.timer);
   gStreamMgmt.timer = NULL;
 }

--- a/source/libs/new-stream/src/streamTriggerTask.c
+++ b/source/libs/new-stream/src/streamTriggerTask.c
@@ -164,6 +164,8 @@ static void stTriggerTaskCheckWaitSession(void *param, void *tmrId) {
   SListNode *pNode = NULL;
   SList      readylist = {0};
 
+  STREAM_TMR_CB_ENTER("stream trigger check");
+
   taosWLockLatch(&gStreamTriggerWaitLatch);
   tdListInitIter(&gStreamTriggerWaitList, &iter, TD_LIST_FORWARD);
   while ((pNode = tdListNext(&iter)) != NULL) {
@@ -231,6 +233,12 @@ static void stTriggerTaskCheckWaitSession(void *param, void *tmrId) {
 
   streamTmrStart(stTriggerTaskCheckWaitSession, STREAM_TRIGGER_CHECK_INTERVAL_MS, NULL, gStreamMgmt.timer,
                  &gStreamTriggerTimerId, "stream-trigger");
+
+  // The self re-arm above is gated by tmrStopped inside streamTmrStart(),
+  // so once cleanup has begun no new dispatch can sneak in here.  Keep the
+  // LEAVE as the last statement so cleanup sees inflight drop to zero only
+  // after every shared object access has completed.
+  STREAM_TMR_CB_LEAVE();
   return;
 }
 


### PR DESCRIPTION
3.4.0 is missing the stream-timer UAF fix that's on the default branch (9578518cc1). On 3.4.0, stream cleanup tears down state without waiting for in-flight timer callbacks to drain — a timer callback can fire and read the freed stream object, use-after-free.

checked it actually races on 3.4.0 (not just a missing line): modeled the timer-callback vs cleanup control flow with -fsanitize=address on ubuntu:22.04 — pre-fix a timer thread reads the freed object (ASan use-after-free), with the fix's drain-before-cleanup applied the callback is awaited and it's clean. it's a teardown race so it needs the timer in flight during cleanup.

clean cherry-pick (-x), original author (mmwang) preserved; dropped the bundled tmq test changes that don't apply to 3.4.0's test layout, kept the core fix (5 files). happy to rebase.

upstream: https://github.com/taosdata/TDengine/commit/9578518cc1