### PR TITLE
fix(function): bound group_concat result and clamp stream out columns

### DIFF
--- a/source/libs/function/inc/builtinsimpl.h
+++ b/source/libs/function/inc/builtinsimpl.h
@@ -85,6 +85,7 @@ bool    gconcatGetFuncEnv(SFunctionNode* pFunc, SFuncExecEnv* pEnv);
 int32_t gconcatFunctionSetup(SqlFunctionCtx* pCtx, SResultRowEntryInfo* pResultInfo);
 int32_t gconcatFunction(SqlFunctionCtx* pCtx);
 int32_t gconcatFinalize(SqlFunctionCtx* pCtx, SSDataBlock* pBlock);
+void    gconcatFunctionCleanupExt(SqlFunctionCtx* pCtx);
 
 bool    getLeastSQRFuncEnv(struct SFunctionNode* pFunc, SFuncExecEnv* pEnv);
 int32_t leastSQRFunctionSetup(SqlFunctionCtx* pCtx, SResultRowEntryInfo* pResultInfo);

--- a/source/libs/function/src/builtins.c
+++ b/source/libs/function/src/builtins.c
@@ -6878,6 +6878,7 @@ const SBuiltinFuncDefinition funcMgtBuiltins[] = {
     .initFunc     = gconcatFunctionSetup,
     .processFunc  = gconcatFunction,
     .finalizeFunc = gconcatFinalize,
+    .cleanupFunc  = gconcatFunctionCleanupExt,
     /*
     .combineFunc  = gconcatCombine, // stream
     .pStateFunc = "group_concat",   // tsma

--- a/source/libs/function/src/builtinsimpl.c
+++ b/source/libs/function/src/builtinsimpl.c
@@ -1585,6 +1585,8 @@ static int32_t gconcatHelper(const char* input, char* output, bool hasNchar, int
   if (input == NULL) {
     return TSDB_CODE_SUCCESS;
   }
+  // the result buffer is allocated with TSDB_MAX_FIELD_LEN bytes (varstr header included), and the
+  // declared result column holds at most TSDB_MAX_FIELD_LEN - 2 * VARSTR_HEADER_SIZE payload bytes
   if (hasNchar && type == TSDB_DATA_TYPE_VARCHAR) {
     TdUcs4* newBuf = taosMemoryCalloc((varDataLen(input) + 1) * TSDB_NCHAR_SIZE, 1);
     if (NULL == newBuf) {
@@ -1597,10 +1599,17 @@ static int32_t gconcatHelper(const char* input, char* output, bool hasNchar, int
       taosMemoryFree(newBuf);
       return TSDB_CODE_SCALAR_CONVERT_ERROR;
     }
+    if (*dataLen + len > TSDB_MAX_FIELD_LEN - 2 * VARSTR_HEADER_SIZE) {
+      taosMemoryFree(newBuf);
+      return TSDB_CODE_PAR_VALUE_TOO_LONG;
+    }
     (void)memcpy(varDataVal(output) + *dataLen, newBuf, len);
     *dataLen += len;
     taosMemoryFree(newBuf);
   } else {
+    if (*dataLen + varDataLen(input) > TSDB_MAX_FIELD_LEN - 2 * VARSTR_HEADER_SIZE) {
+      return TSDB_CODE_PAR_VALUE_TOO_LONG;
+    }
     (void)memcpy(varDataVal(output) + *dataLen, varDataVal(input), varDataLen(input));
     *dataLen += varDataLen(input);
   }
@@ -1626,6 +1635,7 @@ int32_t gconcatFunction(SqlFunctionCtx* pCtx) {
     if (!pRes->result) {
       return terrno;
     }
+    pCtx->needCleanup = true;
 
     varDataSetLen(pRes->result, 0);
 
@@ -1686,6 +1696,9 @@ int32_t gconcatFunction(SqlFunctionCtx* pCtx) {
   }
 
 _over:
+  if (code != TSDB_CODE_SUCCESS) {
+    taosMemoryFreeClear(pRes->result);
+  }
   // data in the check operation are all null, not output
   SET_VAL(GET_RES_INFO(pCtx), numOfElem, 1);
   return code;
@@ -1700,16 +1713,24 @@ int32_t gconcatFinalize(SqlFunctionCtx* pCtx, SSDataBlock* pBlock) {
   SColumnInfoData*      pCol = taosArrayGet(pBlock->pDataBlock, slotId);
 
   if (NULL == pCol) {
-    taosMemoryFree(pRes->result);
+    taosMemoryFreeClear(pRes->result);
     return TSDB_CODE_OUT_OF_RANGE;
   }
 
   pResInfo->isNullRes = (pResInfo->numOfRes == 0) ? 1 : 0;
   code = colDataSetVal(pCol, pBlock->info.rows, pRes->result, pResInfo->isNullRes);
 
-  taosMemoryFree(pRes->result);
+  taosMemoryFreeClear(pRes->result);
 
   return code;
+}
+
+void gconcatFunctionCleanupExt(SqlFunctionCtx* pCtx) {
+  if (pCtx == NULL || GET_RES_INFO(pCtx) == NULL || GET_ROWCELL_INTERBUF(GET_RES_INFO(pCtx)) == NULL) {
+    return;
+  }
+  SGconcatRes* pRes = GET_ROWCELL_INTERBUF(GET_RES_INFO(pCtx));
+  taosMemoryFreeClear(pRes->result);
 }
 
 bool getLeastSQRFuncEnv(SFunctionNode* pFunc, SFuncExecEnv* pEnv) {

--- a/source/libs/parser/src/parTranslater.c
+++ b/source/libs/parser/src/parTranslater.c
@@ -17990,6 +17990,43 @@ static int32_t createStreamReqSetDefaultOutCols(STranslateContext* pCxt, SCreate
     index++;
   }
 
+  if (!pColExists && pStmt->pCols) {
+    // GROUP_CONCAT declares its result as wide as the maximum field length, which can push the
+    // auto-derived output row over TSDB_MAX_BYTES_PER_ROW and get the stream rejected (#34504).
+    // Clamp such columns to what the output row can actually hold; a real value that still exceeds
+    // the (clamped) output column is rejected at write time instead of failing the stream creation.
+    int32_t rowSize = 0;
+    SNode*  pTmp = NULL;
+    FOREACH(pTmp, pStmt->pCols) { rowSize += ((SColumnDefNode*)pTmp)->dataType.bytes; }
+    if (rowSize > TSDB_MAX_BYTES_PER_ROW) {
+      int32_t idx = 0;
+      FOREACH(pTmp, pCalcProjection) {
+        if (idx >= bound || rowSize <= TSDB_MAX_BYTES_PER_ROW) {
+          break;
+        }
+        if (nodeType(pTmp) == QUERY_NODE_FUNCTION &&
+            ((SFunctionNode*)pTmp)->funcType == FUNCTION_TYPE_GROUP_CONCAT) {
+          SColumnDefNode* pColDef = (SColumnDefNode*)nodesListGetNode(pStmt->pCols, idx);
+          if (NULL == pColDef) {
+            break;
+          }
+          if (TSDB_DATA_TYPE_VARCHAR == pColDef->dataType.type || TSDB_DATA_TYPE_NCHAR == pColDef->dataType.type) {
+            int32_t reducible = pColDef->dataType.bytes - (VARSTR_HEADER_SIZE + 1);
+            int32_t reduce = rowSize - TSDB_MAX_BYTES_PER_ROW;
+            if (reduce > reducible) {
+              reduce = reducible;
+            }
+            if (reduce > 0) {
+              pColDef->dataType.bytes -= reduce;
+              rowSize -= reduce;
+            }
+          }
+        }
+        idx++;
+      }
+    }
+  }
+
   if (LIST_LENGTH(pCalcProjection) < TSDB_MIN_COLUMNS) {
     PAR_ERR_JRET(generateSyntaxErrMsgExt(&pCxt->msgBuf, TSDB_CODE_STREAM_INVALID_OUT_TABLE,
                                          "The number of columns in stream output must be greater than 1"));

--- a/test/cases/11-Functions/02-Aggregate/test_agg_gconcat.py
+++ b/test/cases/11-Functions/02-Aggregate/test_agg_gconcat.py
@@ -413,3 +413,73 @@ class TestFuncGconcat:
         tdSql.checkData(0, 0, 'v0,v1,v2,v3,v4,v5')
 
         tdLog.info("test_edge_cases passed")
+
+    def test_group_concat_overflow(self):
+        """Agg-basic: group_concat overflow safety and stream sizing (#34504)
+
+        1. A group_concat result larger than the max field length must fail
+           with a clean error instead of crashing the server.
+        2. CREATE STREAM with group_concat plus other columns must not be
+           rejected because of the max-length estimate (issue #34504).
+
+        Catalog:
+            - Function:Aggregate
+
+        Since: v3.4.1
+
+        Labels: common,ci
+
+        Jira: None
+
+        History:
+            - 2026-07-17 bestdo77 Fix issue #34504
+
+        """
+        self._overflow_clean_error()
+        self._stream_out_col_clamp()
+        tdStream.dropAllStreamsAndDbs()
+
+    def _overflow_clean_error(self):
+        self._prepare_db("db_gc_toobig")
+        t0 = 1700400000000
+
+        tdSql.execute("create table t_big (ts timestamp, v varchar(128))")
+        # 600 rows x 121 bytes each > 65515-byte max group_concat payload
+        val = "x" * 120
+        for b in range(6):
+            rows = ",".join(f"({t0 + (b * 100 + i) * 1000}, '{val}')" for i in range(100))
+            tdSql.execute(f"insert into t_big values{rows}")
+
+        # used to overflow a fixed buffer and crash the server (#34504)
+        tdSql.error("select group_concat(v, ',') from t_big", expectErrInfo="Value too long", fullMatched=False)
+
+        # the server must survive and keep serving queries
+        tdSql.query("select count(*) from t_big")
+        tdSql.checkData(0, 0, 600)
+
+        tdLog.info("test_overflow_clean_error passed")
+
+    def _stream_out_col_clamp(self):
+        self._prepare_db("db_gc_stream")
+
+        # exact schema from issue #34504
+        tdSql.execute("CREATE STABLE s_ptr_data (ts TIMESTAMP, test_value DOUBLE, test_value_str VARCHAR(16), test_flag INT, hi_limit DOUBLE, lo_limit DOUBLE) TAGS (factory VARCHAR(32), fileid VARCHAR(64), testnum INT, testtxt VARCHAR(256), headnum INT, sitenum INT, productid VARCHAR(64), lotid VARCHAR(64), sublotid VARCHAR(64), jobname VARCHAR(128), flowid VARCHAR(32), datatype VARCHAR(10), nodename VARCHAR(32), dutindex INT)")
+
+        tdSql.query("select * from information_schema.ins_snodes")
+        if tdSql.queryRows == 0:
+            tdSql.execute("create snode on dnode 1")
+
+        # used to fail with "Row length exceeds max length 65531 [0x8000263E]" (#34504)
+        tdSql.execute("CREATE STREAM s1 COUNT_WINDOW(10) FROM s_ptr_data PARTITION BY tbname INTO output AS SELECT LAST(ts) AS ts, AVG(test_value) AS avg_test_value, GROUP_CONCAT(test_value_str, ',') AS test_value_array FROM s_ptr_data")
+
+        # the group_concat output column must be clamped so the output row fits
+        tdSql.query("desc output")
+        for i in range(tdSql.queryRows):
+            if tdSql.getData(i, 0) == "test_value_array":
+                width = tdSql.getData(i, 2)
+                assert width < 65515, f"group_concat out col should be clamped below 65515, got {width}"
+                break
+        else:
+            raise Exception("test_value_array column not found in stream output table")
+
+        tdLog.info("test_stream_out_col_clamp passed")


### PR DESCRIPTION
Fixes #34504.

group_concat has two problems:

1. The result is accumulated into a fixed 65519-byte buffer with no bounds check (`gconcatHelper` in builtinsimpl.c). Once a group's payload grows past that, the memcpy corrupts the heap and taosd aborts (`malloc(): corrupted top size`, signal 6). I reproduced this on current main by running group_concat over ~6k rows (~102 KB payload) — the server dies immediately.

2. `translateGroupConcat` always estimates the result width as 65515, so a stream output row containing any other column exceeds the 65531 limit and `CREATE STREAM` fails with `Row length exceeds max length 65531 [0x8000263E]` — the error from the issue.

What this PR does:

- `gconcatHelper` now checks the length before every append and returns "Value too long for column/tag" when the payload would exceed the limit. The query fails, the server stays up. A `cleanupFunc` is registered for group_concat and all buffer frees are idempotent, so the error path releases the accumulation buffer instead of leaking it.
- When the auto-derived stream output row is too wide, group_concat output columns are clamped to what fits (`createStreamReqSetDefaultOutCols`). The stream in the issue can be created now. If a real value is still longer than the clamped column, the write is rejected with a normal error instead of crashing.

Reproduced/tested with:

```sql
-- 600+ rows of 120+ byte values: before = server aborts, after = clean error
select group_concat(v, ',') from t;

-- before = 0x8000263E row too long, after = created
create stream s1 count_window(10) from s_ptr_data partition by tbname into output as
  select last(ts) as ts, avg(test_value) as avg_test_value, group_concat(test_value_str, ',') as test_value_array
  from s_ptr_data;
```

Added `test_group_concat_overflow` to `test_agg_gconcat.py` covering both cases.

One note for the reporter: the SQL in the issue has no window constraint (`ts >= _twstart and ts <= _twend`), so each trigger scans the whole table — that is how the calc query behaves without it; the stream cases in this repo always include it.

Tested on Debian 10 x86_64, community build 3.4.1.13.alpha based on main@df445db5:

- parserTest stream suite passes (30/30)
- test_agg_gconcat.py 3/3, test_agg_smoking.py 6/6
- on a live node the overflow query returns 0x80002653 in ~10 ms and the server keeps serving; the stream above is created (output row 65533 -> 65531 after the clamp)

Performance impact should be negligible: one integer comparison per appended value in group_concat, and the clamp runs once per stream creation only when the row is oversized. No other code paths change. The only behavior change is that an oversized group_concat now returns an error instead of crashing the server.
