### PR TITLE
fix(util): reject oversize length in binary message decoders

### DIFF
--- a/include/util/tencode.h
+++ b/include/util/tencode.h
@@ -412,7 +412,7 @@ static int32_t tDecodeBool(SDecoder* pCoder, bool* val) {
 }
 
 static FORCE_INLINE int32_t tDecodeBinaryWithSize(SDecoder* pCoder, uint32_t size, uint8_t** val) {
-  if (pCoder->pos + size > pCoder->size) {
+  if (size > pCoder->size - pCoder->pos) {
     TAOS_RETURN(TSDB_CODE_OUT_OF_RANGE);
   }
 
@@ -444,7 +444,7 @@ static FORCE_INLINE int32_t tDecodeBinaryTo(SDecoder* pCoder, uint8_t* val, uint
     TAOS_RETURN(TSDB_CODE_INVALID_MSG);
   }
 
-  if (pCoder->pos + len > pCoder->size) {
+  if (len > pCoder->size - pCoder->pos) {
     TAOS_RETURN(TSDB_CODE_OUT_OF_RANGE);
   }
 
@@ -484,7 +484,7 @@ static FORCE_INLINE int32_t tDecodeBinaryAlloc(SDecoder* pCoder, void** val, uin
   if (length) {
     if (len) *len = length;
 
-    if (pCoder->pos + length > pCoder->size) {
+    if (length > pCoder->size - pCoder->pos) {
       TAOS_RETURN(TSDB_CODE_OUT_OF_RANGE);
     }
 
@@ -508,7 +508,7 @@ static FORCE_INLINE int32_t tDecodeBinaryAlloc32(SDecoder* pCoder, void** val, u
   if (length) {
     if (len) *len = length;
 
-    if (pCoder->pos + length > pCoder->size) {
+    if (length > pCoder->size - pCoder->pos) {
       TAOS_RETURN(TSDB_CODE_OUT_OF_RANGE);
     }
     *val = taosMemoryMalloc(length);


### PR DESCRIPTION
**Wrapping length check in the binary decoders**
The bounds check in `tDecodeBinaryWithSize` reads as `pCoder->pos + size > pCoder->size`, but `pos` and `size` are both `uint32_t` so the addition is done in 32 bits and wraps. `size` arrives from a varint in the message via `tDecodeBinary`, so a length close to `UINT32_MAX` (encoded as `ff ff ff ff 0f`) makes the sum wrap below `size` and the check passes. The decoder then returns a pointer with that oversize length and advances `pos` past the end of the buffer, so the next read runs out of bounds. I switched the four binary decoders that take a message-supplied length to the non-wrapping form `size > pCoder->size - pCoder->pos`, which is safe because `pos` never exceeds `size`.