### PR TITLE
fix(query): honor limit for unordered group by

### DIFF
--- a/source/libs/executor/src/projectoperator.c
+++ b/source/libs/executor/src/projectoperator.c
@@ -544,7 +544,8 @@ int32_t doProjectOperation(SOperatorInfo* pOperator, SSDataBlock** pResBlock) {
 //        pOperator->status = OP_EXEC_RECV;
 //      }
 
-      if (pProjectInfo->inputIgnoreGroup) {
+      if (pProjectInfo->inputIgnoreGroup ||
+          (pProjectInfo->outputIgnoreGroup && pLimitInfo->limit.limit >= 0)) {
         pBlock->info.id.groupId = 0;
       }
 

--- a/test/cases/09-DataQuerying/06-Limit/test_group_limit_without_order.py
+++ b/test/cases/09-DataQuerying/06-Limit/test_group_limit_without_order.py
@@ -1,0 +1,32 @@
+from new_test_framework.utils import tdSql
+
+
+class TestGroupLimitWithoutOrder:
+    def test_group_limit_without_order(self):
+        """GROUP BY without ORDER BY honors LIMIT and OFFSET.
+
+        Description: Cover hash-group results, which do not pass through an
+        ORDER BY operator before LIMIT is applied.
+        Labels: common,ci,integration,functional
+        Jira: None
+        Since: v3.4.2.5
+
+        History:
+            - 2026-09-07 Atirna Added regression coverage for #35450
+        """
+        tdSql.execute("drop database if exists group_limit_without_order")
+        tdSql.execute("create database group_limit_without_order")
+        tdSql.execute("use group_limit_without_order")
+        tdSql.execute("create table t (ts timestamp, g int, v int)")
+
+        values = "".join(f"({1700000000000 + g}, {g}, {g})" for g in range(100))
+        tdSql.execute(f"insert into t values {values}")
+
+        tdSql.query("select g, count(*) from t group by g")
+        tdSql.checkRows(100)
+
+        tdSql.query("select g, count(*) from t group by g limit 10")
+        tdSql.checkRows(10)
+
+        tdSql.query("select g, count(*) from t group by g limit 10 offset 95")
+        tdSql.checkRows(5)

--- a/test/ci/cases.task
+++ b/test/ci/cases.task
@@ -602,6 +602,7 @@
 ## 06-Limit
 ,,y,.,./ci/pytest.sh pytest cases/09-DataQuerying/06-Limit/test_query_limit_basic.py
 ,,y,.,./ci/pytest.sh pytest cases/09-DataQuerying/06-Limit/test_query_limit_offset.py
+,,y,.,./ci/pytest.sh pytest cases/09-DataQuerying/06-Limit/test_group_limit_without_order.py
 ## 07-SLimit
 ,,y,.,./ci/pytest.sh pytest cases/09-DataQuerying/07-SLimit/test_slimit.py
 ,,y,.,./ci/pytest.sh pytest cases/09-DataQuerying/07-SLimit/test_slimit_basic.py


### PR DESCRIPTION
## Description

Apply ordinary `LIMIT` across unordered `GROUP BY` result blocks when the top-level projection ignores group IDs.

## Why

`GROUP BY` without `ORDER BY` could return every group even with `LIMIT`.

## Verification

- Before: a table with 100 distinct keys returned 100 rows for `GROUP BY g LIMIT 10`.
- After: the focused case passes, including 10 rows for `LIMIT 10` and 5 rows for `LIMIT 10 OFFSET 95`.

## Issue(s)

Fixes #35450
