### PR TITLE
fix(s3toss): reject invalid config entries

### DIFF
--- a/tools/s3toss/main.go
+++ b/tools/s3toss/main.go
@@ -22,26 +22,24 @@ import (
 )
 
 var config struct {
-	BlockSize    int64
-	DNode        uint
-	DataDirs     [3][]string
-	Endpoint     string
-	Secure       bool
-	BucketLookup minio.BucketLookupType
-	AccessKey    string
-	SecretKey    string
-	Bucket       string
-	Region       string
+	BlockSize int64
+	DNode     uint
+	DataDirs  [3][]string
+	Endpoint  string
+	Secure    bool
+	AccessKey string
+	SecretKey string
+	Bucket    string
+	Region    string
 }
 
 var minioClient *minio.Client
 
 func createMinIOClient() {
 	client, err := minio.New(config.Endpoint, &minio.Options{
-		Creds:        credentials.NewStaticV4(config.AccessKey, config.SecretKey, ""),
-		Secure:       config.Secure,
-		Region:       config.Region,
-		BucketLookup: config.BucketLookup,
+		Creds:  credentials.NewStaticV4(config.AccessKey, config.SecretKey, ""),
+		Secure: config.Secure,
+		Region: config.Region,
 	})
 	if err != nil {
 		log.Fatalln(err)
@@ -669,7 +667,6 @@ func parseAccessString(as string) error {
 	config.Endpoint = ""
 	config.Bucket = ""
 	config.Secure = true
-	config.BucketLookup = minio.BucketLookupAuto
 	config.AccessKey = ""
 	config.SecretKey = ""
 	config.Region = ""
@@ -696,15 +693,6 @@ func parseAccessString(as string) error {
 			default:
 				return fmt.Errorf("invalid ssAccessString protocol %q: expected http or https", part[1])
 			}
-		case "uristyle":
-			switch strings.ToLower(part[1]) {
-			case "path":
-				config.BucketLookup = minio.BucketLookupPath
-			case "virtualhost":
-				config.BucketLookup = minio.BucketLookupDNS
-			default:
-				return fmt.Errorf("invalid ssAccessString uriStyle %q: expected path or virtualHost", part[1])
-			}
 		case "accesskeyid":
 			config.AccessKey = part[1]
 		case "secretaccesskey":
@@ -730,6 +718,7 @@ func parseTaosCfg(path string) error {
 	}
 	defer f.Close()
 
+	ssConfig := false
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -757,13 +746,14 @@ func parseTaosCfg(path string) error {
 
 		case "ssaccessstring":
 			if strings.HasPrefix(parts[1], "s3:") {
+				ssConfig = true
 				if err := parseAccessString(parts[1][3:]); err != nil {
 					return err
 				}
 			}
 
 		case "s3endpoint":
-			if config.Endpoint != "" {
+			if ssConfig || config.Endpoint != "" {
 				continue
 			}
 			endpoint := strings.ToLower(parts[1])
@@ -778,7 +768,7 @@ func parseTaosCfg(path string) error {
 			}
 
 		case "s3accesskey":
-			if config.AccessKey != "" {
+			if ssConfig || config.AccessKey != "" {
 				continue
 			}
 			if idx := strings.IndexByte(parts[1], ':'); idx == -1 {
@@ -789,7 +779,7 @@ func parseTaosCfg(path string) error {
 			}
 
 		case "s3bucketname":
-			if config.Bucket != "" {
+			if ssConfig || config.Bucket != "" {
 				continue
 			}
 			config.Bucket = parts[1]

--- a/tools/s3toss/main.go
+++ b/tools/s3toss/main.go
@@ -661,7 +661,7 @@ func migrateVnodes(mode string, vid, fid uint) {
 	}
 }
 
-func parseAccessString(as string) {
+func parseAccessString(as string) error {
 	items := strings.Split(as, ";")
 
 	config.Endpoint = ""
@@ -672,7 +672,13 @@ func parseAccessString(as string) {
 	config.Region = ""
 
 	for _, item := range items {
+		if item == "" {
+			continue
+		}
 		part := strings.SplitN(item, "=", 2)
+		if len(part) != 2 {
+			return fmt.Errorf("invalid ssAccessString option %q: expected key=value", item)
+		}
 		switch strings.ToLower(part[0]) {
 		case "endpoint":
 			config.Endpoint = part[1]
@@ -688,6 +694,8 @@ func parseAccessString(as string) {
 			config.Region = part[1]
 		}
 	}
+
+	return nil
 }
 
 func parseTaosCfg(path string) error {
@@ -724,24 +732,32 @@ func parseTaosCfg(path string) error {
 					return err
 				}
 			}
+			if lvl < 0 || lvl >= len(config.DataDirs) {
+				return fmt.Errorf("invalid dataDir level %d: must be between 0 and %d", lvl, len(config.DataDirs)-1)
+			}
 			config.DataDirs[lvl] = append(config.DataDirs[lvl], parts[1])
 
-		case "ssAccessString":
+		case "ssaccessstring":
 			if strings.HasPrefix(parts[1], "s3:") {
 				ssConfig = true
-				parseAccessString(parts[1][3:])
+				if err := parseAccessString(parts[1][3:]); err != nil {
+					return err
+				}
 			}
 
 		case "s3endpoint":
 			if ssConfig || config.Endpoint != "" {
 				continue
 			}
-			if strings.HasPrefix(strings.ToLower(parts[1]), "http://") {
+			endpoint := strings.ToLower(parts[1])
+			if strings.HasPrefix(endpoint, "http://") {
 				config.Secure = false
 				config.Endpoint = parts[1][7:]
-			} else {
+			} else if strings.HasPrefix(endpoint, "https://") {
 				config.Secure = true
 				config.Endpoint = parts[1][8:]
+			} else {
+				return fmt.Errorf("invalid s3endpoint %q: expected http:// or https:// prefix", parts[1])
 			}
 
 		case "s3accesskey":

--- a/tools/s3toss/main.go
+++ b/tools/s3toss/main.go
@@ -22,24 +22,26 @@ import (
 )
 
 var config struct {
-	BlockSize int64
-	DNode     uint
-	DataDirs  [3][]string
-	Endpoint  string
-	Secure    bool
-	AccessKey string
-	SecretKey string
-	Bucket    string
-	Region    string
+	BlockSize    int64
+	DNode        uint
+	DataDirs     [3][]string
+	Endpoint     string
+	Secure       bool
+	BucketLookup minio.BucketLookupType
+	AccessKey    string
+	SecretKey    string
+	Bucket       string
+	Region       string
 }
 
 var minioClient *minio.Client
 
 func createMinIOClient() {
 	client, err := minio.New(config.Endpoint, &minio.Options{
-		Creds:  credentials.NewStaticV4(config.AccessKey, config.SecretKey, ""),
-		Secure: config.Secure,
-		Region: config.Region,
+		Creds:        credentials.NewStaticV4(config.AccessKey, config.SecretKey, ""),
+		Secure:       config.Secure,
+		Region:       config.Region,
+		BucketLookup: config.BucketLookup,
 	})
 	if err != nil {
 		log.Fatalln(err)
@@ -667,6 +669,7 @@ func parseAccessString(as string) error {
 	config.Endpoint = ""
 	config.Bucket = ""
 	config.Secure = true
+	config.BucketLookup = minio.BucketLookupAuto
 	config.AccessKey = ""
 	config.SecretKey = ""
 	config.Region = ""
@@ -693,6 +696,15 @@ func parseAccessString(as string) error {
 			default:
 				return fmt.Errorf("invalid ssAccessString protocol %q: expected http or https", part[1])
 			}
+		case "uristyle":
+			switch strings.ToLower(part[1]) {
+			case "path":
+				config.BucketLookup = minio.BucketLookupPath
+			case "virtualhost":
+				config.BucketLookup = minio.BucketLookupDNS
+			default:
+				return fmt.Errorf("invalid ssAccessString uriStyle %q: expected path or virtualHost", part[1])
+			}
 		case "accesskeyid":
 			config.AccessKey = part[1]
 		case "secretaccesskey":
@@ -718,7 +730,6 @@ func parseTaosCfg(path string) error {
 	}
 	defer f.Close()
 
-	ssConfig := false
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -746,14 +757,13 @@ func parseTaosCfg(path string) error {
 
 		case "ssaccessstring":
 			if strings.HasPrefix(parts[1], "s3:") {
-				ssConfig = true
 				if err := parseAccessString(parts[1][3:]); err != nil {
 					return err
 				}
 			}
 
 		case "s3endpoint":
-			if ssConfig || config.Endpoint != "" {
+			if config.Endpoint != "" {
 				continue
 			}
 			endpoint := strings.ToLower(parts[1])
@@ -768,7 +778,7 @@ func parseTaosCfg(path string) error {
 			}
 
 		case "s3accesskey":
-			if ssConfig || config.AccessKey != "" {
+			if config.AccessKey != "" {
 				continue
 			}
 			if idx := strings.IndexByte(parts[1], ':'); idx == -1 {
@@ -779,7 +789,7 @@ func parseTaosCfg(path string) error {
 			}
 
 		case "s3bucketname":
-			if ssConfig || config.Bucket != "" {
+			if config.Bucket != "" {
 				continue
 			}
 			config.Bucket = parts[1]

--- a/tools/s3toss/main.go
+++ b/tools/s3toss/main.go
@@ -685,14 +685,7 @@ func parseAccessString(as string) error {
 		case "bucket":
 			config.Bucket = part[1]
 		case "protocol":
-			switch strings.ToLower(part[1]) {
-			case "http":
-				config.Secure = false
-			case "https":
-				config.Secure = true
-			default:
-				return fmt.Errorf("invalid ssAccessString protocol %q: expected http or https", part[1])
-			}
+			config.Secure = !strings.EqualFold(part[1], "http")
 		case "accesskeyid":
 			config.AccessKey = part[1]
 		case "secretaccesskey":

--- a/tools/s3toss/main.go
+++ b/tools/s3toss/main.go
@@ -685,7 +685,14 @@ func parseAccessString(as string) error {
 		case "bucket":
 			config.Bucket = part[1]
 		case "protocol":
-			config.Secure = !strings.EqualFold(part[1], "http")
+			switch strings.ToLower(part[1]) {
+			case "http":
+				config.Secure = false
+			case "https":
+				config.Secure = true
+			default:
+				return fmt.Errorf("invalid ssAccessString protocol %q: expected http or https", part[1])
+			}
 		case "accesskeyid":
 			config.AccessKey = part[1]
 		case "secretaccesskey":

--- a/tools/s3toss/main_test.go
+++ b/tools/s3toss/main_test.go
@@ -5,12 +5,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/minio/minio-go/v7"
 )
 
 func TestParseAccessStringAcceptsKnownAndUnknownOptions(t *testing.T) {
 	resetConfig()
 
-	if err := parseAccessString("endpoint=s3.amazonaws.com;bucket=mybucket;uriStyle=path;protocol=http;accessKeyId=AK;secretAccessKey=SK;region=us-east-2;"); err != nil {
+	if err := parseAccessString("endpoint=s3.amazonaws.com;bucket=mybucket;uriStyle=path;protocol=http;accessKeyId=AK;secretAccessKey=SK;region=us-east-2;maxRetry=3;"); err != nil {
 		t.Fatalf("parseAccessString returned error: %v", err)
 	}
 
@@ -22,6 +24,9 @@ func TestParseAccessStringAcceptsKnownAndUnknownOptions(t *testing.T) {
 	}
 	if config.Secure {
 		t.Fatal("Secure = true, want false for protocol=http")
+	}
+	if config.BucketLookup != minio.BucketLookupPath {
+		t.Fatalf("BucketLookup = %v, want BucketLookupPath", config.BucketLookup)
 	}
 	if config.AccessKey != "AK" || config.SecretKey != "SK" || config.Region != "us-east-2" {
 		t.Fatalf("unexpected credentials or region: access=%q secret=%q region=%q", config.AccessKey, config.SecretKey, config.Region)
@@ -52,6 +57,29 @@ func TestParseAccessStringRejectsInvalidProtocol(t *testing.T) {
 	}
 }
 
+func TestParseAccessStringRejectsInvalidURIStyle(t *testing.T) {
+	resetConfig()
+
+	err := parseAccessString("endpoint=s3.amazonaws.com;uriStyle=host")
+	if err == nil {
+		t.Fatal("parseAccessString succeeded for invalid uriStyle")
+	}
+	if !strings.Contains(err.Error(), "expected path or virtualHost") {
+		t.Fatalf("error = %q, want uriStyle error", err)
+	}
+}
+
+func TestParseAccessStringAcceptsVirtualHostURIStyle(t *testing.T) {
+	resetConfig()
+
+	if err := parseAccessString("endpoint=s3.amazonaws.com;uriStyle=virtualHost"); err != nil {
+		t.Fatalf("parseAccessString returned error: %v", err)
+	}
+	if config.BucketLookup != minio.BucketLookupDNS {
+		t.Fatalf("BucketLookup = %v, want BucketLookupDNS", config.BucketLookup)
+	}
+}
+
 func TestParseTaosCfgParsesSsAccessString(t *testing.T) {
 	resetConfig()
 
@@ -69,6 +97,9 @@ func TestParseTaosCfgParsesSsAccessString(t *testing.T) {
 	}
 	if config.Secure {
 		t.Fatal("Secure = true, want false for protocol=http")
+	}
+	if config.BucketLookup != minio.BucketLookupPath {
+		t.Fatalf("BucketLookup = %v, want BucketLookupPath", config.BucketLookup)
 	}
 }
 
@@ -97,6 +128,31 @@ func TestParseTaosCfgRejectsInvalidDataDirLevel(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid dataDir level 3") {
 		t.Fatalf("error = %q, want invalid dataDir level 3", err)
+	}
+}
+
+func TestParseTaosCfgLetsLegacyFillMissingSsAccessStringFields(t *testing.T) {
+	resetConfig()
+
+	cfgPath := writeConfig(t, strings.Join([]string{
+		"dataDir /tmp/taos 0",
+		"ssAccessString s3:endpoint=s3.amazonaws.com;protocol=https",
+		"s3bucketname legacy-bucket",
+		"s3accesskey AK:SK",
+	}, "\n")+"\n")
+
+	if err := parseTaosCfg(cfgPath); err != nil {
+		t.Fatalf("parseTaosCfg returned error: %v", err)
+	}
+
+	if config.Endpoint != "s3.amazonaws.com" {
+		t.Fatalf("Endpoint = %q, want s3.amazonaws.com", config.Endpoint)
+	}
+	if config.Bucket != "legacy-bucket" || config.AccessKey != "AK" || config.SecretKey != "SK" {
+		t.Fatalf("legacy fields were not used as fallback: bucket=%q access=%q secret=%q", config.Bucket, config.AccessKey, config.SecretKey)
+	}
+	if !config.Secure {
+		t.Fatal("Secure = false, want true for protocol=https")
 	}
 }
 
@@ -161,6 +217,7 @@ func resetConfig() {
 	}
 	config.Endpoint = ""
 	config.Secure = false
+	config.BucketLookup = minio.BucketLookupAuto
 	config.AccessKey = ""
 	config.SecretKey = ""
 	config.Bucket = ""

--- a/tools/s3toss/main_test.go
+++ b/tools/s3toss/main_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseAccessStringAcceptsKnownAndUnknownOptions(t *testing.T) {
 	resetConfig()
 
-	if err := parseAccessString("endpoint=s3.amazonaws.com;bucket=mybucket;uriStyle=path;protocol=http;accessKeyId=AK;secretAccessKey=SK;region=us-east-2;"); err != nil {
+	if err := parseAccessString("endpoint=s3.amazonaws.com;bucket=mybucket;uriStyle=path;protocol=http;accessKeyId=AK;secretAccessKey=SK;region=us-east-2"); err != nil {
 		t.Fatalf("parseAccessString returned error: %v", err)
 	}
 
@@ -37,18 +37,6 @@ func TestParseAccessStringRejectsMalformedOption(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "expected key=value") {
 		t.Fatalf("error = %q, want expected key=value", err)
-	}
-}
-
-func TestParseAccessStringRejectsInvalidProtocol(t *testing.T) {
-	resetConfig()
-
-	err := parseAccessString("endpoint=s3.amazonaws.com;protocol=ftp")
-	if err == nil {
-		t.Fatal("parseAccessString succeeded for invalid protocol")
-	}
-	if !strings.Contains(err.Error(), "expected http or https") {
-		t.Fatalf("error = %q, want protocol error", err)
 	}
 }
 
@@ -100,35 +88,6 @@ func TestParseTaosCfgRejectsInvalidDataDirLevel(t *testing.T) {
 	}
 }
 
-func TestParseTaosCfgParsesLegacyS3Endpoint(t *testing.T) {
-	tests := []struct {
-		name     string
-		endpoint string
-		secure   bool
-	}{
-		{name: "http", endpoint: "http://localhost:9000", secure: false},
-		{name: "https", endpoint: "https://localhost:9000", secure: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resetConfig()
-
-			cfgPath := writeConfig(t, "dataDir /tmp/taos 0\ns3endpoint "+tt.endpoint+"\n")
-
-			if err := parseTaosCfg(cfgPath); err != nil {
-				t.Fatalf("parseTaosCfg returned error: %v", err)
-			}
-			if config.Endpoint != "localhost:9000" {
-				t.Fatalf("Endpoint = %q, want localhost:9000", config.Endpoint)
-			}
-			if config.Secure != tt.secure {
-				t.Fatalf("Secure = %v, want %v", config.Secure, tt.secure)
-			}
-		})
-	}
-}
-
 func TestParseTaosCfgRejectsInvalidS3Endpoint(t *testing.T) {
 	resetConfig()
 
@@ -156,9 +115,7 @@ func writeConfig(t *testing.T, contents string) string {
 func resetConfig() {
 	config.BlockSize = 0
 	config.DNode = 0
-	for i := range config.DataDirs {
-		config.DataDirs[i] = nil
-	}
+	config.DataDirs = [3][]string{}
 	config.Endpoint = ""
 	config.Secure = false
 	config.AccessKey = ""

--- a/tools/s3toss/main_test.go
+++ b/tools/s3toss/main_test.go
@@ -113,15 +113,13 @@ func writeConfig(t *testing.T, contents string) string {
 }
 
 func resetConfig() {
-	config = struct {
-		BlockSize int64
-		DNode     uint
-		DataDirs  [3][]string
-		Endpoint  string
-		Secure    bool
-		AccessKey string
-		SecretKey string
-		Bucket    string
-		Region    string
-	}{}
+	config.BlockSize = 0
+	config.DNode = 0
+	config.DataDirs = [3][]string{}
+	config.Endpoint = ""
+	config.Secure = false
+	config.AccessKey = ""
+	config.SecretKey = ""
+	config.Bucket = ""
+	config.Region = ""
 }

--- a/tools/s3toss/main_test.go
+++ b/tools/s3toss/main_test.go
@@ -5,14 +5,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/minio/minio-go/v7"
 )
 
 func TestParseAccessStringAcceptsKnownAndUnknownOptions(t *testing.T) {
 	resetConfig()
 
-	if err := parseAccessString("endpoint=s3.amazonaws.com;bucket=mybucket;uriStyle=path;protocol=http;accessKeyId=AK;secretAccessKey=SK;region=us-east-2;maxRetry=3;"); err != nil {
+	if err := parseAccessString("endpoint=s3.amazonaws.com;bucket=mybucket;uriStyle=path;protocol=http;accessKeyId=AK;secretAccessKey=SK;region=us-east-2;"); err != nil {
 		t.Fatalf("parseAccessString returned error: %v", err)
 	}
 
@@ -24,9 +22,6 @@ func TestParseAccessStringAcceptsKnownAndUnknownOptions(t *testing.T) {
 	}
 	if config.Secure {
 		t.Fatal("Secure = true, want false for protocol=http")
-	}
-	if config.BucketLookup != minio.BucketLookupPath {
-		t.Fatalf("BucketLookup = %v, want BucketLookupPath", config.BucketLookup)
 	}
 	if config.AccessKey != "AK" || config.SecretKey != "SK" || config.Region != "us-east-2" {
 		t.Fatalf("unexpected credentials or region: access=%q secret=%q region=%q", config.AccessKey, config.SecretKey, config.Region)
@@ -57,29 +52,6 @@ func TestParseAccessStringRejectsInvalidProtocol(t *testing.T) {
 	}
 }
 
-func TestParseAccessStringRejectsInvalidURIStyle(t *testing.T) {
-	resetConfig()
-
-	err := parseAccessString("endpoint=s3.amazonaws.com;uriStyle=host")
-	if err == nil {
-		t.Fatal("parseAccessString succeeded for invalid uriStyle")
-	}
-	if !strings.Contains(err.Error(), "expected path or virtualHost") {
-		t.Fatalf("error = %q, want uriStyle error", err)
-	}
-}
-
-func TestParseAccessStringAcceptsVirtualHostURIStyle(t *testing.T) {
-	resetConfig()
-
-	if err := parseAccessString("endpoint=s3.amazonaws.com;uriStyle=virtualHost"); err != nil {
-		t.Fatalf("parseAccessString returned error: %v", err)
-	}
-	if config.BucketLookup != minio.BucketLookupDNS {
-		t.Fatalf("BucketLookup = %v, want BucketLookupDNS", config.BucketLookup)
-	}
-}
-
 func TestParseTaosCfgParsesSsAccessString(t *testing.T) {
 	resetConfig()
 
@@ -97,9 +69,6 @@ func TestParseTaosCfgParsesSsAccessString(t *testing.T) {
 	}
 	if config.Secure {
 		t.Fatal("Secure = true, want false for protocol=http")
-	}
-	if config.BucketLookup != minio.BucketLookupPath {
-		t.Fatalf("BucketLookup = %v, want BucketLookupPath", config.BucketLookup)
 	}
 }
 
@@ -128,31 +97,6 @@ func TestParseTaosCfgRejectsInvalidDataDirLevel(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid dataDir level 3") {
 		t.Fatalf("error = %q, want invalid dataDir level 3", err)
-	}
-}
-
-func TestParseTaosCfgLetsLegacyFillMissingSsAccessStringFields(t *testing.T) {
-	resetConfig()
-
-	cfgPath := writeConfig(t, strings.Join([]string{
-		"dataDir /tmp/taos 0",
-		"ssAccessString s3:endpoint=s3.amazonaws.com;protocol=https",
-		"s3bucketname legacy-bucket",
-		"s3accesskey AK:SK",
-	}, "\n")+"\n")
-
-	if err := parseTaosCfg(cfgPath); err != nil {
-		t.Fatalf("parseTaosCfg returned error: %v", err)
-	}
-
-	if config.Endpoint != "s3.amazonaws.com" {
-		t.Fatalf("Endpoint = %q, want s3.amazonaws.com", config.Endpoint)
-	}
-	if config.Bucket != "legacy-bucket" || config.AccessKey != "AK" || config.SecretKey != "SK" {
-		t.Fatalf("legacy fields were not used as fallback: bucket=%q access=%q secret=%q", config.Bucket, config.AccessKey, config.SecretKey)
-	}
-	if !config.Secure {
-		t.Fatal("Secure = false, want true for protocol=https")
 	}
 }
 
@@ -217,7 +161,6 @@ func resetConfig() {
 	}
 	config.Endpoint = ""
 	config.Secure = false
-	config.BucketLookup = minio.BucketLookupAuto
 	config.AccessKey = ""
 	config.SecretKey = ""
 	config.Bucket = ""

--- a/tools/s3toss/main_test.go
+++ b/tools/s3toss/main_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseAccessStringAcceptsKnownAndUnknownOptions(t *testing.T) {
+	resetConfig()
+
+	if err := parseAccessString("endpoint=s3.amazonaws.com;bucket=mybucket;uriStyle=path;protocol=http;accessKeyId=AK;secretAccessKey=SK;region=us-east-2"); err != nil {
+		t.Fatalf("parseAccessString returned error: %v", err)
+	}
+
+	if config.Endpoint != "s3.amazonaws.com" {
+		t.Fatalf("Endpoint = %q, want s3.amazonaws.com", config.Endpoint)
+	}
+	if config.Bucket != "mybucket" {
+		t.Fatalf("Bucket = %q, want mybucket", config.Bucket)
+	}
+	if config.Secure {
+		t.Fatal("Secure = true, want false for protocol=http")
+	}
+	if config.AccessKey != "AK" || config.SecretKey != "SK" || config.Region != "us-east-2" {
+		t.Fatalf("unexpected credentials or region: access=%q secret=%q region=%q", config.AccessKey, config.SecretKey, config.Region)
+	}
+}
+
+func TestParseAccessStringRejectsMalformedOption(t *testing.T) {
+	resetConfig()
+
+	err := parseAccessString("endpoint")
+	if err == nil {
+		t.Fatal("parseAccessString succeeded for malformed option")
+	}
+	if !strings.Contains(err.Error(), "expected key=value") {
+		t.Fatalf("error = %q, want expected key=value", err)
+	}
+}
+
+func TestParseTaosCfgParsesSsAccessString(t *testing.T) {
+	resetConfig()
+
+	cfgPath := writeConfig(t, "dataDir /tmp/taos 0\nssAccessString s3:endpoint=s3.amazonaws.com;bucket=mybucket;uriStyle=path;protocol=http;accessKeyId=AK;secretAccessKey=SK;region=us-east-2\n")
+
+	if err := parseTaosCfg(cfgPath); err != nil {
+		t.Fatalf("parseTaosCfg returned error: %v", err)
+	}
+
+	if config.Endpoint != "s3.amazonaws.com" {
+		t.Fatalf("Endpoint = %q, want s3.amazonaws.com", config.Endpoint)
+	}
+	if config.Bucket != "mybucket" || config.AccessKey != "AK" || config.SecretKey != "SK" || config.Region != "us-east-2" {
+		t.Fatalf("unexpected S3 config: bucket=%q access=%q secret=%q region=%q", config.Bucket, config.AccessKey, config.SecretKey, config.Region)
+	}
+	if config.Secure {
+		t.Fatal("Secure = true, want false for protocol=http")
+	}
+}
+
+func TestParseTaosCfgRejectsMalformedSsAccessString(t *testing.T) {
+	resetConfig()
+
+	cfgPath := writeConfig(t, "dataDir /tmp/taos 0\nssAccessString s3:endpoint\n")
+
+	err := parseTaosCfg(cfgPath)
+	if err == nil {
+		t.Fatal("parseTaosCfg succeeded for malformed ssAccessString")
+	}
+	if !strings.Contains(err.Error(), "expected key=value") {
+		t.Fatalf("error = %q, want expected key=value", err)
+	}
+}
+
+func TestParseTaosCfgRejectsInvalidDataDirLevel(t *testing.T) {
+	resetConfig()
+
+	cfgPath := writeConfig(t, "dataDir /tmp/taos 3\n")
+
+	err := parseTaosCfg(cfgPath)
+	if err == nil {
+		t.Fatal("parseTaosCfg succeeded for invalid dataDir level")
+	}
+	if !strings.Contains(err.Error(), "invalid dataDir level 3") {
+		t.Fatalf("error = %q, want invalid dataDir level 3", err)
+	}
+}
+
+func TestParseTaosCfgRejectsInvalidS3Endpoint(t *testing.T) {
+	resetConfig()
+
+	cfgPath := writeConfig(t, "dataDir /tmp/taos 0\ns3endpoint localhost:9000\n")
+
+	err := parseTaosCfg(cfgPath)
+	if err == nil {
+		t.Fatal("parseTaosCfg succeeded for invalid s3endpoint")
+	}
+	if !strings.Contains(err.Error(), "expected http:// or https:// prefix") {
+		t.Fatalf("error = %q, want endpoint prefix error", err)
+	}
+}
+
+func writeConfig(t *testing.T, contents string) string {
+	t.Helper()
+
+	cfgPath := filepath.Join(t.TempDir(), "taos.cfg")
+	if err := os.WriteFile(cfgPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	return cfgPath
+}
+
+func resetConfig() {
+	config = struct {
+		BlockSize int64
+		DNode     uint
+		DataDirs  [3][]string
+		Endpoint  string
+		Secure    bool
+		AccessKey string
+		SecretKey string
+		Bucket    string
+		Region    string
+	}{}
+}

--- a/tools/s3toss/main_test.go
+++ b/tools/s3toss/main_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseAccessStringAcceptsKnownAndUnknownOptions(t *testing.T) {
 	resetConfig()
 
-	if err := parseAccessString("endpoint=s3.amazonaws.com;bucket=mybucket;uriStyle=path;protocol=http;accessKeyId=AK;secretAccessKey=SK;region=us-east-2"); err != nil {
+	if err := parseAccessString("endpoint=s3.amazonaws.com;bucket=mybucket;uriStyle=path;protocol=http;accessKeyId=AK;secretAccessKey=SK;region=us-east-2;"); err != nil {
 		t.Fatalf("parseAccessString returned error: %v", err)
 	}
 
@@ -37,6 +37,18 @@ func TestParseAccessStringRejectsMalformedOption(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "expected key=value") {
 		t.Fatalf("error = %q, want expected key=value", err)
+	}
+}
+
+func TestParseAccessStringRejectsInvalidProtocol(t *testing.T) {
+	resetConfig()
+
+	err := parseAccessString("endpoint=s3.amazonaws.com;protocol=ftp")
+	if err == nil {
+		t.Fatal("parseAccessString succeeded for invalid protocol")
+	}
+	if !strings.Contains(err.Error(), "expected http or https") {
+		t.Fatalf("error = %q, want protocol error", err)
 	}
 }
 
@@ -88,6 +100,35 @@ func TestParseTaosCfgRejectsInvalidDataDirLevel(t *testing.T) {
 	}
 }
 
+func TestParseTaosCfgParsesLegacyS3Endpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		secure   bool
+	}{
+		{name: "http", endpoint: "http://localhost:9000", secure: false},
+		{name: "https", endpoint: "https://localhost:9000", secure: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetConfig()
+
+			cfgPath := writeConfig(t, "dataDir /tmp/taos 0\ns3endpoint "+tt.endpoint+"\n")
+
+			if err := parseTaosCfg(cfgPath); err != nil {
+				t.Fatalf("parseTaosCfg returned error: %v", err)
+			}
+			if config.Endpoint != "localhost:9000" {
+				t.Fatalf("Endpoint = %q, want localhost:9000", config.Endpoint)
+			}
+			if config.Secure != tt.secure {
+				t.Fatalf("Secure = %v, want %v", config.Secure, tt.secure)
+			}
+		})
+	}
+}
+
 func TestParseTaosCfgRejectsInvalidS3Endpoint(t *testing.T) {
 	resetConfig()
 
@@ -115,7 +156,9 @@ func writeConfig(t *testing.T, contents string) string {
 func resetConfig() {
 	config.BlockSize = 0
 	config.DNode = 0
-	config.DataDirs = [3][]string{}
+	for i := range config.DataDirs {
+		config.DataDirs[i] = nil
+	}
 	config.Endpoint = ""
 	config.Secure = false
 	config.AccessKey = ""


### PR DESCRIPTION
# Description

`s3toss` now fails selected malformed `taos.cfg` entries with explicit parse errors instead of allowing malformed local configuration to reach unchecked parser operations.

## What Problem This Solves

`s3toss` is a local shared-storage maintenance tool. Its user-visible entry point is a `taos.cfg` path supplied with `-taoscfg`; `parseTaosCfg()` runs before MinIO client initialization and before any migration I/O.

On the existing CLI path, malformed legacy configuration was reachable for `dataDir` and `s3endpoint`:

```text
dataDir /tmp/taos 3
```

For this shape, `parseTaosCfg()` used the parsed level directly as an index into `config.DataDirs`, whose supported tiers are `0..2`. That boundary matches TDengine's storage contract: the multi-tier storage docs define `dataDir` level values as `0`, `1`, and `2`, `include/util/tdef.h` sets `TFS_MAX_TIERS` to `3`, and core TFS validation rejects levels below `0` or greater than or equal to `TFS_MAX_TIERS` in `source/libs/tfs/src/tfs.c`.

```text
s3endpoint localhost:9000
```

For the legacy endpoint form, the parser treated any non-`http://` value as HTTPS and sliced the string as if that prefix existed. Longer malformed values could be truncated incorrectly, and shorter values could panic.

The `ssAccessString` path is narrower:

```text
ssAccessString s3:endpoint
```

The unchecked `parseAccessString()` helper could read `part[1]` after `strings.SplitN(item, "=", 2)`, but the old CLI path did not actually enter the `ssAccessString` branch because `parseTaosCfg()` lowercased the key and then matched it against mixed-case `case "ssAccessString"`. This PR connects that intended branch as `ssaccessstring` and returns an explicit parse error before malformed `key=value` options can be consumed.

## Changes

The production change is limited to `tools/s3toss` configuration parsing:

```diff
+if item == "" {
+    continue
+}
 part := strings.SplitN(item, "=", 2)
+if len(part) != 2 {
+    return fmt.Errorf("invalid ssAccessString option %q: expected key=value", item)
+}
@@
+if lvl < 0 || lvl >= len(config.DataDirs) {
+    return fmt.Errorf("invalid dataDir level %d: must be between 0 and %d", lvl, len(config.DataDirs)-1)
+}
 config.DataDirs[lvl] = append(config.DataDirs[lvl], parts[1])
@@
-case "ssAccessString":
+case "ssaccessstring":
@@
+} else if strings.HasPrefix(endpoint, "https://") {
+    config.Secure = true
+    config.Endpoint = parts[1][8:]
 } else {
+    return fmt.Errorf("invalid s3endpoint %q: expected http:// or https:// prefix", parts[1])
 }
```

Focused unit tests cover valid S3 access strings, malformed access-string options, out-of-range `dataDir` levels, invalid legacy endpoints, and the real `taos.cfg` parsing path.

The PR does not change migration behavior, MinIO client setup, credential handling, object naming, existing `protocol` handling, or which unknown well-formed S3 options `s3toss` ignores. Non-S3 `ssAccessString` values remain ignored as before.

## Evidence

The focused tests exercise both the helper-level parser and the user-visible config-file path:

```text
ssAccessString s3:endpoint=s3.amazonaws.com;bucket=mybucket;protocol=http;accessKeyId=AK;secretAccessKey=SK;region=us-east-2
ssAccessString s3:endpoint
dataDir /tmp/taos 3
s3endpoint localhost:9000
```

Expected error fragments are covered by tests:

```text
expected key=value
invalid dataDir level 3
expected http:// or https:// prefix
```

Local validation was run with Go 1.24.2:

```text
cd tools/s3toss && go test -count=1 ./...
ok   github.com/taosdata/s3toss 0.005s
```

GitHub checks: no checks are currently reported for this branch.

## Possible call chain / impact

```text
administrator or automation runs s3toss with -taoscfg
  -> main()
  -> parseTaosCfg()
  -> dataDir / s3endpoint / intended ssAccessString branch
  -> previous unchecked index/slice/helper parsing, now explicit parse error
  -> createMinIOClient() and migration I/O only run after parsing succeeds
```

This affects only invalid local configuration inputs in the `s3toss` tool. It is not a network request path, and it does not change core TDengine TFS parsing.

# Issue(s)

- Fix: #35403

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?