### PR TITLE
 fix(gpt): fix errors in generating candidate window when exclude_overlap and exclude_source are both set.

### DIFF
--- a/tools/tdgpt/requirements.txt
+++ b/tools/tdgpt/requirements.txt
@@ -7,7 +7,6 @@ cycler==0.12.1
 filelock==3.20.3
 fonttools==4.54.1
 fsspec==2024.2.0
-h5py==3.12.1
 itsdangerous==2.2.0
 Jinja2==3.1.6
 joblib==1.4.2

--- a/tools/tdgpt/requirements.txt
+++ b/tools/tdgpt/requirements.txt
@@ -26,7 +26,7 @@ pytz==2024.2
 rich==13.9.2
 rstl==0.1.3
 six==1.16.0
-sympy==1.12
+sympy==1.13.1
 threadpoolctl==3.5.0
 urllib3==2.7.0
 Flask-Testing==0.8.1

--- a/tools/tdgpt/requirements_docker.txt
+++ b/tools/tdgpt/requirements_docker.txt
@@ -16,7 +16,7 @@ matplotlib==3.9.2
 gunicorn==23.0.0
 --only-binary h5py
 h5py>=3.10,<3.13 
-keras==3.9.0
+keras==3.12.0
 taospy
 cmdstanpy==1.2.0
 fastdtw==0.3.4

--- a/tools/tdgpt/taosanalytics/algo/tool/profile_search.py
+++ b/tools/tdgpt/taosanalytics/algo/tool/profile_search.py
@@ -288,7 +288,7 @@ def _build_window_candidates_from_series(ts_vals, data_vals, source_len: int, mi
 
 
 def _build_candidates_from_profiles(ts_vals, profiles, min_window, max_window,
-                                    exclude_source=False, source_ts_window=None):
+                                    exclude_source=False, exclude_overlap=False, source_ts_window=None):
     if not isinstance(profiles, list) or len(profiles) == 0:
         raise ValueError('"target_data.data" must be a non-empty array')
 
@@ -314,9 +314,13 @@ def _build_candidates_from_profiles(ts_vals, profiles, min_window, max_window,
         else:
             raise ValueError('when "target_data.data" is a list of profiles, each corresponding item in "target_data.ts" must be a [start_ts, end_ts] pair')
 
-        if exclude_source and source_ts_window is not None:
-            if ts_window[0] <= source_ts_window[0] and ts_window[1] >= source_ts_window[1]:
-                continue
+        if source_ts_window is not None:
+            if exclude_source and ts_window[0] <= source_ts_window[0] and ts_window[1] >= source_ts_window[1]:
+                    continue
+            
+            # overlap with the source timewindow should also be excluded.
+            if exclude_overlap and _is_interval_overlapping(ts_window, source_ts_window):
+                    continue
 
         has_candidate = True
         yield {
@@ -552,7 +556,7 @@ def do_profile_search_impl(req_json):
         if parsed["is_profile_list"]:
             return _build_candidates_from_profiles(
                 ts_list, data_list, min_window, max_window,
-                exclude_source=exclude_source, source_ts_window=source_ts_window
+                exclude_source=exclude_source, exclude_overlap=exclude_overlap, source_ts_window=source_ts_window
             )
         return _build_window_candidates_from_series(
             ts_list, data_list, source_arr.size, min_window, max_window,

--- a/tools/tdgpt/taosanalytics/algo/tool/profile_search.py
+++ b/tools/tdgpt/taosanalytics/algo/tool/profile_search.py
@@ -241,7 +241,7 @@ def _calc_cosine_similarity(arr1, arr2):
 
 def _build_window_candidates_from_series(ts_vals, data_vals, source_len: int, min_window: int, max_window: int,
                                         window_size_step: int, window_sliding_step: int,
-                                        exclude_source: bool = False, source_ts_window=None):
+                                        exclude_source: bool = False, exclude_overlap: bool = False, source_ts_window=None):
     ts_arr = np.array(ts_vals)
     data_arr = np.array(data_vals, dtype=float)
 
@@ -272,9 +272,13 @@ def _build_window_candidates_from_series(ts_vals, data_vals, source_len: int, mi
             end = start + win_size - 1
             assert end < data_arr.size and end < ts_arr.size
 
-            if exclude_source and source_ts_window is not None:
-                if ts_arr[start] <= source_ts_window[0] and ts_arr[end] >= source_ts_window[1]:
-                    continue
+            if source_ts_window is not None:
+                if exclude_source and ts_arr[start] <= source_ts_window[0] and ts_arr[end] >= source_ts_window[1]:
+                        continue
+                
+                # overlap with the source timewindow should also be excluded.
+                if exclude_overlap and _is_interval_overlapping([ts_arr[start], ts_arr[end]], source_ts_window):
+                        continue
 
             yield {
                 "series": data_arr[start:end + 1],
@@ -553,7 +557,7 @@ def do_profile_search_impl(req_json):
         return _build_window_candidates_from_series(
             ts_list, data_list, source_arr.size, min_window, max_window,
             window_size_step, window_sliding_step,
-            exclude_source=exclude_source, source_ts_window=source_ts_window
+            exclude_source=exclude_source, exclude_overlap=exclude_overlap, source_ts_window=source_ts_window
         )
 
     # Score all candidates once.


### PR DESCRIPTION
# Description

 fix(gpt): fix errors in generating candidate window when exclude_overlap and exclude_source are both set.

# Issue(s)

- https://project.feishu.cn/taosdata_td/defect/detail/7008574051
- https://project.feishu.cn/taosdata_td/defect/detail/7008411408
- https://project.feishu.cn/taosdata_td/defect/detail/7008475009

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
